### PR TITLE
docs: Update token refresh strategy documentation

### DIFF
--- a/docs/LAMBDA_SYNC.md
+++ b/docs/LAMBDA_SYNC.md
@@ -39,9 +39,9 @@ CloudWatch (logs, metrics, traces)
 
 **Features:**
 - Fetch tokens from AWS Secrets Manager
-- Auto-refresh expired tokens (12-week lifespan)
-- Update stored tokens after refresh
-- 1-day expiration buffer for proactive refresh
+- Auto-refresh at the halfway point of token lifetime (~6 weeks for 12-week tokens)
+- Update stored tokens after refresh, keeping both access and refresh tokens rolling
+- Fallback: refresh within 30 days of expiry if token issue date is unknown
 
 **Key Methods:**
 - `get_valid_access_token()` - Returns valid token, refreshes if needed
@@ -296,8 +296,9 @@ View distributed traces in X-Ray console:
 ### Common Issues
 
 **1. Token Expired**
-- **Error:** "401 Unauthorized" from SmashRun API
-- **Fix:** Token manager should auto-refresh; check Secrets Manager permissions
+- **Error:** `KeyError: 'access_token'` or "401 Unauthorized" from SmashRun API
+- **Cause:** Both access and refresh tokens share the same ~12-week lifespan. If the Lambda was offline long enough for both to expire, auto-refresh fails.
+- **Fix:** Re-authorize with SmashRun: `uv run python scripts/get_oauth_tokens.py`, then update the secret in Secrets Manager
 
 **2. Rate Limited**
 - **Error:** "429 Too Many Requests"

--- a/docs/SMASHRUN_OAUTH.md
+++ b/docs/SMASHRUN_OAUTH.md
@@ -204,10 +204,11 @@ print(f"New Refresh Token: {new_token_data['refresh_token']}")  # May be same or
 
 ### When to Refresh
 
-Refresh tokens when:
-- Access token expires (12 weeks)
-- API returns 401 Unauthorized
-- Before scheduled daily sync (proactive)
+The `TokenManager` automatically refreshes at the **halfway point** of the token lifetime (~6 weeks for a 12-week token). This ensures both the access token and refresh token stay fresh — SmashRun refresh tokens have the same ~12-week lifespan as access tokens, so waiting until the last day to refresh risks both tokens expiring simultaneously.
+
+Manual refresh is needed when:
+- Both tokens have already expired (re-authorize via `scripts/get_oauth_tokens.py`)
+- API returns 401 Unauthorized after a prolonged outage
 
 ## 🔐 Security Best Practices
 
@@ -244,12 +245,15 @@ def update_smashrun_tokens(access_token, refresh_token):
     )
 ```
 
-### 3. Rotate Tokens Regularly
+### 3. Token Lifespans
 
-Even though refresh tokens don't expire, rotate them periodically:
-- Re-authorize every 6 months
-- After any security incidents
-- If tokens may have been compromised
+SmashRun access tokens **and** refresh tokens both expire after ~12 weeks (~84 days). The `TokenManager` handles this by refreshing at the halfway point (~6 weeks), which rolls both tokens forward automatically. If the Lambda is offline for more than 12 weeks, you'll need to re-authorize manually:
+
+```bash
+uv run python scripts/get_oauth_tokens.py
+```
+
+Also re-authorize after any security incidents or if tokens may have been compromised.
 
 ## 🚀 Complete Sync Script
 


### PR DESCRIPTION
## Summary
- **SMASHRUN_OAUTH.md**: Corrects the claim that "refresh tokens don't expire" — they share the same ~12-week lifespan as access tokens, which is what caused the Feb 13–19 outage. Documents the new halflife refresh strategy and manual re-auth steps.
- **LAMBDA_SYNC.md**: Updates TokenManager description from "1-day expiration buffer" to "halfway point refresh". Adds the actual error signature (`KeyError: 'access_token'`) and re-authorization command to the troubleshooting section.

## Test plan
- [x] Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)