### PR TITLE
ci: Add Supabase migration workflow

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -15,7 +15,8 @@
 # - Manual: Apply migrations with safety confirmation
 #
 # Prerequisites:
-# - SUPABASE_DB_PASSWORD secret must be configured
+# - SUPABASE_ACCESS_TOKEN secret must be configured (Management API)
+# - SUPABASE_DB_PASSWORD secret must be configured (database connection)
 # - Supabase project must exist (project ref: dnwllbukmvdddwhlsmqb)
 #
 # Security:
@@ -94,6 +95,7 @@ jobs:
       - name: Link Supabase project
         run: supabase link --project-ref ${{ env.SUPABASE_PROJECT_REF }}
         env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
 
       # ========================================================================
@@ -116,6 +118,7 @@ jobs:
             echo "has_changes=unknown" >> $GITHUB_OUTPUT
           fi
         env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
 
       # ========================================================================
@@ -188,6 +191,7 @@ jobs:
       - name: Link Supabase project
         run: supabase link --project-ref ${{ env.SUPABASE_PROJECT_REF }}
         env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
 
       # ========================================================================
@@ -202,6 +206,7 @@ jobs:
           echo "$OUTPUT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
         env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
 
       # ========================================================================

--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -126,28 +126,35 @@ jobs:
       # ========================================================================
       - name: Post Dry Run Results to PR
         uses: actions/github-script@v7
+        env:
+          DRY_RUN_OUTPUT: ${{ steps.dry-run.outputs.output }}
+          HAS_CHANGES: ${{ steps.dry-run.outputs.has_changes }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const output = `#### Supabase Migration Dry Run 🗄️
-
-            **Status:** \`${{ steps.dry-run.outputs.has_changes }}\` pending changes
-
-            <details><summary>Show Dry Run Output</summary>
-
-            \`\`\`
-            ${{ steps.dry-run.outputs.output }}
-            \`\`\`
-
-            </details>
-
-            *Pusher: @${{ github.actor }}, Workflow: \`${{ github.workflow }}\`*`;
+            const dryRunOutput = process.env.DRY_RUN_OUTPUT;
+            const hasChanges = process.env.HAS_CHANGES;
+            const body = [
+              '#### Supabase Migration Dry Run',
+              '',
+              `**Status:** \`${hasChanges}\` pending changes`,
+              '',
+              '<details><summary>Show Dry Run Output</summary>',
+              '',
+              '```',
+              dryRunOutput,
+              '```',
+              '',
+              '</details>',
+              '',
+              `*Pusher: @${{ github.actor }}, Workflow: \`${{ github.workflow }}\`*`
+            ].join('\n');
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: output
+              body: body
             });
 
   # ==========================================================================

--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -57,6 +57,7 @@ permissions:
 
 env:
   SUPABASE_PROJECT_REF: dnwllbukmvdddwhlsmqb
+  SUPABASE_CLI_VERSION: "2.75.0"
 
 # Prevent overlapping migration runs
 concurrency:
@@ -84,6 +85,8 @@ jobs:
       # ========================================================================
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
+        with:
+          version: ${{ env.SUPABASE_CLI_VERSION }}
 
       # ========================================================================
       # Step 3: Link to Supabase project
@@ -176,6 +179,8 @@ jobs:
       # ========================================================================
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
+        with:
+          version: ${{ env.SUPABASE_CLI_VERSION }}
 
       # ========================================================================
       # Step 4: Link to Supabase project

