### PR TITLE
style: Fix terraform formatting

### DIFF
--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -90,7 +90,7 @@ output "dynamodb_table_name" {
 
 output "backend_config" {
   description = "Backend configuration to use in main Terraform"
-  value = <<-EOT
+  value       = <<-EOT
     backend "s3" {
       bucket         = "${aws_s3_bucket.terraform_state.id}"
       key            = "myrunstreak/terraform.tfstate"

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_version = ">= 1.5.0"
 
-  
+
 
   backend "s3" {
     bucket         = "myrunstreak-terraform-state-855323747881"
@@ -81,8 +81,8 @@ module "s3" {
   lambda_execution_role_arn = module.iam.lambda_execution_role_arn
 
   # Optional features
-  enable_cors       = false  # Enable if building web UI
-  enable_monitoring = true   # CloudWatch alarms for bucket size
+  enable_cors       = false # Enable if building web UI
+  enable_monitoring = true  # CloudWatch alarms for bucket size
 
   tags = local.common_tags
 }
@@ -112,8 +112,8 @@ module "secrets" {
   supabase_service_role_key = var.supabase_service_role_key
 
   # Optional features
-  enable_rotation      = false  # Manual token management for now
-  enable_age_monitoring = false  # Optional alarm for stale secrets
+  enable_rotation       = false # Manual token management for now
+  enable_age_monitoring = false # Optional alarm for stale secrets
 
   tags = local.common_tags
 }
@@ -180,16 +180,16 @@ module "lambda" {
   smashrun_secret_name = module.secrets.smashrun_oauth_secret_name
 
   # Performance tuning
-  memory_size             = 512   # MB (affects CPU allocation)
-  timeout                 = 300   # 5 minutes
-  ephemeral_storage_size  = 1024  # 1 GB for DuckDB operations
+  memory_size            = 512  # MB (affects CPU allocation)
+  timeout                = 300  # 5 minutes
+  ephemeral_storage_size = 1024 # 1 GB for DuckDB operations
 
   # Logging
-  log_level           = var.lambda_log_level
-  log_retention_days  = 14
+  log_level          = var.lambda_log_level
+  log_retention_days = 14
 
   # Monitoring
-  enable_xray_tracing = false  # Enable for distributed tracing
+  enable_xray_tracing = false # Enable for distributed tracing
   enable_alarms       = true
 
   # Permissions will be created separately below to avoid circular dependencies
@@ -199,7 +199,7 @@ module "lambda" {
   # Additional environment variables needed by the sync handler
   # Note: Secrets (Supabase, SmashRun credentials) are fetched from Secrets Manager
   extra_environment_variables = {
-    SMASHRUN_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob"  # Out-of-band redirect for CLI
+    SMASHRUN_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob" # Out-of-band redirect for CLI
   }
 
   tags = local.common_tags
@@ -233,12 +233,12 @@ module "lambda_query" {
 
   # S3 configuration (read-only access)
   s3_bucket_name       = module.s3.bucket_id
-  smashrun_secret_name = null  # Query Lambda doesn't need SmashRun credentials
+  smashrun_secret_name = null # Query Lambda doesn't need SmashRun credentials
 
   # Performance tuning for fast queries
-  memory_size            = 256  # MB (queries are fast)
-  timeout                = 30   # 30 seconds (API Gateway limit)
-  ephemeral_storage_size = 512  # 512 MB for DuckDB read operations
+  memory_size            = 256 # MB (queries are fast)
+  timeout                = 30  # 30 seconds (API Gateway limit)
+  ephemeral_storage_size = 512 # 512 MB for DuckDB read operations
 
   # Logging
   log_level          = var.lambda_log_level
@@ -291,9 +291,9 @@ module "lambda_publish_status" {
   smashrun_secret_name = null
 
   # Performance tuning
-  memory_size            = 256  # MB
-  timeout                = 60   # 1 minute
-  ephemeral_storage_size = 512  # MB
+  memory_size            = 256 # MB
+  timeout                = 60  # 1 minute
+  ephemeral_storage_size = 512 # MB
 
   # Logging
   log_level          = var.lambda_log_level
@@ -380,7 +380,7 @@ module "eventbridge" {
   }
 
   # Retry configuration
-  maximum_event_age_seconds = 3600  # 1 hour
+  maximum_event_age_seconds = 3600 # 1 hour
   maximum_retry_attempts    = 2
 
   # Monitoring
@@ -421,8 +421,8 @@ resource "aws_iam_role_policy" "lambda_invoke_publish_status" {
     Version = "2012-10-17"
     Statement = [
       {
-        Effect = "Allow"
-        Action = "lambda:InvokeFunction"
+        Effect   = "Allow"
+        Action   = "lambda:InvokeFunction"
         Resource = module.lambda_publish_status.function_arn
       }
     ]

--- a/terraform/environments/dev/outputs.tf
+++ b/terraform/environments/dev/outputs.tf
@@ -178,7 +178,7 @@ output "eventbridge_enabled" {
 output "deployment_instructions" {
   description = "Instructions for testing the deployment"
   sensitive   = true
-  value = <<-EOT
+  value       = <<-EOT
 
     MyRunStreak.run Infrastructure Deployed Successfully!
 

--- a/terraform/modules/api_gateway_consumer/main.tf
+++ b/terraform/modules/api_gateway_consumer/main.tf
@@ -43,11 +43,11 @@ data "aws_ssm_parameter" "api_gateway_invoke_url" {
 }
 
 locals {
-  api_gateway_id     = data.aws_ssm_parameter.api_gateway_id.value
-  root_resource_id   = data.aws_ssm_parameter.api_gateway_root_resource_id.value
-  api_execution_arn  = data.aws_ssm_parameter.api_gateway_execution_arn.value
-  stage_name         = data.aws_ssm_parameter.api_gateway_stage_name.value
-  api_invoke_url     = data.aws_ssm_parameter.api_gateway_invoke_url.value
+  api_gateway_id    = data.aws_ssm_parameter.api_gateway_id.value
+  root_resource_id  = data.aws_ssm_parameter.api_gateway_root_resource_id.value
+  api_execution_arn = data.aws_ssm_parameter.api_gateway_execution_arn.value
+  stage_name        = data.aws_ssm_parameter.api_gateway_stage_name.value
+  api_invoke_url    = data.aws_ssm_parameter.api_gateway_invoke_url.value
 }
 
 # ==============================================================================

--- a/terraform/modules/ecr/main.tf
+++ b/terraform/modules/ecr/main.tf
@@ -21,7 +21,7 @@
 
 resource "aws_ecr_repository" "sync" {
   name                 = "${var.project_name}-sync-${var.environment}"
-  image_tag_mutability = "MUTABLE"  # Allow overwriting :latest tag
+  image_tag_mutability = "MUTABLE" # Allow overwriting :latest tag
 
   # Enable image scanning on push
   image_scanning_configuration {
@@ -79,9 +79,9 @@ resource "aws_ecr_lifecycle_policy" "sync" {
         rulePriority = 1
         description  = "Keep last ${var.image_retention_count} images"
         selection = {
-          tagStatus     = "any"
-          countType     = "imageCountMoreThan"
-          countNumber   = var.image_retention_count
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = var.image_retention_count
         }
         action = {
           type = "expire"
@@ -104,9 +104,9 @@ resource "aws_ecr_lifecycle_policy" "query" {
         rulePriority = 1
         description  = "Keep last ${var.image_retention_count} images"
         selection = {
-          tagStatus     = "any"
-          countType     = "imageCountMoreThan"
-          countNumber   = var.image_retention_count
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = var.image_retention_count
         }
         action = {
           type = "expire"
@@ -212,9 +212,9 @@ resource "aws_ecr_lifecycle_policy" "publish_status" {
         rulePriority = 1
         description  = "Keep last ${var.image_retention_count} images"
         selection = {
-          tagStatus     = "any"
-          countType     = "imageCountMoreThan"
-          countNumber   = var.image_retention_count
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = var.image_retention_count
         }
         action = {
           type = "expire"

--- a/terraform/modules/eventbridge/variables.tf
+++ b/terraform/modules/eventbridge/variables.tf
@@ -63,7 +63,7 @@ variable "custom_input" {
 variable "maximum_event_age_seconds" {
   description = "Maximum age of event before discarding (60-86400)"
   type        = number
-  default     = 3600  # 1 hour
+  default     = 3600 # 1 hour
 
   validation {
     condition     = var.maximum_event_age_seconds >= 60 && var.maximum_event_age_seconds <= 86400

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -111,7 +111,7 @@ resource "aws_iam_role_policy" "s3_access" {
           "s3:GetObject",
           "s3:GetObjectVersion",
           "s3:PutObject",
-          "s3:DeleteObject"  # For cleanup if needed
+          "s3:DeleteObject" # For cleanup if needed
         ]
         Resource = "${var.s3_bucket_arn}/*"
         # Note: "/*" means all objects in the bucket

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -96,14 +96,14 @@ resource "aws_lambda_function" "sync_runner" {
   }
 
   # Performance Configuration
-  memory_size = var.memory_size  # 128-10240 MB
-  timeout     = var.timeout      # 1-900 seconds (15 minutes max)
+  memory_size = var.memory_size # 128-10240 MB
+  timeout     = var.timeout     # 1-900 seconds (15 minutes max)
   # More memory = more CPU = faster execution
   # But also = higher cost per second
   # 512 MB is sweet spot for most workloads
 
   # Architecture
-  architectures = ["x86_64"]  # or ["arm64"] (Graviton2 - 20% cheaper)
+  architectures = ["x86_64"] # or ["arm64"] (Graviton2 - 20% cheaper)
   # arm64 requires all dependencies compiled for ARM
   # x86_64 is safer for compatibility
 
@@ -176,7 +176,7 @@ resource "aws_lambda_function" "sync_runner" {
 
   # Ephemeral Storage (/tmp directory)
   ephemeral_storage {
-    size = var.ephemeral_storage_size  # 512-10240 MB
+    size = var.ephemeral_storage_size # 512-10240 MB
   }
   # Lambda provides /tmp directory for temporary files
   # DuckDB database is ~3 MB, plus some overhead
@@ -277,7 +277,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
   evaluation_periods  = "1"
   metric_name         = "Errors"
   namespace           = "AWS/Lambda"
-  period              = "300"  # 5 minutes
+  period              = "300" # 5 minutes
   statistic           = "Sum"
   threshold           = "1"
   alarm_description   = "Lambda function is experiencing errors"
@@ -321,7 +321,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_duration" {
   namespace           = "AWS/Lambda"
   period              = "300"
   statistic           = "Maximum"
-  threshold           = var.timeout * 1000 * 0.9  # 90% of timeout (in milliseconds)
+  threshold           = var.timeout * 1000 * 0.9 # 90% of timeout (in milliseconds)
   alarm_description   = "Lambda function is approaching timeout"
   treat_missing_data  = "notBreaching"
 

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -89,7 +89,7 @@ variable "memory_size" {
 variable "timeout" {
   description = "Function timeout in seconds (1-900)"
   type        = number
-  default     = 300  # 5 minutes
+  default     = 300 # 5 minutes
 
   validation {
     condition     = var.timeout >= 1 && var.timeout <= 900
@@ -100,7 +100,7 @@ variable "timeout" {
 variable "ephemeral_storage_size" {
   description = "Size of /tmp directory in MB (512-10240)"
   type        = number
-  default     = 1024  # 1 GB for DuckDB operations
+  default     = 1024 # 1 GB for DuckDB operations
 
   validation {
     condition     = var.ephemeral_storage_size >= 512 && var.ephemeral_storage_size <= 10240

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -101,7 +101,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "database" {
     id     = "delete-old-versions"
     status = "Enabled"
 
-    filter {}  # Apply to all objects
+    filter {} # Apply to all objects
 
     noncurrent_version_expiration {
       noncurrent_days = 30
@@ -109,7 +109,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "database" {
 
     noncurrent_version_transition {
       noncurrent_days = 7
-      storage_class   = "GLACIER_IR"  # Cheaper storage for old versions
+      storage_class   = "GLACIER_IR" # Cheaper storage for old versions
     }
   }
 
@@ -117,7 +117,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "database" {
     id     = "cleanup-incomplete-uploads"
     status = "Enabled"
 
-    filter {}  # Apply to all objects
+    filter {} # Apply to all objects
 
     abort_incomplete_multipart_upload {
       days_after_initiation = 7
@@ -174,10 +174,10 @@ resource "aws_s3_bucket_policy" "database" {
         ]
       },
       {
-        Sid    = "DenyInsecureTransport"
-        Effect = "Deny"
+        Sid       = "DenyInsecureTransport"
+        Effect    = "Deny"
         Principal = "*"
-        Action = "s3:*"
+        Action    = "s3:*"
         Resource = [
           aws_s3_bucket.database.arn,
           "${aws_s3_bucket.database.arn}/*"
@@ -205,7 +205,7 @@ resource "aws_cloudwatch_metric_alarm" "bucket_size" {
   evaluation_periods  = "1"
   metric_name         = "BucketSizeBytes"
   namespace           = "AWS/S3"
-  period              = "86400"  # Daily check
+  period              = "86400" # Daily check
   statistic           = "Average"
   threshold           = var.max_bucket_size_bytes
   alarm_description   = "S3 bucket size exceeds threshold - possible issue"

--- a/terraform/modules/s3/variables.tf
+++ b/terraform/modules/s3/variables.tf
@@ -57,7 +57,7 @@ variable "enable_monitoring" {
 variable "max_bucket_size_bytes" {
   description = "Maximum bucket size in bytes before alerting"
   type        = number
-  default     = 1073741824  # 1 GB
+  default     = 1073741824 # 1 GB
 }
 
 variable "alarm_sns_topic_arn" {

--- a/terraform/modules/secrets/main.tf
+++ b/terraform/modules/secrets/main.tf
@@ -201,7 +201,7 @@ resource "aws_cloudwatch_metric_alarm" "secret_age" {
   evaluation_periods  = "1"
   metric_name         = "SecretAge"
   namespace           = "AWS/SecretsManager"
-  period              = "86400"  # Daily check
+  period              = "86400" # Daily check
   statistic           = "Maximum"
   threshold           = var.max_secret_age_days
   alarm_description   = "Secret has not been rotated recently"


### PR DESCRIPTION
## Summary

Run `terraform fmt` to fix formatting issues across all modules.

## Files formatted

- terraform/bootstrap/main.tf
- terraform/environments/dev/main.tf
- terraform/environments/dev/outputs.tf
- terraform/modules/api_gateway_consumer/main.tf
- terraform/modules/ecr/main.tf
- terraform/modules/eventbridge/variables.tf
- terraform/modules/iam/main.tf
- terraform/modules/lambda/main.tf
- terraform/modules/lambda/variables.tf
- terraform/modules/s3/main.tf
- terraform/modules/s3/variables.tf
- terraform/modules/secrets/main.tf

🤖 Generated with [Claude Code](https://claude.com/claude-code)