### PR TITLE
fix: Add rate limiting for SmashRun detail fetches

### DIFF
--- a/src/lambdas/sync_runs/handler.py
+++ b/src/lambdas/sync_runs/handler.py
@@ -1,6 +1,7 @@
 """Lambda function handler for multi-user SmashRun sync."""
 
 import os
+import time
 from datetime import date, datetime, timedelta
 from typing import Any
 from uuid import UUID
@@ -250,6 +251,8 @@ def sync_user_source(
                 activity_id = activity_data.get("activityId")
                 if activity_id:
                     try:
+                        # Throttle to stay under SmashRun's 80 req/10s rate limit
+                        time.sleep(0.15)
                         activity_data = api_client.get_activity_by_id(str(activity_id))
                     except Exception as e:
                         logger.warning(


### PR DESCRIPTION
## Summary

- Adds 150ms throttle between SmashRun detail API calls to stay under the 80 req/10s rate limit
- Without this, backfill syncs fire detail fetches too fast, hit 429 errors, and fall back to low-precision bulk data
- Observed in the Dec 2024 backfill after PR #40 merged: first ~80 detail fetches succeeded, the rest got rate-limited

## Impact

- Daily sync (1-3 runs): ~0.5s overhead
- Monthly backfill (31 runs): ~5s overhead
- Full backfill (458 runs): ~69s (within Lambda 15-min timeout)

## Test plan

- [x] All 49 tests pass
- [x] Ruff lint and format checks pass
- [ ] After merge + Lambda deploy, re-run Dec 2024 backfill and verify all detail fetches succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)