### PR TITLE
fix: Increase distance_km precision to 5 decimal places

### DIFF
--- a/supabase/migrations/20260301000001_increase_distance_precision.sql
+++ b/supabase/migrations/20260301000001_increase_distance_precision.sql
@@ -1,0 +1,16 @@
+-- Increase distance_km precision from NUMERIC(10,3) to NUMERIC(10,5).
+--
+-- SmashRun API returns distances with 5 decimal places (e.g. 1.64145 km),
+-- but NUMERIC(10,3) truncates to 3 decimals (1.641 km). The ~1 meter/run
+-- truncation error accumulates: over 31 runs in a month it can total 30+
+-- meters, enough to make a 100-mile month appear as 99.98 miles.
+--
+-- This is a safe ALTER: widening precision never loses existing data.
+
+-- runs table: primary distance field
+ALTER TABLE runs
+    ALTER COLUMN distance_km TYPE NUMERIC(10, 5);
+
+-- splits table: cumulative distance field
+ALTER TABLE splits
+    ALTER COLUMN cumulative_distance_km TYPE NUMERIC(10, 5);


### PR DESCRIPTION
## Summary
- SmashRun API returns distances with 5 decimal places (e.g. `1.64145` km)
- `NUMERIC(10,3)` was truncating to 3 decimals (`1.641` km), losing ~1 meter per run
- Over 31 runs/month, this accumulates to ~30 meters — enough to turn a 100.00-mile month into 99.98 miles (Dec 2024 was affected)
- Widens `runs.distance_km` and `splits.cumulative_distance_km` to `NUMERIC(10,5)`

## After merge
Backfill required to re-sync all runs with full precision:
```bash
aws lambda invoke --function-name myrunstreak-sync-runner-dev \
  --payload '{"since_date": "2014-01-01"}' \
  --cli-binary-format raw-in-base64-out response.json
```

## Test plan
- [ ] Verify migration dry-run passes on this PR
- [ ] After merge, confirm migration applies successfully
- [ ] Backfill runs and verify Dec 2024 totals >= 100 miles

🤖 Generated with [Claude Code](https://claude.com/claude-code)