--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -1,0 +1,265 @@
+# ==============================================================================
+# GitHub Actions Workflow - Supabase Migrations
+# ==============================================================================
+# This workflow manages database migrations for the Supabase-hosted PostgreSQL
+# database. It validates migrations on PRs and applies them on merge to main.
+#
+# Triggers:
+# - Pull requests that modify supabase/migrations/**
+# - Push to main branch (when PR is merged)
+# - Manual workflow dispatch (with safety confirmation)
+#
+# What it does:
+# - On PR: Dry-run migrations and post results as PR comment
+# - On merge: Apply pending migrations to the remote database
+# - Manual: Apply migrations with safety confirmation
+#
+# Prerequisites:
+# - SUPABASE_DB_PASSWORD secret must be configured
+# - Supabase project must exist (project ref: dnwllbukmvdddwhlsmqb)
+#
+# Security:
+# - Database password stored as GitHub Secret
+# - Manual dispatch requires typing "migrate" to confirm
+# - Concurrency group prevents overlapping migration runs
+# ==============================================================================
+
+name: "Supabase Migrations"
+
+on:
+  # Validate migrations on PRs
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "supabase/migrations/**"
+      - ".github/workflows/supabase-migrations.yml"
+
+  # Apply migrations when merged to main
+  push:
+    branches:
+      - main
+    paths:
+      - "supabase/migrations/**"
+      - ".github/workflows/supabase-migrations.yml"
+
+  # Allow manual trigger (USE WITH CAUTION)
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "migrate" to confirm manual migration'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  SUPABASE_PROJECT_REF: dnwllbukmvdddwhlsmqb
+
+# Prevent overlapping migration runs
+concurrency:
+  group: supabase-migrations
+  cancel-in-progress: false
+
+jobs:
+  # ==========================================================================
+  # Job 1: Validate Migrations (PR only)
+  # ==========================================================================
+  migration-check:
+    name: "Migration Dry Run"
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      # ========================================================================
+      # Step 1: Check out code
+      # ========================================================================
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # ========================================================================
+      # Step 2: Set up Supabase CLI
+      # ========================================================================
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+
+      # ========================================================================
+      # Step 3: Link to Supabase project
+      # ========================================================================
+      - name: Link Supabase project
+        run: supabase link --project-ref ${{ env.SUPABASE_PROJECT_REF }}
+        env:
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      # ========================================================================
+      # Step 4: Dry-run migrations
+      # ========================================================================
+      - name: Dry-run migrations
+        id: dry-run
+        run: |
+          OUTPUT=$(supabase db push --dry-run 2>&1) || true
+          echo "output<<EOF" >> $GITHUB_OUTPUT
+          echo "$OUTPUT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          # Check if there are pending migrations
+          if echo "$OUTPUT" | grep -q "Would push"; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          elif echo "$OUTPUT" | grep -q "No pending migrations"; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=unknown" >> $GITHUB_OUTPUT
+          fi
+        env:
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      # ========================================================================
+      # Step 5: Post results as PR comment
+      # ========================================================================
+      - name: Post Dry Run Results to PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Supabase Migration Dry Run 🗄️
+
+            **Status:** \`${{ steps.dry-run.outputs.has_changes }}\` pending changes
+
+            <details><summary>Show Dry Run Output</summary>
+
+            \`\`\`
+            ${{ steps.dry-run.outputs.output }}
+            \`\`\`
+
+            </details>
+
+            *Pusher: @${{ github.actor }}, Workflow: \`${{ github.workflow }}\`*`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            });
+
+  # ==========================================================================
+  # Job 2: Apply Migrations (merge to main or manual dispatch)
+  # ==========================================================================
+  migration-apply:
+    name: "Apply Migrations"
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+
+    steps:
+      # ========================================================================
+      # Step 1: Safety check for manual dispatch
+      # ========================================================================
+      - name: Verify Manual Confirmation
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ github.event.inputs.confirm }}" != "migrate" ]; then
+            echo "❌ Manual confirmation failed. Must type 'migrate' to proceed."
+            exit 1
+          fi
+          echo "✅ Manual confirmation received"
+
+      # ========================================================================
+      # Step 2: Check out code
+      # ========================================================================
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # ========================================================================
+      # Step 3: Set up Supabase CLI
+      # ========================================================================
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+
+      # ========================================================================
+      # Step 4: Link to Supabase project
+      # ========================================================================
+      - name: Link Supabase project
+        run: supabase link --project-ref ${{ env.SUPABASE_PROJECT_REF }}
+        env:
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      # ========================================================================
+      # Step 5: Apply pending migrations
+      # ========================================================================
+      - name: Apply Migrations
+        id: push
+        run: |
+          OUTPUT=$(supabase db push 2>&1)
+          echo "$OUTPUT"
+          echo "output<<EOF" >> $GITHUB_OUTPUT
+          echo "$OUTPUT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+        env:
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      # ========================================================================
+      # Step 6: Create deployment summary
+      # ========================================================================
+      - name: Create Migration Summary
+        if: success()
+        run: |
+          cat >> $GITHUB_STEP_SUMMARY <<EOF
+          ## 🗄️ Supabase Migrations Applied
+
+          **Project:** \`${{ env.SUPABASE_PROJECT_REF }}\`
+          **Applied At:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')
+          **Triggered By:** @${{ github.actor }}
+          **Trigger:** \`${{ github.event_name }}\`
+
+          ---
+
+          ### 📋 Migration Output
+
+          \`\`\`
+          ${{ steps.push.outputs.output }}
+          \`\`\`
+
+          ---
+
+          ### 📊 Supabase Console Links
+
+          - [Database](https://supabase.com/dashboard/project/${{ env.SUPABASE_PROJECT_REF }}/editor)
+          - [Migrations](https://supabase.com/dashboard/project/${{ env.SUPABASE_PROJECT_REF }}/database/migrations)
+          - [Logs](https://supabase.com/dashboard/project/${{ env.SUPABASE_PROJECT_REF }}/logs/postgres-logs)
+
+          EOF
+
+      # ========================================================================
+      # Step 7: Handle migration failure
+      # ========================================================================
+      - name: Migration Failed
+        if: failure()
+        run: |
+          cat >> $GITHUB_STEP_SUMMARY <<EOF
+          ## ❌ Supabase Migration Failed
+
+          **Project:** \`${{ env.SUPABASE_PROJECT_REF }}\`
+          **Failed At:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')
+          **Triggered By:** @${{ github.actor }}
+
+          ---
+
+          ### 🔍 Troubleshooting
+
+          1. Check the error output above
+          2. Verify \`SUPABASE_DB_PASSWORD\` secret is correct
+          3. Check [Supabase Dashboard](https://supabase.com/dashboard/project/${{ env.SUPABASE_PROJECT_REF }}/database/migrations) for migration state
+          4. Run \`supabase db push --dry-run\` locally to debug
+
+          ### 🔄 Recovery
+
+          If a migration partially applied:
+          1. Check which migrations succeeded in the Supabase Dashboard
+          2. Fix the failing migration SQL
+          3. Push a new commit or re-run the workflow manually
+
+          EOF
+
+          exit 1

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -195,6 +195,7 @@ Go to your GitHub repository → Settings → Secrets and variables → Actions 
 | `SMASHRUN_ACCESS_TOKEN` | SmashRun OAuth access token | From OAuth flow |
 | `SMASHRUN_REFRESH_TOKEN` | SmashRun OAuth refresh token | From OAuth flow |
 | `API_KEY_PERSONAL` | API Gateway API key | Generate: `python -c "import secrets; print(secrets.token_urlsafe(32))"` |
+| `SUPABASE_ACCESS_TOKEN` | Supabase Management API token | Dashboard > Account > Access Tokens |
 | `SUPABASE_DB_PASSWORD` | Supabase database password | Dashboard > Settings > Database > Database password |
 
 ### Adding Secrets via GitHub CLI
@@ -214,6 +215,7 @@ gh secret set SMASHRUN_CLIENT_SECRET --body "your-client-secret"
 gh secret set SMASHRUN_ACCESS_TOKEN --body "your-access-token"
 gh secret set SMASHRUN_REFRESH_TOKEN --body "your-refresh-token"
 gh secret set API_KEY_PERSONAL --body "$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
+gh secret set SUPABASE_ACCESS_TOKEN --body "your-access-token"
 gh secret set SUPABASE_DB_PASSWORD --body "your-database-password"
 ```
 

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -22,6 +22,7 @@ We use GitHub Actions for **automated CI/CD**:
 - **Terraform Plan** - Preview infrastructure changes on PRs
 - **Terraform Apply** - Deploy infrastructure when merged to main
 - **Lambda Deploy** - Deploy code changes independently
