### PR TITLE
Fix Lambda platform-specific dependencies (DuckDB)

### DIFF
--- a/.github/workflows/lambda-deploy.yml
+++ b/.github/workflows/lambda-deploy.yml
@@ -148,7 +148,8 @@ jobs:
         run: |
           # Install production dependencies to lambda-package directory
           # This installs only the dependencies defined in pyproject.toml (not dev dependencies)
-          uv pip install --target lambda-package --no-cache .
+          # Use --python-platform to get binaries compatible with AWS Lambda (Amazon Linux 2)
+          uv pip install --target lambda-package --no-cache --python-platform manylinux2014_x86_64 .
 
       # ========================================================================
       # Step 7: Copy Application Code


### PR DESCRIPTION
## Problem

The Lambda deployment is failing with this error:
```json
{"errorMessage": "Unable to import module 'lambda_function': No module named '_duckdb'", 
 "errorType": "Runtime.ImportModuleError"}
```

**Root Cause:** DuckDB has native binary components (`_duckdb` is a C extension). The workflow was installing packages on **Ubuntu** (GitHub Actions runner), but AWS Lambda runs on **Amazon Linux 2**. The binaries are incompatible.

## Solution

Added `--python-platform manylinux2014_x86_64` flag to `uv pip install` command.

This tells UV to download wheels that are compatible with AWS Lambda's runtime environment (Amazon Linux 2), ensuring all native dependencies are compiled for the correct platform.

### Change
```diff
- uv pip install --target lambda-package --no-cache .
+ uv pip install --target lambda-package --no-cache --python-platform manylinux2014_x86_64 .
```

## Testing

This will be verified when:
1. PR is merged to main
2. Workflow runs automatically
3. Quality checks pass (Ruff, Mypy, pytest)
4. Dependencies are installed for correct platform
5. Lambda deployment succeeds
6. Smoke test passes ✅

## References

- [UV platform specification](https://docs.astral.sh/uv/reference/cli/#uv-pip-install)
- [AWS Lambda Python runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html)
- [manylinux compatibility](https://github.com/pypa/manylinux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>