### PR TITLE
feat: add publish_status Lambda for 'Did I Run Today?' feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,10 @@ RUN uv export --frozen --no-dev --no-hashes --no-emit-project -o requirements.tx
 # Copy application source code
 COPY src/ ${LAMBDA_TASK_ROOT}/src/
 
+# Fix permissions - strip any macOS extended attributes issues
+# Ensure all files are readable
+RUN chmod -R 755 ${LAMBDA_TASK_ROOT}/src
+
 # Create the Lambda handler entry point
 # This imports the correct handler based on HANDLER_MODULE build arg
 RUN printf '%s\n' \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ dependencies = [
     "httpx>=0.27.0",
     "authlib>=1.3.0",
 
+    # Google Cloud Storage
+    "google-cloud-storage>=2.18.0",
+
     # Data Validation & Models
     "pydantic>=2.9.0",
     "pydantic-settings>=2.5.0",

--- a/src/lambdas/publish_status/__init__.py
+++ b/src/lambdas/publish_status/__init__.py
@@ -1,0 +1,1 @@
+"""Publish status Lambda for generating public run status JSON."""

--- a/src/lambdas/publish_status/handler.py
+++ b/src/lambdas/publish_status/handler.py
@@ -1,0 +1,188 @@
+"""Lambda handler for publishing run status to GCS."""
+
+import json
+import logging
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+from google.cloud import storage
+from google.oauth2 import service_account
+
+from src.shared.secrets import get_secret
+from src.shared.supabase_client import get_supabase_client
+from src.shared.supabase_ops.runs_repository import RunsRepository
+from src.shared.supabase_ops.users_repository import UsersRepository
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# Configuration
+GCS_BUCKET_NAME = "myrunstreak-public"
+GCS_OBJECT_PATH = "status.json"
+ENVIRONMENT = "dev"
+
+
+def get_gcs_credentials() -> dict[str, Any]:
+    """Get GCS service account credentials from Secrets Manager."""
+    secret_name = f"myrunstreak/{ENVIRONMENT}/gcs/credentials"
+    # get_secret already returns parsed JSON as a dict
+    return get_secret(secret_name)
+
+
+def upload_to_gcs(data: dict[str, Any]) -> str:
+    """
+    Upload JSON data to Google Cloud Storage.
+
+    Args:
+        data: Dictionary to upload as JSON
+
+    Returns:
+        Public URL of uploaded file
+    """
+    # Get credentials from Secrets Manager
+    creds_dict = get_gcs_credentials()
+    credentials = service_account.Credentials.from_service_account_info(creds_dict)
+
+    # Create GCS client
+    client = storage.Client(credentials=credentials, project=creds_dict.get("project_id"))
+
+    # Upload to bucket
+    bucket = client.bucket(GCS_BUCKET_NAME)
+    blob = bucket.blob(GCS_OBJECT_PATH)
+
+    # Set cache control
+    blob.cache_control = "public, max-age=300"  # Cache for 5 minutes
+
+    # Upload with explicit content type
+    json_data = json.dumps(data, indent=2, default=str)
+    blob.upload_from_string(json_data, content_type="application/json")
+
+    logger.info(f"Uploaded status to gs://{GCS_BUCKET_NAME}/{GCS_OBJECT_PATH}")
+
+    return f"https://storage.googleapis.com/{GCS_BUCKET_NAME}/{GCS_OBJECT_PATH}"
+
+
+def build_status_data(user_id: UUID, runs_repo: RunsRepository) -> dict[str, Any]:
+    """
+    Build the status JSON structure.
+
+    Args:
+        user_id: User UUID
+        runs_repo: Runs repository instance
+
+    Returns:
+        Status data dictionary
+    """
+    today = date.today()
+    seven_days_ago = today - timedelta(days=7)
+
+    # Get last 7 days of runs
+    recent_runs = runs_repo.get_runs_by_date_range(user_id, seven_days_ago, today)
+
+    # Get current streak
+    streak_days = runs_repo.get_current_streak(user_id)
+
+    # Determine if ran today
+    ran_today = any(run["start_date"] == today.isoformat() for run in recent_runs)
+
+    # Get last run (most recent)
+    last_run = None
+    if recent_runs:
+        latest = recent_runs[0]  # Already sorted desc by date
+        last_run = {
+            "date": latest["start_date"],
+            "distance_km": round(float(latest["distance_km"]), 2),
+            "duration_min": round(float(latest["duration_seconds"]) / 60, 1),
+        }
+
+    # Build last 7 days array
+    last_7_days = []
+    for run in recent_runs:
+        last_7_days.append(
+            {
+                "date": run["start_date"],
+                "distance_km": round(float(run["distance_km"]), 2),
+            }
+        )
+
+    # Calculate streak start date (approximate)
+    streak_start = None
+    if streak_days > 0:
+        streak_start = (today - timedelta(days=streak_days - 1)).isoformat()
+
+    return {
+        "updated_at": datetime.now(UTC).isoformat(),
+        "ran_today": ran_today,
+        "streak": {
+            "current_days": streak_days,
+            "started": streak_start,
+        },
+        "last_run": last_run,
+        "last_7_days": last_7_days,
+    }
+
+
+def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    """
+    Lambda handler for publishing run status.
+
+    Can be triggered by:
+    - EventBridge schedule
+    - Direct invocation from sync Lambda
+    - API Gateway (for testing)
+
+    Args:
+        event: Lambda event (may contain user_id override)
+        context: Lambda context
+
+    Returns:
+        Response with status URL
+    """
+    logger.info(f"Publish status event: {json.dumps(event)}")
+
+    try:
+        # Initialize clients
+        supabase = get_supabase_client()
+        runs_repo = RunsRepository(supabase)
+        users_repo = UsersRepository(supabase)
+
+        # Get user_id from event or use default (first active SmashRun user)
+        user_id_str = event.get("user_id")
+
+        if not user_id_str:
+            # Get first active SmashRun source as default
+            sources = users_repo.get_all_active_sources(source_type="smashrun")
+            if not sources:
+                raise ValueError("No active SmashRun sources found")
+            user_id = UUID(sources[0]["user_id"])
+            logger.info(f"Using default user_id from first active source: {user_id}")
+        else:
+            user_id = UUID(user_id_str)
+
+        # Build status data
+        status_data = build_status_data(user_id, runs_repo)
+
+        # Upload to GCS
+        public_url = upload_to_gcs(status_data)
+
+        logger.info(f"Published status for user {user_id}: {public_url}")
+
+        return {
+            "statusCode": 200,
+            "body": json.dumps(
+                {
+                    "message": "Status published successfully",
+                    "url": public_url,
+                    "ran_today": status_data["ran_today"],
+                    "streak_days": status_data["streak"]["current_days"],
+                }
+            ),
+        }
+
+    except Exception as e:
+        logger.error(f"Failed to publish status: {e}")
+        return {
+            "statusCode": 500,
+            "body": json.dumps({"error": str(e)}),
+        }

--- a/terraform/environments/dev/outputs.tf
+++ b/terraform/environments/dev/outputs.tf
@@ -70,6 +70,20 @@ output "lambda_log_group_name" {
 }
 
 # ==============================================================================
+# Publish Status Lambda Outputs
+# ==============================================================================
+
+output "publish_status_function_name" {
+  description = "Name of the publish status Lambda function"
+  value       = module.lambda_publish_status.function_name
+}
+
+output "publish_status_function_arn" {
+  description = "ARN of the publish status Lambda function"
+  value       = module.lambda_publish_status.function_arn
+}
+
+# ==============================================================================
 # ECR Outputs
 # ==============================================================================
 
@@ -81,6 +95,11 @@ output "ecr_sync_repository_url" {
 output "ecr_query_repository_url" {
   description = "URL of the query Lambda ECR repository"
   value       = module.ecr.query_repository_url
+}
+
+output "ecr_publish_status_repository_url" {
+  description = "URL of the publish status Lambda ECR repository"
+  value       = module.ecr.publish_status_repository_url
 }
 
 # ==============================================================================

--- a/terraform/modules/ecr/outputs.tf
+++ b/terraform/modules/ecr/outputs.tf
@@ -32,6 +32,21 @@ output "query_repository_name" {
   value       = aws_ecr_repository.query.name
 }
 
+output "publish_status_repository_url" {
+  description = "URL of the publish status Lambda ECR repository"
+  value       = aws_ecr_repository.publish_status.repository_url
+}
+
+output "publish_status_repository_arn" {
+  description = "ARN of the publish status Lambda ECR repository"
+  value       = aws_ecr_repository.publish_status.arn
+}
+
+output "publish_status_repository_name" {
+  description = "Name of the publish status Lambda ECR repository"
+  value       = aws_ecr_repository.publish_status.name
+}
+
 output "registry_id" {
   description = "The registry ID where the repositories are created"
   value       = aws_ecr_repository.sync.registry_id

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version < '3.13'",
+]
 
 [[package]]
 name = "ag-ui-protocol"
@@ -682,6 +686,22 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/da/83d7043169ac2c8c7469f0e375610d78ae2160134bf1b80634c482fa079c/google_api_core-2.28.1.tar.gz", hash = "sha256:2b405df02d68e68ce0fbc138559e6036559e685159d148ae5861013dc201baf8", size = 176759, upload-time = "2025-10-28T21:34:51.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/d4/90197b416cb61cefd316964fd9e7bd8324bcbafabf40eef14a9f20b81974/google_api_core-2.28.1-py3-none-any.whl", hash = "sha256:4021b0f8ceb77a6fb4de6fde4502cecab45062e66ff4f2895169e0b35bc9466c", size = 173706, upload-time = "2025-10-28T21:34:50.151Z" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.42.1"
 source = { registry = "https://pypi.org/simple" }
@@ -693,6 +713,56 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/6b/22a77135757c3a7854c9f008ffed6bf4e8851616d77faf13147e9ab5aae6/google_auth-2.42.1.tar.gz", hash = "sha256:30178b7a21aa50bffbdc1ffcb34ff770a2f65c712170ecd5446c4bef4dc2b94e", size = 295541, upload-time = "2025-10-30T16:42:19.381Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/92/05/adeb6c495aec4f9d93f9e2fc29eeef6e14d452bba11d15bdb874ce1d5b10/google_auth-2.42.1-py2.py3-none-any.whl", hash = "sha256:eb73d71c91fc95dbd221a2eb87477c278a355e7367a35c0d84e6b0e5f9b4ad11", size = 222550, upload-time = "2025-10-30T16:42:17.878Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/03/ef0bc99d0e0faf4fdbe67ac445e18cdaa74824fd93cd069e7bb6548cb52d/google_cloud_core-2.5.0.tar.gz", hash = "sha256:7c1b7ef5c92311717bd05301aa1a91ffbc565673d3b0b4163a52d8413a186963", size = 36027, upload-time = "2025-10-29T23:17:39.513Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/20/bfa472e327c8edee00f04beecc80baeddd2ab33ee0e86fd7654da49d45e9/google_cloud_core-2.5.0-py3-none-any.whl", hash = "sha256:67d977b41ae6c7211ee830c7912e41003ea8194bff15ae7d72fd6f51e57acabc", size = 29469, upload-time = "2025-10-29T23:17:38.548Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/cd/7e112cf025b2b591067b599e4bfe965df0c12b0cc0afdb5556469bff126d/google_cloud_storage-3.6.0.tar.gz", hash = "sha256:29cc6b9a6c0fc9cdad071e375d540a5a50fbc9a7fad8300fa02fb904f6fe2ca2", size = 17251072, upload-time = "2025-11-17T10:18:29.81Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/ef/3b57bf617ee0c79450c1ff211d1eb888db8fc1050ac74b3e52cc6ed86e63/google_cloud_storage-3.6.0-py3-none-any.whl", hash = "sha256:5decbdddd63b7d1fc3e266a393ad6453d2e27d172bd982b1e2f15481668db097", size = 299039, upload-time = "2025-11-17T10:18:27.66Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/ae/87802e6d9f9d69adfaedfcfd599266bf386a54d0be058b532d04c794f76d/google_crc32c-1.7.1.tar.gz", hash = "sha256:2bff2305f98846f3e825dbeec9ee406f89da7962accdb29356e4eadc251bd472", size = 14495, upload-time = "2025-03-26T14:29:13.32Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/b7/787e2453cf8639c94b3d06c9d61f512234a82e1d12d13d18584bd3049904/google_crc32c-1.7.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:2d73a68a653c57281401871dd4aeebbb6af3191dcac751a76ce430df4d403194", size = 30470, upload-time = "2025-03-26T14:34:31.655Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b4/6042c2b0cbac3ec3a69bb4c49b28d2f517b7a0f4a0232603c42c58e22b44/google_crc32c-1.7.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:22beacf83baaf59f9d3ab2bbb4db0fb018da8e5aebdce07ef9f09fce8220285e", size = 30315, upload-time = "2025-03-26T15:01:54.634Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ad/01e7a61a5d059bc57b702d9ff6a18b2585ad97f720bd0a0dbe215df1ab0e/google_crc32c-1.7.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19eafa0e4af11b0a4eb3974483d55d2d77ad1911e6cf6f832e1574f6781fd337", size = 33180, upload-time = "2025-03-26T14:41:32.168Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/a5/7279055cf004561894ed3a7bfdf5bf90a53f28fadd01af7cd166e88ddf16/google_crc32c-1.7.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6d86616faaea68101195c6bdc40c494e4d76f41e07a37ffdef270879c15fb65", size = 32794, upload-time = "2025-03-26T14:41:33.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/d6/77060dbd140c624e42ae3ece3df53b9d811000729a5c821b9fd671ceaac6/google_crc32c-1.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:b7491bdc0c7564fcf48c0179d2048ab2f7c7ba36b84ccd3a3e1c3f7a72d3bba6", size = 33477, upload-time = "2025-03-26T14:29:10.94Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/72/b8d785e9184ba6297a8620c8a37cf6e39b81a8ca01bb0796d7cbb28b3386/google_crc32c-1.7.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:df8b38bdaf1629d62d51be8bdd04888f37c451564c2042d36e5812da9eff3c35", size = 30467, upload-time = "2025-03-26T14:36:06.909Z" },
+    { url = "https://files.pythonhosted.org/packages/34/25/5f18076968212067c4e8ea95bf3b69669f9fc698476e5f5eb97d5b37999f/google_crc32c-1.7.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:e42e20a83a29aa2709a0cf271c7f8aefaa23b7ab52e53b322585297bb94d4638", size = 30309, upload-time = "2025-03-26T15:06:15.318Z" },
+    { url = "https://files.pythonhosted.org/packages/92/83/9228fe65bf70e93e419f38bdf6c5ca5083fc6d32886ee79b450ceefd1dbd/google_crc32c-1.7.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:905a385140bf492ac300026717af339790921f411c0dfd9aa5a9e69a08ed32eb", size = 33133, upload-time = "2025-03-26T14:41:34.388Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ca/1ea2fd13ff9f8955b85e7956872fdb7050c4ace8a2306a6d177edb9cf7fe/google_crc32c-1.7.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b211ddaf20f7ebeec5c333448582c224a7c90a9d98826fbab82c0ddc11348e6", size = 32773, upload-time = "2025-03-26T14:41:35.19Z" },
+    { url = "https://files.pythonhosted.org/packages/89/32/a22a281806e3ef21b72db16f948cad22ec68e4bdd384139291e00ff82fe2/google_crc32c-1.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:0f99eaa09a9a7e642a61e06742856eec8b19fc0037832e03f941fe7cf0c8e4db", size = 33475, upload-time = "2025-03-26T14:29:11.771Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c5/002975aff514e57fc084ba155697a049b3f9b52225ec3bc0f542871dd524/google_crc32c-1.7.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32d1da0d74ec5634a05f53ef7df18fc646666a25efaaca9fc7dcfd4caf1d98c3", size = 33243, upload-time = "2025-03-26T14:41:35.975Z" },
+    { url = "https://files.pythonhosted.org/packages/61/cb/c585282a03a0cea70fcaa1bf55d5d702d0f2351094d663ec3be1c6c67c52/google_crc32c-1.7.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e10554d4abc5238823112c2ad7e4560f96c7bf3820b202660373d769d9e6e4c9", size = 32870, upload-time = "2025-03-26T14:41:37.08Z" },
 ]
 
 [[package]]
@@ -712,6 +782,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9f/97/784fba9bc6c41263ff90cb9063eadfdd755dde79cfa5a8d0e397b067dcf9/google_genai-1.47.0.tar.gz", hash = "sha256:ecece00d0a04e6739ea76cc8dad82ec9593d9380aaabef078990e60574e5bf59", size = 241471, upload-time = "2025-10-29T22:01:02.88Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/89/ef/e080e8d67c270ea320956bb911a9359664fc46d3b87d1f029decd33e5c4c/google_genai-1.47.0-py3-none-any.whl", hash = "sha256:e3851237556cbdec96007d8028b4b1f2425cdc5c099a8dc36b72a57e42821b60", size = 241506, upload-time = "2025-10-29T22:01:00.982Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/d7/520b62a35b23038ff005e334dba3ffc75fcf583bee26723f1fd8fd4b6919/google_resumable_media-2.8.0.tar.gz", hash = "sha256:f1157ed8b46994d60a1bc432544db62352043113684d4e030ee02e77ebe9a1ae", size = 2163265, upload-time = "2025-11-17T15:38:06.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/0b/93afde9cfe012260e9fe1522f35c9b72d6ee222f316586b1f23ecf44d518/google_resumable_media-2.8.0-py3-none-any.whl", hash = "sha256:dd14a116af303845a8d932ddae161a26e86cc229645bc98b39f026f9b1717582", size = 81340, upload-time = "2025-11-17T15:38:05.594Z" },
 ]
 
 [[package]]