+- **Supabase Migrations** - Validate and apply database migrations
 
 **Why separate Terraform and Lambda?**
 - Code changes are frequent (daily/weekly)
@@ -86,6 +87,24 @@ We use GitHub Actions for **automated CI/CD**:
 4. Updates Lambda function code
 5. Runs smoke test
 6. Posts deployment summary
+
+### 4. Supabase Migrations (`.github/workflows/supabase-migrations.yml`)
+
+**Triggers:**
+- Pull requests that modify `supabase/migrations/**`
+- Push to `main` branch (after PR merge)
+- Manual dispatch (with confirmation)
+
+**What it does:**
+- **On PR:** Dry-runs `supabase db push --dry-run` and posts results as a PR comment
+- **On merge:** Applies pending migrations with `supabase db push`
+- **Manual:** Applies migrations after typing "migrate" to confirm
+
+**Safety features:**
+- Dry-run on PRs catches errors before merge
+- Concurrency group prevents overlapping migration runs
+- Manual dispatch requires typing "migrate"
+- Failure step with troubleshooting guidance and Supabase console links
 
 ---
 
@@ -176,6 +195,7 @@ Go to your GitHub repository → Settings → Secrets and variables → Actions 
 | `SMASHRUN_ACCESS_TOKEN` | SmashRun OAuth access token | From OAuth flow |
 | `SMASHRUN_REFRESH_TOKEN` | SmashRun OAuth refresh token | From OAuth flow |
 | `API_KEY_PERSONAL` | API Gateway API key | Generate: `python -c "import secrets; print(secrets.token_urlsafe(32))"` |
