### PR TITLE
fix: Capture migration errors and retry precision migration

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -207,11 +207,15 @@ jobs:
       - name: Apply Migrations
         id: push
         run: |
+          set +e
           OUTPUT=$(supabase db push 2>&1)
+          EXIT_CODE=$?
+          set -e
           echo "$OUTPUT"
           echo "output<<EOF" >> $GITHUB_OUTPUT
           echo "$OUTPUT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+          exit $EXIT_CODE
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}


### PR DESCRIPTION
## Summary
- Fix Apply Migrations step to capture error output before exiting (bash -e was swallowing errors)
- This also retriggers the precision migration that failed silently on PR #37

## Test plan
- [ ] Verify migration-apply shows actual error output if it fails
- [ ] Verify the distance precision migration applies successfully on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)