### PR TITLE
feat: Add since_date override for manual backfill sync

### DIFF
--- a/src/lambdas/sync_runs/handler.py
+++ b/src/lambdas/sync_runs/handler.py
@@ -82,14 +82,20 @@ def lambda_handler(event: dict[str, Any], context: LambdaContext) -> dict[str, A
 
                 logger.info(f"Syncing source {source_id} (user={user_id}, type={source_type})")
 
-                # Get last sync date (default to 30 days ago if never synced)
-                last_sync_at = source.get("last_sync_at")
-                if last_sync_at:
-                    since_date = datetime.fromisoformat(last_sync_at).date()
-                    logger.info(f"Last sync: {since_date}")
+                # Allow since_date override from event payload (for manual backfill)
+                since_date_override = event.get("since_date")
+                if since_date_override:
+                    since_date = date.fromisoformat(since_date_override)
+                    logger.info(f"Using since_date override from event: {since_date}")
                 else:
-                    since_date = date.today() - timedelta(days=30)
-                    logger.info(f"Never synced, using default: {since_date}")
+                    # Get last sync date (default to 30 days ago if never synced)
+                    last_sync_at = source.get("last_sync_at")
+                    if last_sync_at:
+                        since_date = datetime.fromisoformat(last_sync_at).date()
+                        logger.info(f"Last sync: {since_date}")
+                    else:
+                        since_date = date.today() - timedelta(days=30)
+                        logger.info(f"Never synced, using default: {since_date}")
 
                 # Sync runs for this user source
                 runs_synced = sync_user_source(


### PR DESCRIPTION
## Summary
- Adds optional `since_date` field to the sync Lambda event payload, enabling manual re-sync from a specific date
- Normal scheduled EventBridge invocations are unaffected (they don't include `since_date`)
- Needed to backfill missed runs from Feb 4-6 when SmashRun returned 0 activities during the normal sync windows

## Context
Investigation of the streak reset (4,182 days → 4 days) showed:
- Lambda is running correctly twice daily, no errors
- SmashRun API returned 0 activities for Feb 4-6 during scheduled syncs
- The runs exist in SmashRun but were likely uploaded after the sync windows passed
- Streak broke on Feb 5 morning when no run existed for Feb 4

## Usage
After deployment, invoke with a backfill date to re-sync missed runs:
```bash
aws lambda invoke \
  --function-name myrunstreak-sync-runner-dev \
  --payload '{"since_date":"2026-02-03","action":"backfill"}' \
  --cli-binary-format raw-in-base64-out \
  --region us-east-2 \
  response.json
```

## Test plan
- [ ] Verify CI passes (ruff, mypy, pytest)
- [ ] Merge and confirm Lambda deploys via CI/CD
- [ ] Invoke Lambda with `since_date` of `2026-02-03` to backfill missed runs
- [ ] Verify streak is restored to ~4,187 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)