+| `SUPABASE_DB_PASSWORD` | Supabase database password | Dashboard > Settings > Database > Database password |
 
 ### Adding Secrets via GitHub CLI
 
@@ -194,6 +214,7 @@ gh secret set SMASHRUN_CLIENT_SECRET --body "your-client-secret"
 gh secret set SMASHRUN_ACCESS_TOKEN --body "your-access-token"
 gh secret set SMASHRUN_REFRESH_TOKEN --body "your-refresh-token"
 gh secret set API_KEY_PERSONAL --body "$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
+gh secret set SUPABASE_DB_PASSWORD --body "your-database-password"
 ```
 
 ---
@@ -347,6 +368,19 @@ PR Merged → main branch → src/** changes → lambda-deploy.yml runs
 gh workflow run lambda-deploy.yml
 ```
 
+### Supabase Migrations
+
+**Automatic triggers:**
+```
+Pull Request → supabase/migrations/** changes → migration-check (dry-run)
+PR Merged → main branch → supabase/migrations/** changes → migration-apply
+```
+
+**Manual trigger (USE WITH CAUTION):**
+```bash
+gh workflow run supabase-migrations.yml -f confirm=migrate
+```
+
 ---
 
 ## Troubleshooting
@@ -489,10 +523,11 @@ Benefits:
 
 You now have:
 
-✅ **3 automated workflows:**
+✅ **4 automated workflows:**
 - Terraform Plan (on PRs)
 - Terraform Apply (on merge)
 - Lambda Deploy (on code changes)
+- Supabase Migrations (on migration changes)
 
 ✅ **Secure authentication:**
 - AWS OIDC (no long-lived credentials)


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for Supabase database migrations
- **On PR**: Dry-runs `supabase db push --dry-run` and posts results as a PR comment
- **On merge to main**: Applies pending migrations with `supabase db push`
- **Manual dispatch**: With safety confirmation (type "migrate")
- Update `docs/GITHUB_ACTIONS.md` with workflow #4 docs and `SUPABASE_DB_PASSWORD` secret

## Test plan
- [ ] Verify `migration-check` job runs dry-run on this PR
- [ ] Verify dry-run results are posted as a PR comment
- [ ] After merge, verify `migration-apply` job applies successfully
- [ ] Check Supabase Dashboard > Migrations to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)