### PR TITLE
fix: Mark SSM-derived outputs as sensitive

### DIFF
--- a/terraform/environments/dev/outputs.tf
+++ b/terraform/environments/dev/outputs.tf
@@ -120,26 +120,31 @@ output "github_actions_role_arn" {
 output "api_gateway_url" {
   description = "Base URL of the API Gateway (from SSM)"
   value       = module.api_gateway_consumer.api_gateway_invoke_url
+  sensitive   = true
 }
 
 output "api_sync_endpoint" {
   description = "Full URL for the sync endpoint"
   value       = module.api_gateway_consumer.sync_endpoint
+  sensitive   = true
 }
 
 output "api_health_endpoint" {
   description = "Full URL for the health check endpoint"
   value       = "${module.api_gateway_consumer.api_gateway_invoke_url}/health"
+  sensitive   = true
 }
 
 output "api_stats_endpoint" {
   description = "Base URL for stats endpoints"
   value       = module.api_gateway_consumer.stats_endpoint
+  sensitive   = true
 }
 
 output "api_runs_endpoint" {
   description = "Base URL for runs endpoints"
   value       = module.api_gateway_consumer.runs_endpoint
+  sensitive   = true
 }
 
 # Note: API key is now managed by runstreak-common repo
@@ -171,6 +176,7 @@ output "eventbridge_enabled" {
 
 output "deployment_instructions" {
   description = "Instructions for testing the deployment"
+  sensitive   = true
   value = <<-EOT
 
     MyRunStreak.run Infrastructure Deployed Successfully!

--- a/terraform/modules/api_gateway_consumer/outputs.tf
+++ b/terraform/modules/api_gateway_consumer/outputs.tf
@@ -5,42 +5,50 @@
 output "api_gateway_id" {
   description = "API Gateway REST API ID (from SSM)"
   value       = local.api_gateway_id
+  sensitive   = true
 }
 
 output "api_gateway_invoke_url" {
   description = "API Gateway invoke URL (from SSM)"
   value       = local.api_invoke_url
+  sensitive   = true
 }
 
 output "api_gateway_execution_arn" {
   description = "API Gateway execution ARN (from SSM)"
   value       = local.api_execution_arn
+  sensitive   = true
 }
 
 output "stage_name" {
   description = "API Gateway stage name (from SSM)"
   value       = local.stage_name
+  sensitive   = true
 }
 
 # Endpoint URLs
 output "sync_endpoint" {
   description = "Full URL for the sync endpoint"
   value       = "${local.api_invoke_url}/sync"
+  sensitive   = true
 }
 
 output "stats_endpoint" {
   description = "Base URL for stats endpoints"
   value       = "${local.api_invoke_url}/stats"
+  sensitive   = true
 }
 
 output "runs_endpoint" {
   description = "Base URL for runs endpoints"
   value       = "${local.api_invoke_url}/runs"
+  sensitive   = true
 }
 
 output "auth_endpoint" {
   description = "Base URL for auth endpoints"
   value       = "${local.api_invoke_url}/auth"
+  sensitive   = true
 }
 
 # Deployment ID (for debugging)


### PR DESCRIPTION
## Summary
- Mark all terraform outputs that reference SSM parameter values as `sensitive = true`
- This fixes the "Output refers to sensitive values" error in terraform plan

## Root Cause
SSM parameter values are marked as sensitive by the AWS provider. Any outputs that derive from these values must also be explicitly marked as sensitive.

## Also Fixed (via AWS CLI)
- Added OIDC provider permissions to `GitHubActions-Terraform-IAM` policy to fix `iam:GetOpenIDConnectProvider` access denied error

## Test plan
- [ ] Terraform plan should pass without errors
- [ ] Terraform apply should complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)