### PR TITLE
revert: Remove unnecessary detail-fetch per activity

### DIFF
--- a/src/lambdas/sync_runs/handler.py
+++ b/src/lambdas/sync_runs/handler.py
@@ -1,7 +1,6 @@
 """Lambda function handler for multi-user SmashRun sync."""
 
 import os
-import time
 from datetime import date, datetime, timedelta
 from typing import Any
 from uuid import UUID
@@ -244,21 +243,6 @@ def sync_user_source(
         # Store in Supabase
         for activity_data in activities:
             try:
-                # Fetch full activity detail for higher-precision distance.
-                # The bulk search endpoint returns ~3 decimal places (e.g. 1.641 km)
-                # while the detail endpoint returns 5 (e.g. 1.64145 km). The ~1 m/run
-                # truncation accumulates enough to turn a 100-mile month into 99.98.
-                activity_id = activity_data.get("activityId")
-                if activity_id:
-                    try:
-                        # Throttle to stay under SmashRun's 80 req/10s rate limit
-                        time.sleep(0.15)
-                        activity_data = api_client.get_activity_by_id(str(activity_id))
-                    except Exception as e:
-                        logger.warning(
-                            f"Detail fetch failed for {activity_id}, using bulk data: {e}"
-                        )
-
                 # Parse activity
                 activity = api_client.parse_activity(activity_data)
 


### PR DESCRIPTION
## Summary

- Reverts the per-activity detail fetch added in PR #40 and rate limiting from PR #41
- Testing confirmed both endpoints return identical 5-decimal precision (e.g. `1.64145` km)
- The original truncation was caused by the `NUMERIC(10,3)` column, already fixed in PR #39

## Why

Direct API comparison showed:
```
BULK   id=40618000 distance=1.64145
DETAIL id=40618000 distance=1.64145
```

The detail fetch was adding ~150ms latency per run and hitting SmashRun's rate limit on backfills — all for zero precision benefit.

## Dec 2024 status

The actual total is **160.90218 km = 99.98 mi** (31 runs). This is the true distance from SmashRun's data. SmashRun's "ONE HUNDRED" badge likely rounds up for display.

## Test plan

- [x] All 49 tests pass
- [x] Ruff lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)