@@ -1513,6 +1595,7 @@ dependencies = [
     { name = "authlib" },
     { name = "aws-lambda-powertools" },
     { name = "boto3" },
+    { name = "google-cloud-storage" },
     { name = "httpx" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
@@ -1547,6 +1630,7 @@ requires-dist = [
     { name = "aws-lambda-powertools", specifier = ">=3.2.0" },
     { name = "boto3", specifier = ">=1.35.0" },
     { name = "boto3-stubs", extras = ["essential"], marker = "extra == 'dev'", specifier = ">=1.35.0" },
+    { name = "google-cloud-storage", specifier = ">=2.18.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'chat'", specifier = ">=0.27.0" },
     { name = "moto", marker = "extra == 'dev'", specifier = ">=5.0.0" },
@@ -1895,6 +1979,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "proto-plus"
+version = "1.26.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/ac/87285f15f7cce6d4a008f33f1757fb5a13611ea8914eb58c3d0d26243468/proto_plus-1.26.1.tar.gz", hash = "sha256:21a515a4c4c0088a773899e23c7bbade3d18f9c66c73edd4c7ee3816bc96a012", size = 56142, upload-time = "2025-03-10T15:54:38.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/6d/280c4c2ce28b1593a19ad5239c8b826871fc6ec275c21afc8e1820108039/proto_plus-1.26.1-py3-none-any.whl", hash = "sha256:13285478c2dcf2abb829db158e1047e2f1e8d63a077d94263c2b88b043c75a66", size = 50163, upload-time = "2025-03-10T15:54:37.335Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add new `publish_status` Lambda that queries Supabase for user streak data and uploads JSON to GCS
- Configure sync Lambda to automatically invoke publish_status after each sync
- Add google-cloud-storage dependency for GCS uploads
- Add ECR repository and Lambda infrastructure for publish_status
- Fix Docker permission issues with macOS extended attributes

## Details

The publish_status Lambda:
- Queries Supabase for: current streak, last run, last 7 days of runs
- Uploads JSON to `gs://myrunstreak-public/status.json`
- Publicly accessible for qualityplaybook.com to fetch via browser JavaScript

JSON structure:
```json
{
  "updated_at": "2025-11-21T18:19:08Z",
  "ran_today": true,
  "streak": {
    "current_days": 4108,
    "started": "2014-08-24"
  },
  "last_run": {
    "date": "2025-11-21",
    "distance_km": 5.63,
    "duration_min": 33.7
  },
  "last_7_days": [...]
}
```

## Test plan

- [x] Lambda successfully queries Supabase for user data
- [x] JSON uploads to GCS with correct content-type
- [x] Public URL accessible: https://storage.googleapis.com/myrunstreak-public/status.json
- [x] Sync Lambda invokes publish_status after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)