### PR TITLE
feat: add human-readable streak duration to status output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,3 +104,8 @@ ignore_missing_imports = true
 module = ["google.cloud.*", "google.oauth2.*"]
 ignore_missing_imports = true
 disallow_untyped_calls = false
+
+[dependency-groups]
+dev = [
+    "types-python-dateutil>=2.9.0.20251115",
+]

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,9 +1,10 @@
 """Tests for unit conversion utilities."""
 
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 
 import pytest
 
+from src.lambdas.publish_status.handler import format_streak_duration
 from src.shared.models import (
     Activity,
     UnitSystem,
@@ -136,3 +137,67 @@ def test_zero_distance_handling():
     assert activity.distance_miles >= 0
     assert activity.average_pace_min_per_mile >= 0
     assert activity.average_speed_mph >= 0
+
+
+# Tests for format_streak_duration
+def test_format_streak_duration_years_months_days():
+    """Test full format with years, months, and days."""
+    today = date(2025, 3, 5)
+    streak_start = "2013-11-30"  # 11 years, 3 months, 5 days
+    result = format_streak_duration(streak_start, today)
+    assert result == "11 years, 3 months and 5 days"
+
+
+def test_format_streak_duration_singular():
+    """Test singular form for 1 year, 1 month, 1 day."""
+    today = date(2025, 2, 2)
+    streak_start = "2024-01-01"  # 1 year, 1 month, 1 day
+    result = format_streak_duration(streak_start, today)
+    assert result == "1 year, 1 month and 1 day"
+
+
+def test_format_streak_duration_days_only():
+    """Test format with only days."""
+    today = date(2025, 1, 15)
+    streak_start = "2025-01-10"  # 5 days
+    result = format_streak_duration(streak_start, today)
+    assert result == "5 days"
+
+
+def test_format_streak_duration_months_and_days():
+    """Test format with months and days only."""
+    today = date(2025, 3, 15)
+    streak_start = "2025-01-10"  # 2 months and 5 days
+    result = format_streak_duration(streak_start, today)
+    assert result == "2 months and 5 days"
+
+
+def test_format_streak_duration_years_and_days():
+    """Test format with years and days only (no months)."""
+    today = date(2025, 1, 15)
+    streak_start = "2023-01-10"  # 2 years and 5 days
+    result = format_streak_duration(streak_start, today)
+    assert result == "2 years and 5 days"
+
+
+def test_format_streak_duration_none_input():
+    """Test that None input returns None."""
+    result = format_streak_duration(None, date.today())
+    assert result is None
+
+
+def test_format_streak_duration_zero_days():
+    """Test format when started today (0 days)."""
+    today = date(2025, 1, 15)
+    streak_start = "2025-01-15"  # Same day
+    result = format_streak_duration(streak_start, today)
+    assert result == "0 days"
+
+
+def test_format_streak_duration_month_boundary():
+    """Test across month boundaries with different day counts."""
+    # March 2 with start Jan 31 - should handle different month lengths
+    today = date(2025, 3, 2)
+    streak_start = "2025-01-31"
+    result = format_streak_duration(streak_start, today)
+    assert result == "1 month and 2 days"

--- a/uv.lock
+++ b/uv.lock
@@ -1624,6 +1624,11 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "types-python-dateutil" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "authlib", specifier = ">=1.3.0" },
@@ -1650,6 +1655,9 @@ requires-dist = [
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.12.0" },
 ]
 provides-extras = ["dev", "cli", "chat"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "types-python-dateutil", specifier = ">=2.9.0.20251115" }]
 
 [[package]]
 name = "nexus-rpc"
@@ -2983,6 +2991,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/69/5a/bd06c2dbb77ebd4ea764473c9c4c014c7ba94432192cb965a274f8544b9d/types_protobuf-6.32.1.20250918.tar.gz", hash = "sha256:44ce0ae98475909ca72379946ab61a4435eec2a41090821e713c17e8faf5b88f", size = 63780, upload-time = "2025-09-18T02:50:39.391Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/5a/8d93d4f4af5dc3dd62aa4f020deae746b34b1d94fb5bee1f776c6b7e9d6c/types_protobuf-6.32.1.20250918-py3-none-any.whl", hash = "sha256:22ba6133d142d11cc34d3788ad6dead2732368ebb0406eaa7790ea6ae46c8d0b", size = 77885, upload-time = "2025-09-18T02:50:38.028Z" },
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20251115"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/36/06d01fb52c0d57e9ad0c237654990920fa41195e4b3d640830dabf9eeb2f/types_python_dateutil-2.9.0.20251115.tar.gz", hash = "sha256:8a47f2c3920f52a994056b8786309b43143faa5a64d4cbb2722d6addabdf1a58", size = 16363, upload-time = "2025-11-15T03:00:13.717Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/0b/56961d3ba517ed0df9b3a27bfda6514f3d01b28d499d1bce9068cfe4edd1/types_python_dateutil-2.9.0.20251115-py3-none-any.whl", hash = "sha256:9cf9c1c582019753b8639a081deefd7e044b9fa36bd8217f565c6c4e36ee0624", size = 18251, upload-time = "2025-11-15T03:00:12.317Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds a `duration` field to the streak object in status.json showing "X years, Y months and Z days" format
- Uses `dateutil.relativedelta` for accurate month/year calculations across edge cases
- Adds comprehensive unit tests for the new formatting function

## Example Output
```json
"streak": {
    "current_days": 4137,
    "started": "2013-11-30",
    "duration": "11 years, 3 months and 5 days",
    "total_mi": 45234.7
}
```

## Test plan
- [x] Unit tests pass for various date scenarios (years+months+days, singular forms, edge cases)
- [x] Ruff linting passes
- [x] Mypy type checking passes
- [ ] Deploy and verify status.json includes new field

🤖 Generated with [Claude Code](https://claude.com/claude-code)