### PR TITLE
fix: Drop/recreate views for distance_km precision change

### DIFF
--- a/supabase/migrations/20260301000001_increase_distance_precision.sql
+++ b/supabase/migrations/20260301000001_increase_distance_precision.sql
@@ -6,6 +6,11 @@
 -- meters, enough to make a 100-mile month appear as 99.98 miles.
 --
 -- This is a safe ALTER: widening precision never loses existing data.
+-- Views that reference distance_km must be dropped and recreated.
+
+-- Drop dependent views
+DROP VIEW IF EXISTS daily_summary;
+DROP VIEW IF EXISTS monthly_summary;
 
 -- runs table: primary distance field
 ALTER TABLE runs
@@ -14,3 +19,36 @@ ALTER TABLE runs
 -- splits table: cumulative distance field
 ALTER TABLE splits
     ALTER COLUMN cumulative_distance_km TYPE NUMERIC(10, 5);
+
+-- Recreate views
+CREATE VIEW daily_summary AS
+SELECT
+    user_id,
+    start_date,
+    COUNT(*) AS run_count,
+    SUM(distance_km) AS total_km,
+    AVG(distance_km) AS avg_km,
+    AVG(average_pace_min_per_km) AS avg_pace,
+    MIN(start_date_time_local) AS first_run,
+    MAX(start_date_time_local) AS last_run
+FROM runs
+GROUP BY user_id, start_date
+ORDER BY user_id, start_date DESC;
+
+CREATE VIEW monthly_summary AS
+SELECT
+    user_id,
+    start_year,
+    start_month,
+    TO_DATE(start_year || '-' || start_month || '-01', 'YYYY-MM-DD') AS month_start,
+    COUNT(*) AS run_count,
+    SUM(distance_km) AS total_km,
+    AVG(distance_km) AS avg_km,
+    MAX(distance_km) AS longest_run_km,
+    AVG(average_pace_min_per_km) AS avg_pace
+FROM runs
+GROUP BY user_id, start_year, start_month
+ORDER BY user_id, start_year DESC, start_month DESC;
+
+COMMENT ON VIEW daily_summary IS 'Daily statistics per user';
+COMMENT ON VIEW monthly_summary IS 'Monthly statistics per user';


### PR DESCRIPTION
## Summary
- Fix the failed migration from PR #37 — PostgreSQL can't ALTER a column type when views depend on it
- Updated migration drops `daily_summary` and `monthly_summary` views, alters the column, then recreates them

## Test plan
- [ ] Verify dry-run passes on this PR
- [ ] After merge, verify migration applies successfully
- [ ] Backfill and verify Dec 2024 >= 100 miles

🤖 Generated with [Claude Code](https://claude.com/claude-code)