### PR TITLE
feat: update sync schedule to 9am and 12pm ET and auto-publish status

### DIFF
--- a/terraform/environments/dev/outputs.tf
+++ b/terraform/environments/dev/outputs.tf
@@ -140,18 +140,18 @@ output "api_key_value" {
 # EventBridge Outputs
 # ==============================================================================
 
-output "eventbridge_rule_name" {
-  description = "Name of the EventBridge rule for daily syncs"
-  value       = module.eventbridge.rule_name
+output "eventbridge_rule_names" {
+  description = "Names of the EventBridge rules for syncs"
+  value       = module.eventbridge.rule_names
 }
 
-output "eventbridge_schedule" {
-  description = "Cron expression for the daily sync schedule"
-  value       = module.eventbridge.schedule_expression
+output "eventbridge_schedules" {
+  description = "Cron expressions for the sync schedules"
+  value       = module.eventbridge.schedule_expressions
 }
 
 output "eventbridge_enabled" {
-  description = "Whether the EventBridge rule is currently enabled"
+  description = "Whether the EventBridge rules are currently enabled"
   value       = module.eventbridge.is_enabled
 }
 
@@ -183,8 +183,9 @@ output "deployment_instructions" {
 
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-    ⏰ Automated Sync Schedule:
-      ${module.eventbridge.schedule_expression}
+    ⏰ Automated Sync Schedules:
+      Morning: 9am EST / 10am EDT (14:00 UTC)
+      Midday:  12pm EST / 1pm EDT (17:00 UTC)
       Status: ${module.eventbridge.is_enabled ? "ENABLED ✓" : "DISABLED ✗"}
 
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/terraform/modules/eventbridge/outputs.tf
+++ b/terraform/modules/eventbridge/outputs.tf
@@ -2,27 +2,27 @@
 # EventBridge Module - Outputs
 # ==============================================================================
 
-output "rule_name" {
-  description = "Name of the EventBridge rule"
-  value       = aws_cloudwatch_event_rule.daily_sync.name
+output "rule_names" {
+  description = "Names of the EventBridge rules"
+  value       = { for k, v in aws_cloudwatch_event_rule.sync : k => v.name }
 }
 
-output "rule_arn" {
-  description = "ARN of the EventBridge rule"
-  value       = aws_cloudwatch_event_rule.daily_sync.arn
+output "rule_arns" {
+  description = "ARNs of the EventBridge rules"
+  value       = { for k, v in aws_cloudwatch_event_rule.sync : k => v.arn }
 }
 
-output "rule_id" {
-  description = "ID of the EventBridge rule"
-  value       = aws_cloudwatch_event_rule.daily_sync.id
+output "rule_ids" {
+  description = "IDs of the EventBridge rules"
+  value       = { for k, v in aws_cloudwatch_event_rule.sync : k => v.id }
 }
 
-output "schedule_expression" {
-  description = "Cron/rate expression for the schedule"
-  value       = aws_cloudwatch_event_rule.daily_sync.schedule_expression
+output "schedule_expressions" {
+  description = "Cron/rate expressions for the schedules"
+  value       = { for k, v in aws_cloudwatch_event_rule.sync : k => v.schedule_expression }
 }
 
 output "is_enabled" {
-  description = "Whether the rule is currently enabled"
-  value       = aws_cloudwatch_event_rule.daily_sync.state == "ENABLED"
+  description = "Whether the rules are currently enabled"
+  value       = length(aws_cloudwatch_event_rule.sync) > 0 ? values(aws_cloudwatch_event_rule.sync)[0].state == "ENABLED" : false
 }

--- a/terraform/modules/eventbridge/variables.tf
+++ b/terraform/modules/eventbridge/variables.tf
@@ -24,21 +24,20 @@ variable "lambda_function_arn" {
 }
 
 # Schedule Configuration
-variable "schedule_expression" {
-  description = "Cron or rate expression for the schedule"
-  type        = string
-  default     = "cron(0 11 * * ? *)"  # Daily at 11:00 UTC (6am EST / 7am EDT)
-
-  validation {
-    condition     = can(regex("^(cron|rate)\\(", var.schedule_expression))
-    error_message = "Schedule expression must start with 'cron(' or 'rate('."
-  }
-}
-
-variable "schedule_description" {
-  description = "Human-readable description of when the schedule runs"
-  type        = string
-  default     = "6am EST / 7am EDT (11:00 UTC)"
+variable "schedules" {
+  description = "List of schedules with name, cron expression, and description"
+  type = list(object({
+    name        = string
+    expression  = string
+    description = string
+  }))
+  default = [
+    {
+      name        = "morning"
+      expression  = "cron(0 14 * * ? *)"
+      description = "9am EST / 10am EDT (14:00 UTC)"
+    }
+  ]
 }
 
 variable "enabled" {


### PR DESCRIPTION
## Summary
- Update EventBridge schedule from daily 6am to twice daily at **9am and 12pm ET**
- Add automatic `publish_status` invocation after successful sync to keep widget updated
- Refactor EventBridge module to support multiple schedules

## Changes
- **sync_runs handler**: Triggers `publish_status` Lambda after syncing runs
- **EventBridge module**: Now supports list of schedules instead of single schedule
- **Dev environment**: Configured with morning (14:00 UTC) and midday (17:00 UTC) schedules

## Test plan
- [x] Manually invoked sync Lambda - successfully triggered publish_status
- [x] Verified status.json updated with latest run data
- [x] Terraform apply successful - both EventBridge rules created and enabled
- [x] Verified new schedules active in AWS console

🤖 Generated with [Claude Code](https://claude.com/claude-code)