### PR TITLE
feat: load secrets from AWS Secrets Manager at runtime

### DIFF
--- a/scripts/check_status.py
+++ b/scripts/check_status.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""
+Quick diagnostic tool to check MyRunStreak system status.
+
+Usage:
+    AWS_PROFILE=silverbeer uv run python scripts/check_status.py
+"""
+
+import json
+import subprocess
+from datetime import UTC, datetime
+
+
+def run_aws_cmd(cmd: list[str]) -> dict | list | str | None:
+    """Run an AWS CLI command and return JSON output."""
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        if result.stdout.strip():
+            return json.loads(result.stdout)
+        return None
+    except subprocess.CalledProcessError as e:
+        print(f"  Error: {e.stderr}")
+        return None
+    except json.JSONDecodeError:
+        return result.stdout.strip() if result.stdout else None
+
+
+def check_eventbridge_rules() -> None:
+    """Check EventBridge scheduled rules."""
+    print("\n" + "=" * 60)
+    print("EVENTBRIDGE SCHEDULES")
+    print("=" * 60)
+
+    rules = run_aws_cmd([
+        "aws", "events", "list-rules",
+        "--query", "Rules[?contains(Name, `myrunstreak`)]",
+        "--output", "json",
+    ])
+
+    if not rules:
+        print("  No EventBridge rules found")
+        return
+
+    for rule in rules:
+        name = rule.get("Name", "Unknown")
+        state = rule.get("State", "Unknown")
+        schedule = rule.get("ScheduleExpression", "N/A")
+        description = rule.get("Description", "")
+
+        status_icon = "✅" if state == "ENABLED" else "❌"
+        print(f"\n  {status_icon} {name}")
+        print(f"     State: {state}")
+        print(f"     Schedule: {schedule}")
+        if description:
+            print(f"     Description: {description[:60]}...")
+
+
+def check_lambda_logs(function_name: str, hours: int = 24) -> dict:
+    """Check recent Lambda invocations from CloudWatch logs."""
+    print(f"\n  Checking logs for {function_name}...")
+
+    # Get log streams
+    streams = run_aws_cmd([
+        "aws", "logs", "describe-log-streams",
+        "--log-group-name", f"/aws/lambda/{function_name}",
+        "--order-by", "LastEventTime",
+        "--descending",
+        "--limit", "5",
+        "--output", "json",
+    ])
+
+    if not streams or "logStreams" not in streams:
+        return {"status": "no_logs", "message": "No log streams found"}
+
+    # Get recent log events
+    result = subprocess.run(
+        [
+            "aws", "logs", "tail",
+            f"/aws/lambda/{function_name}",
+            "--since", f"{hours}h",
+            "--format", "short",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    logs = result.stdout if result.returncode == 0 else ""
+
+    # Parse logs for status
+    invocations = logs.count("START RequestId")
+    errors = logs.count("ERROR")
+    successes = logs.count("Sync completed") + logs.count("SUCCESS")
+
+    # Check for specific error patterns
+    has_missing_env = "Field required" in logs or "validation errors" in logs
+
+    return {
+        "invocations": invocations,
+        "errors": errors,
+        "successes": successes,
+        "has_missing_env_vars": has_missing_env,
+        "raw_logs": logs[-2000:] if logs else "",  # Last 2000 chars
+    }
+
+
+def check_cloudwatch_logs() -> None:
+    """Check CloudWatch logs for all Lambda functions."""
+    print("\n" + "=" * 60)
+    print("CLOUDWATCH LOGS (Last 24 hours)")
+    print("=" * 60)
+
+    functions = [
+        "myrunstreak-sync-runner-dev",
+        "myrunstreak-publish-status-dev",
+        "myrunstreak-query-runner-dev",
+    ]
+
+    for func in functions:
+        result = check_lambda_logs(func)
+        print(f"\n  📋 {func}")
+        print(f"     Invocations: {result.get('invocations', 0)}")
+        print(f"     Errors: {result.get('errors', 0)}")
+        print(f"     Successes: {result.get('successes', 0)}")
+
+        if result.get("has_missing_env_vars"):
+            print("     ⚠️  Missing environment variables detected!")
+
+
+def check_gcs_status_file() -> dict:
+    """Check the 'Did I Run Today' status file in GCS."""
+    print("\n" + "=" * 60)
+    print("GCS STATUS FILE (Did I Run Today)")
+    print("=" * 60)
+
+    gcs_url = "https://storage.googleapis.com/myrunstreak-public/status.json"
+
+    try:
+        result = subprocess.run(
+            ["curl", "-s", gcs_url],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+        if result.returncode == 0 and result.stdout.strip():
+            data = json.loads(result.stdout)
+            print(f"\n  ✅ Status file found at {gcs_url}")
+            print(f"\n  Updated: {data.get('updated_at', 'Unknown')}")
+            print(f"  Ran today: {'✅ YES' if data.get('ran_today') else '❌ NO'}")
+
+            streak = data.get("streak", {})
+            print(f"  Streak: {streak.get('current_days', 0)} days")
+            print(f"  Streak started: {streak.get('started', 'Unknown')}")
+
+            last_run = data.get("last_run", {})
+            if last_run:
+                print(f"\n  Last run: {last_run.get('date')}")
+                print(f"    Distance: {last_run.get('distance_mi')} miles")
+                print(f"    Duration: {last_run.get('duration_min')} min")
+
+            print(f"\n  Month total: {data.get('month_total_mi', 0)} miles")
+            print(f"  Year total: {data.get('year_total_mi', 0)} miles")
+
+            return {"status": "ok", "data": data}
+        else:
+            print(f"\n  ❌ Could not fetch status file from {gcs_url}")
+            return {"status": "error", "message": "Failed to fetch"}
+
+    except json.JSONDecodeError as e:
+        print(f"\n  ❌ Invalid JSON in status file: {e}")
+        return {"status": "error", "message": str(e)}
+    except Exception as e:
+        print(f"\n  ❌ Error checking status file: {e}")
+        return {"status": "error", "message": str(e)}
+
+
+def check_lambda_env_vars() -> None:
+    """Check Lambda environment variable configuration."""
+    print("\n" + "=" * 60)
+    print("LAMBDA ENVIRONMENT VARIABLES")
+    print("=" * 60)
+
+    func = "myrunstreak-sync-runner-dev"
+    config = run_aws_cmd([
+        "aws", "lambda", "get-function-configuration",
+        "--function-name", func,
+        "--output", "json",
+    ])
+
+    if not config:
+        print(f"  ❌ Could not get config for {func}")
+        return
+
+    env_vars = config.get("Environment", {}).get("Variables", {})
+
+    required_vars = [
+        "SMASHRUN_CLIENT_ID",
+        "SMASHRUN_CLIENT_SECRET",
+        "SUPABASE_URL",
+        "SUPABASE_KEY",
+    ]
+
+    print(f"\n  Lambda: {func}")
+    print(f"  Environment variables configured: {len(env_vars)}")
+
+    for var in required_vars:
+        # Check both upper and lower case versions
+        has_var = var in env_vars or var.lower() in env_vars
+        status = "✅" if has_var else "❌ MISSING"
+        print(f"     {status} {var}")
+
+    # Show what IS configured
+    if env_vars:
+        print("\n  Configured variables:")
+        for key in sorted(env_vars.keys()):
+            value = env_vars[key]
+            # Mask secrets
+            if "secret" in key.lower() or "key" in key.lower() or "password" in key.lower():
+                display_value = value[:4] + "***" if len(value) > 4 else "***"
+            else:
+                display_value = value[:50] + "..." if len(value) > 50 else value
+            print(f"     {key}: {display_value}")
+
+
+def main() -> None:
+    """Run all diagnostic checks."""
+    print("\n" + "🏃" * 30)
+    print("  MyRunStreak System Status Check")
+    print(f"  {datetime.now(UTC).strftime('%Y-%m-%d %H:%M:%S UTC')}")
+    print("🏃" * 30)
+
+    check_eventbridge_rules()
+    check_cloudwatch_logs()
+    gcs_result = check_gcs_status_file()
+    check_lambda_env_vars()
+
+    print("\n" + "=" * 60)
+    print("OVERALL STATUS")
+    print("=" * 60)
+
+    # Determine overall health
+    if gcs_result.get("status") == "ok":
+        data = gcs_result.get("data", {})
+        ran_today = data.get("ran_today", False)
+        streak = data.get("streak", {}).get("current_days", 0)
+
+        if ran_today:
+            print("\n  ✅ ALL SYSTEMS OPERATIONAL")
+            print("     - You ran today!")
+            print(f"     - Streak: {streak} days")
+        else:
+            print("\n  ⚠️  SYSTEMS OPERATIONAL - No run logged today")
+            print(f"     - Streak: {streak} days")
+            print("     - Go for a run to keep your streak alive!")
+    else:
+        print("\n  ❌ SYSTEM ISSUES DETECTED")
+        print("     - Check CloudWatch logs for errors")
+        print("     - Verify Lambda has Secrets Manager permissions")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lambdas/publish_status/handler.py
+++ b/src/lambdas/publish_status/handler.py
@@ -121,6 +121,14 @@ def build_status_data(user_id: UUID, runs_repo: RunsRepository) -> dict[str, Any
     if streak_days > 0:
         streak_start = (today - timedelta(days=streak_days - 1)).isoformat()
 
+    # Calculate total miles during the streak
+    streak_total_km = 0.0
+    if streak_days > 0 and streak_start:
+        streak_start_date = date.fromisoformat(streak_start)
+        streak_runs = runs_repo.get_runs_by_date_range(user_id, streak_start_date, today)
+        streak_total_km = sum(float(run["distance_km"]) for run in streak_runs)
+    streak_total_mi = round(km_to_miles(streak_total_km), 1)
+
     # Get runs for this month
     first_of_month = today.replace(day=1)
     month_runs = runs_repo.get_runs_by_date_range(user_id, first_of_month, today)
@@ -139,6 +147,7 @@ def build_status_data(user_id: UUID, runs_repo: RunsRepository) -> dict[str, Any
         "streak": {
             "current_days": streak_days,
             "started": streak_start,
+            "total_mi": streak_total_mi,
         },
         "last_run": last_run,
         "last_7_days": last_7_days,

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -1,9 +1,13 @@
 """Configuration management for MyRunStreak.com."""
 
+import logging
+import os
 from pathlib import Path
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
 
 
 def find_env_file() -> Path | None:
@@ -23,6 +27,11 @@ def find_env_file() -> Path | None:
     return None
 
 
+def is_running_in_lambda() -> bool:
+    """Check if code is running in AWS Lambda environment."""
+    return "AWS_LAMBDA_FUNCTION_NAME" in os.environ
+
+
 # Find env file once at module load
 _env_file = find_env_file()
 
@@ -32,6 +41,8 @@ class Settings(BaseSettings):
     Application settings loaded from environment variables.
 
     These settings are used across Lambda functions and local development.
+    In Lambda, secrets are loaded from AWS Secrets Manager.
+    Locally, they come from .env file.
     """
 
     model_config = SettingsConfigDict(
@@ -43,9 +54,11 @@ class Settings(BaseSettings):
 
     # SmashRun OAuth Configuration
     smashrun_client_id: str = Field(
+        default="",
         description="SmashRun OAuth Client ID",
     )
     smashrun_client_secret: str = Field(
+        default="",
         description="SmashRun OAuth Client Secret",
     )
     smashrun_redirect_uri: str = Field(
@@ -55,9 +68,11 @@ class Settings(BaseSettings):
 
     # Supabase Configuration
     supabase_url: str = Field(
+        default="",
         description="Supabase project URL",
     )
     supabase_key: str = Field(
+        default="",
         description="Supabase service role key (bypasses RLS)",
     )
 
@@ -88,14 +103,78 @@ class Settings(BaseSettings):
 _settings: Settings | None = None
 
 
+def _load_secrets_from_aws() -> dict[str, str]:
+    """
+    Load secrets from AWS Secrets Manager.
+
+    Returns:
+        Dict with secret values to overlay on settings
+    """
+    from .secrets import get_smashrun_oauth_credentials, get_supabase_credentials
+
+    secrets: dict[str, str] = {}
+
+    try:
+        # Load SmashRun OAuth credentials
+        smashrun_creds = get_smashrun_oauth_credentials()
+        secrets["smashrun_client_id"] = smashrun_creds.get("client_id", "")
+        secrets["smashrun_client_secret"] = smashrun_creds.get("client_secret", "")
+        logger.debug("Loaded SmashRun credentials from Secrets Manager")
+    except Exception as e:
+        logger.warning(f"Failed to load SmashRun credentials from Secrets Manager: {e}")
+
+    try:
+        # Load Supabase credentials
+        supabase_creds = get_supabase_credentials()
+        secrets["supabase_url"] = supabase_creds.get("url", "")
+        secrets["supabase_key"] = supabase_creds.get("key", "")
+        logger.debug("Loaded Supabase credentials from Secrets Manager")
+    except Exception as e:
+        logger.warning(f"Failed to load Supabase credentials from Secrets Manager: {e}")
+
+    return secrets
+
+
 def get_settings() -> Settings:
     """
     Get application settings (singleton pattern).
 
+    In Lambda: Loads secrets from AWS Secrets Manager
+    Locally: Loads from .env file
+
     Returns:
-        Settings instance loaded from environment
+        Settings instance with all configuration
     """
     global _settings
-    if _settings is None:
-        _settings = Settings()  # type: ignore[call-arg]
+    if _settings is not None:
+        return _settings
+
+    if is_running_in_lambda():
+        # In Lambda: Load base settings, then overlay secrets from Secrets Manager
+        logger.info("Running in Lambda - loading secrets from AWS Secrets Manager")
+
+        # First load base settings (non-secret env vars)
+        base_settings = Settings()
+
+        # Load secrets from AWS Secrets Manager
+        secrets = _load_secrets_from_aws()
+
+        # Create new settings with secrets overlaid
+        _settings = Settings(
+            smashrun_client_id=secrets.get("smashrun_client_id", base_settings.smashrun_client_id),
+            smashrun_client_secret=secrets.get(
+                "smashrun_client_secret", base_settings.smashrun_client_secret
+            ),
+            smashrun_redirect_uri=base_settings.smashrun_redirect_uri,
+            supabase_url=secrets.get("supabase_url", base_settings.supabase_url),
+            supabase_key=secrets.get("supabase_key", base_settings.supabase_key),
+            duckdb_path=base_settings.duckdb_path,
+            aws_region=base_settings.aws_region,
+            environment=base_settings.environment,
+            log_level=base_settings.log_level,
+        )
+    else:
+        # Locally: Just load from .env file
+        _settings = Settings()
+
     return _settings


### PR DESCRIPTION
## Summary

- Update `config.py` to fetch secrets from Secrets Manager when running in Lambda instead of expecting them as environment variables
- Add `streak.total_mi` field to `status.json` output for frontend compatibility  
- Add `check_status.py` diagnostic script to monitor system health

## Changes

### Secrets Loading (`src/shared/config.py`)
When running in Lambda (detected via `AWS_LAMBDA_FUNCTION_NAME` env var), secrets are now loaded at runtime from:
- `myrunstreak/{env}/smashrun/oauth` → `client_id`, `client_secret`
- `myrunstreak/{env}/supabase/credentials` → `url`, `key`

This keeps secrets out of environment variables for better security.

### Status Output (`src/lambdas/publish_status/handler.py`)
Added `streak.total_mi` to the streak object in `status.json`:
```json
"streak": {
  "current_days": 4111,
  "started": "2014-08-25",
  "total_mi": 3301.3
}
```

### Diagnostic Tool (`scripts/check_status.py`)
New script to check system health:
```bash
AWS_PROFILE=silverbeer uv run python scripts/check_status.py
```

Checks:
- EventBridge schedules
- CloudWatch logs for all Lambdas
- GCS status file (Did I Run Today widget)
- Lambda environment configuration

## Test plan

- [x] Tested config loading locally with simulated Lambda environment
- [x] Deployed sync Lambda - successfully synced 2 runs
- [x] Deployed publish_status Lambda - status.json now includes `streak.total_mi`
- [x] Verified GCS status file has correct structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)