### PR TITLE
feat: Add SmashRun goals tracking (yearly/monthly)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,11 @@ terraform.tfplan
 secrets.json
 credentials.json
 
+# Database dumps (may contain prod PII)
+*.dump
+prod_*.sql
+*_dump.sql
+
 # Testing & Coverage
 .pytest_cache/
 .coverage

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install test lint format type-check bootstrap-tf init-tf plan-tf apply-tf destroy-tf
+.PHONY: help install test lint format type-check bootstrap-tf init-tf plan-tf apply-tf destroy-tf restore-prod
 
 # Default target
 help:
@@ -17,6 +17,9 @@ help:
 	@echo "  make plan-tf       - Plan Terraform changes (dev environment)"
 	@echo "  make apply-tf      - Apply Terraform changes (dev environment)"
 	@echo "  make destroy-tf    - Destroy Terraform infrastructure (dev)"
+	@echo ""
+	@echo "Database:"
+	@echo "  make restore-prod  - Restore prod Supabase data to local (destroys local data)"
 	@echo ""
 	@echo "All-in-One:"
 	@echo "  make setup         - Complete setup (install + bootstrap)"
@@ -57,6 +60,10 @@ apply-tf:
 destroy-tf:
 	@echo "WARNING: This will destroy all infrastructure in dev environment"
 	@cd terraform/environments/dev && terraform destroy
+
+# Database
+restore-prod:
+	@scripts/restore_prod_to_local.sh
 
 # Complete setup
 setup: install

--- a/scripts/restore_prod_to_local.sh
+++ b/scripts/restore_prod_to_local.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Restore production Supabase data to the local Supabase instance.
+#
+# Workflow:
+#   1. Reset local DB (applies all migrations from supabase/migrations/)
+#   2. Dump production public-schema data via pg_dump
+#   3. Load dump into local DB via psql
+#
+# Schema comes from migrations, not the dump. This keeps local schema aligned
+# with the migration history and works even when prod hasn't received a new
+# migration yet.
+#
+# Requirements:
+#   - supabase CLI (for local dev)
+#   - pg_dump, psql (PostgreSQL client tools)
+#   - PROD_DATABASE_URL from one of: shell env, .env, or .env.restore
+#
+# WARNING: Downloads production data (may contain PII) to your laptop. Treat
+# the dump file as sensitive. The script deletes it on exit but check your
+# backups/trash.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+DUMP_FILE="$(mktemp -t myrunstreak_prod_dump.XXXXXX.sql)"
+trap 'rm -f "$DUMP_FILE"' EXIT
+
+# Local Supabase default (from supabase/config.toml: [db] port = 54322)
+LOCAL_DB_URL="${LOCAL_DATABASE_URL:-postgresql://postgres:postgres@127.0.0.1:54322/postgres}"
+
+# Load PROD_DATABASE_URL from .env or .env.restore if not already set.
+# Both files are gitignored. .env is the main app env file; .env.restore is a
+# separate file if you prefer to keep DB dumps creds isolated from app config.
+# Priority: shell env > .env.restore > .env
+for env_file in .env.restore .env; do
+    if [[ -z "${PROD_DATABASE_URL:-}" && -f "$env_file" ]]; then
+        # Grep only the var we need to avoid leaking other secrets into shell
+        line=$(grep -E '^[[:space:]]*PROD_DATABASE_URL[[:space:]]*=' "$env_file" || true)
+        if [[ -n "$line" ]]; then
+            # Strip leading/trailing whitespace, leading "export ", surrounding quotes
+            value="${line#*=}"
+            value="${value%\"}"; value="${value#\"}"
+            value="${value%\'}"; value="${value#\'}"
+            export PROD_DATABASE_URL="$value"
+            echo "Loaded PROD_DATABASE_URL from $env_file"
+        fi
+    fi
+done
+
+if [[ -z "${PROD_DATABASE_URL:-}" ]]; then
+    cat >&2 <<EOF
+ERROR: PROD_DATABASE_URL not set.
+
+Get the prod connection string from Supabase dashboard:
+  Project → Settings → Database → Connection string → URI
+
+Then either export it:
+  export PROD_DATABASE_URL='postgresql://postgres.xxxxx:PASSWORD@aws-0-us-east-1.pooler.supabase.com:6543/postgres'
+
+Or add to .env (or .env.restore):
+  PROD_DATABASE_URL='postgresql://...'
+EOF
+    exit 1
+fi
+
+# Check required tools
+for cmd in supabase pg_dump psql; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "ERROR: '$cmd' not found on PATH" >&2
+        exit 1
+    fi
+done
+
+# Confirm destructive action
+echo "This will:"
+echo "  1. RESET the local Supabase DB (all local data destroyed)"
+echo "  2. Apply all migrations from supabase/migrations/"
+echo "  3. Dump public-schema data from PROD"
+echo "  4. Load prod data into local DB"
+echo ""
+echo "Local DB: $LOCAL_DB_URL"
+echo "Prod DB:  ${PROD_DATABASE_URL%%@*}@<redacted>"
+echo ""
+read -r -p "Continue? [y/N] " confirm
+if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+    echo "Aborted."
+    exit 0
+fi
+
+# Step 1: reset local DB (applies migrations)
+echo ""
+echo "==> Resetting local Supabase DB..."
+supabase db reset
+
+# Step 2: dump prod data
+echo ""
+echo "==> Dumping prod public-schema data..."
+# --data-only: schema already applied via migrations
+# --disable-triggers: avoid trigger side effects on reload
+# --schema=public: exclude auth, storage, supabase internals
+# --no-owner --no-acl: strip ownership/grants (different between envs)
+pg_dump \
+    --data-only \
+    --disable-triggers \
+    --schema=public \
+    --no-owner \
+    --no-acl \
+    --file="$DUMP_FILE" \
+    "$PROD_DATABASE_URL"
+
+DUMP_SIZE=$(wc -c < "$DUMP_FILE" | tr -d ' ')
+echo "    Dumped $DUMP_SIZE bytes"
+
+# Step 3: load into local
+echo ""
+echo "==> Loading dump into local DB..."
+psql \
+    --single-transaction \
+    --set ON_ERROR_STOP=on \
+    --quiet \
+    --dbname="$LOCAL_DB_URL" \
+    --file="$DUMP_FILE"
+
+echo ""
+echo "==> Done."
+echo ""
+echo "Row counts in local:"
+psql --dbname="$LOCAL_DB_URL" --quiet --no-align --tuples-only <<'SQL'
+SELECT 'users: ' || COUNT(*) FROM users
+UNION ALL SELECT 'user_sources: ' || COUNT(*) FROM user_sources
+UNION ALL SELECT 'runs: ' || COUNT(*) FROM runs
+UNION ALL SELECT 'splits: ' || COUNT(*) FROM splits
+UNION ALL SELECT 'goals: ' || COUNT(*) FROM goals;
+SQL

--- a/src/lambdas/publish_status/handler.py
+++ b/src/lambdas/publish_status/handler.py
@@ -13,6 +13,7 @@ from google.oauth2 import service_account
 
 from src.shared.secrets import get_secret
 from src.shared.supabase_client import get_supabase_client
+from src.shared.supabase_ops.goals_repository import GoalsRepository
 from src.shared.supabase_ops.runs_repository import RunsRepository
 from src.shared.supabase_ops.users_repository import UsersRepository
 
@@ -115,7 +116,66 @@ def upload_to_gcs(data: dict[str, Any]) -> str:
     return f"https://storage.googleapis.com/{GCS_BUCKET_NAME}/{GCS_OBJECT_PATH}"
 
 
-def build_status_data(user_id: UUID, runs_repo: RunsRepository) -> dict[str, Any]:
+def build_goals_block(
+    user_id: UUID,
+    source_id: UUID | None,
+    goals_repo: GoalsRepository,
+    today: date,
+) -> dict[str, Any]:
+    """
+    Build the goals block for status.json.
+
+    Reads yearly and current-month goals for the user from the goals table
+    (populated by the sync lambda). Distances are converted to miles for
+    consistency with the rest of the payload.
+
+    Args:
+        user_id: User UUID
+        source_id: Source UUID (None when user has no active SmashRun source)
+        goals_repo: Goals repository instance
+        today: Today's date (in user's timezone)
+
+    Returns:
+        Dict with 'yearly' and 'monthly' keys. Each is None if no goal stored
+        or no goal set on SmashRun (goal_km is null).
+    """
+    yearly: dict[str, Any] | None = None
+    monthly: dict[str, Any] | None = None
+
+    if source_id is None:
+        return {"yearly": None, "monthly": None}
+
+    def render(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if not row or row.get("goal_km") is None:
+            return None
+        goal_km = float(row["goal_km"])
+        progress_km = float(row.get("progress_km") or 0.0)
+        goal_mi = km_to_miles(goal_km)
+        progress_mi = km_to_miles(progress_km)
+        percent = (progress_km / goal_km * 100) if goal_km > 0 else None
+        return {
+            "goal_mi": round(goal_mi, 1),
+            "progress_mi": round(progress_mi, 1),
+            "percent": round(percent, 1) if percent is not None else None,
+            "text": row.get("goal_text"),
+            "fetched_at": row.get("fetched_at"),
+        }
+
+    yearly_row = goals_repo.get_by_period(user_id, source_id, today.year, None)
+    monthly_row = goals_repo.get_by_period(user_id, source_id, today.year, today.month)
+
+    yearly = render(yearly_row)
+    monthly = render(monthly_row)
+
+    return {"yearly": yearly, "monthly": monthly}
+
+
+def build_status_data(
+    user_id: UUID,
+    runs_repo: RunsRepository,
+    goals_repo: GoalsRepository,
+    source_id: UUID | None = None,
+) -> dict[str, Any]:
     """
     Build the status JSON structure.
 
@@ -125,6 +185,8 @@ def build_status_data(user_id: UUID, runs_repo: RunsRepository) -> dict[str, Any
     Args:
         user_id: User UUID
         runs_repo: Runs repository instance
+        goals_repo: Goals repository instance
+        source_id: Primary SmashRun source UUID (for goals lookup)
 
     Returns:
         Status data dictionary
@@ -199,6 +261,8 @@ def build_status_data(user_id: UUID, runs_repo: RunsRepository) -> dict[str, Any
     month_total_mi = round(km_to_miles(month_total_km), 1)
     year_total_mi = round(km_to_miles(year_total_km), 1)
 
+    goals = build_goals_block(user_id, source_id, goals_repo, today)
+
     return {
         "updated_at": datetime.now(UTC).isoformat(),
         "ran_today": ran_today,
@@ -212,6 +276,7 @@ def build_status_data(user_id: UUID, runs_repo: RunsRepository) -> dict[str, Any
         "last_7_days": last_7_days,
         "month_total_mi": month_total_mi,
         "year_total_mi": year_total_mi,
+        "goals": goals,
     }
 
 
@@ -238,9 +303,11 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         supabase = get_supabase_client()
         runs_repo = RunsRepository(supabase)
         users_repo = UsersRepository(supabase)
+        goals_repo = GoalsRepository(supabase)
 
         # Get user_id from event or use default (first active SmashRun user)
         user_id_str = event.get("user_id")
+        source_id: UUID | None = None
 
         if not user_id_str:
             # Get first active SmashRun source as default
@@ -248,12 +315,20 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             if not sources:
                 raise ValueError("No active SmashRun sources found")
             user_id = UUID(sources[0]["user_id"])
+            source_id = UUID(sources[0]["id"])
             logger.info(f"Using default user_id from first active source: {user_id}")
         else:
             user_id = UUID(user_id_str)
+            # Look up user's active SmashRun source for goals
+            user_sources = users_repo.get_user_sources(user_id, active_only=True)
+            smashrun_source = next(
+                (s for s in user_sources if s.get("source_type") == "smashrun"), None
+            )
+            if smashrun_source:
+                source_id = UUID(smashrun_source["id"])
 
         # Build status data
-        status_data = build_status_data(user_id, runs_repo)
+        status_data = build_status_data(user_id, runs_repo, goals_repo, source_id)
 
         # Upload to GCS
         public_url = upload_to_gcs(status_data)

--- a/src/lambdas/sync_runs/handler.py
+++ b/src/lambdas/sync_runs/handler.py
@@ -15,6 +15,7 @@ from src.shared.smashrun import SmashRunAPIClient, SmashRunOAuthClient
 from src.shared.smashrun.token_manager import TokenManager
 from src.shared.supabase_client import get_supabase_client
 from src.shared.supabase_ops import (
+    GoalsRepository,
     RunsRepository,
     UsersRepository,
     activity_to_run_dict,
@@ -51,6 +52,7 @@ def lambda_handler(event: dict[str, Any], context: LambdaContext) -> dict[str, A
         supabase = get_supabase_client()
         users_repo = UsersRepository(supabase)
         runs_repo = RunsRepository(supabase)
+        goals_repo = GoalsRepository(supabase)
 
         # Get all active SmashRun sources
         logger.info("Fetching all active SmashRun sources")
@@ -104,6 +106,7 @@ def lambda_handler(event: dict[str, Any], context: LambdaContext) -> dict[str, A
                     access_token_secret=access_token_secret,
                     since_date=since_date,
                     runs_repo=runs_repo,
+                    goals_repo=goals_repo,
                     settings=settings,
                 )
 
@@ -189,6 +192,7 @@ def sync_user_source(
     access_token_secret: str,
     since_date: date,
     runs_repo: RunsRepository,
+    goals_repo: GoalsRepository,
     settings: Any,
 ) -> int:
     """
@@ -200,6 +204,7 @@ def sync_user_source(
         access_token_secret: AWS Secrets Manager path for OAuth tokens
         since_date: Fetch runs on or after this date
         runs_repo: RunsRepository for storing runs
+        goals_repo: GoalsRepository for storing yearly/monthly goals
         settings: Application settings
 
     Returns:
@@ -264,5 +269,71 @@ def sync_user_source(
                 # Continue with next activity
                 continue
 
+        # Refresh yearly + monthly goals for current period if stale/missing.
+        # Keeps us from re-fetching the same goal every day.
+        try:
+            sync_current_goals(
+                user_id=user_id,
+                source_id=source_id,
+                api_client=api_client,
+                goals_repo=goals_repo,
+                settings=settings,
+            )
+        except Exception as e:
+            logger.warning(f"Goal sync failed for source {source_id}: {e}")
+            # Don't fail the whole sync if goals refresh fails
+
     logger.info(f"Successfully synced {runs_synced} runs for source {source_id}")
     return runs_synced
+
+
+def sync_current_goals(
+    user_id: UUID,
+    source_id: UUID,
+    api_client: SmashRunAPIClient,
+    goals_repo: GoalsRepository,
+    settings: Any,
+) -> None:
+    """
+    Refresh current-year and current-month goals from SmashRun if stale.
+
+    Yearly goal staleness defaults to 14 days, monthly to 3 days (configurable
+    via settings.goal_yearly_staleness_days / goal_monthly_staleness_days).
+    Missing rows are always fetched. Periods with no goal set on SmashRun are
+    recorded as "absent" so we don't hammer the API.
+
+    Args:
+        user_id: User UUID
+        source_id: Source UUID
+        api_client: Active SmashRunAPIClient (inside context manager)
+        goals_repo: GoalsRepository
+        settings: Application settings
+    """
+    today = date.today()
+    yearly_ttl = timedelta(days=settings.goal_yearly_staleness_days)
+    monthly_ttl = timedelta(days=settings.goal_monthly_staleness_days)
+
+    periods: list[tuple[int, int | None, timedelta]] = [
+        (today.year, None, yearly_ttl),
+        (today.year, today.month, monthly_ttl),
+    ]
+
+    for year, month, ttl in periods:
+        label = f"{year}" if month is None else f"{year}/{month}"
+        existing = goals_repo.get_by_period(user_id, source_id, year, month)
+
+        if not goals_repo.is_stale(existing, ttl):
+            logger.debug(f"Goal {label} is fresh, skipping fetch")
+            continue
+
+        logger.info(f"Fetching goal {label} from SmashRun")
+        goal = api_client.get_goal(year, month)
+
+        if goal is None:
+            goals_repo.mark_absent(user_id, source_id, year, month)
+            logger.info(f"No goal set on SmashRun for {label}")
+        else:
+            goals_repo.upsert(user_id, source_id, goal)
+            logger.info(
+                f"Stored goal {label}: {goal.goal_km} km goal, {goal.progress_km} km progress"
+            )

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -98,6 +98,18 @@ class Settings(BaseSettings):
         description="Logging level",
     )
 
+    # Goals Sync Cache Control
+    goal_yearly_staleness_days: int = Field(
+        default=14,
+        description="Re-fetch yearly goal if stored copy is older than this many days",
+        ge=1,
+    )
+    goal_monthly_staleness_days: int = Field(
+        default=3,
+        description="Re-fetch monthly goal if stored copy is older than this many days",
+        ge=1,
+    )
+
 
 # Singleton instance
 _settings: Settings | None = None
@@ -172,6 +184,8 @@ def get_settings() -> Settings:
             aws_region=base_settings.aws_region,
             environment=base_settings.environment,
             log_level=base_settings.log_level,
+            goal_yearly_staleness_days=base_settings.goal_yearly_staleness_days,
+            goal_monthly_staleness_days=base_settings.goal_monthly_staleness_days,
         )
     else:
         # Locally: Just load from .env file

--- a/src/shared/models/__init__.py
+++ b/src/shared/models/__init__.py
@@ -9,6 +9,7 @@ from .enums import (
     Terrain,
     WeatherType,
 )
+from .goal import Goal
 from .nested import HeartRateRecovery, Lap, Song
 from .split import Split
 from .units import (
@@ -22,6 +23,7 @@ from .units import (
 __all__ = [
     # Main models
     "Activity",
+    "Goal",
     "Split",
     # Nested models
     "Lap",

--- a/src/shared/models/goal.py
+++ b/src/shared/models/goal.py
@@ -1,0 +1,84 @@
+"""Running goal data model."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class Goal(BaseModel):
+    """
+    Represents a yearly or monthly running goal from SmashRun API.
+
+    Distance stored in kilometers (SmashRun's native unit) to stay consistent
+    with runs.distance_km. Imperial conversions are exposed as properties.
+
+    SmashRun API shape:
+        {"goalText": "...", "goalKilometers": 2500.0, "kilometers": 847.3}
+    """
+
+    year: int = Field(description="Goal year", ge=2000, le=2100)
+    month: int | None = Field(
+        default=None,
+        description="Goal month (1-12) or None for yearly goal",
+        ge=1,
+        le=12,
+    )
+
+    goal_text: str | None = Field(
+        default=None,
+        description="Human-readable goal description from SmashRun",
+        alias="goalText",
+    )
+    goal_km: float | None = Field(
+        default=None,
+        description="Target distance in kilometers",
+        alias="goalKilometers",
+        gt=0,
+    )
+    progress_km: float | None = Field(
+        default=None,
+        description="Current progress toward goal in kilometers",
+        alias="kilometers",
+        ge=0,
+    )
+
+    fetched_at: datetime | None = Field(
+        default=None,
+        description="When this goal was fetched from the API",
+    )
+
+    model_config = {"populate_by_name": True}
+
+    @field_validator("goal_km", "progress_km", mode="before")
+    @classmethod
+    def coerce_numeric(cls, v: float | int | str | None) -> float | None:
+        """Coerce numeric-like values, treating 0 as None for goal_km only via validator."""
+        if v is None or v == "":
+            return None
+        return float(v)
+
+    @property
+    def is_yearly(self) -> bool:
+        """True if this is a yearly goal (no month)."""
+        return self.month is None
+
+    @property
+    def goal_miles(self) -> float | None:
+        """Goal distance in miles."""
+        from .units import km_to_miles
+
+        return km_to_miles(self.goal_km) if self.goal_km is not None else None
+
+    @property
+    def progress_miles(self) -> float | None:
+        """Progress distance in miles."""
+        from .units import km_to_miles
+
+        return km_to_miles(self.progress_km) if self.progress_km is not None else None
+
+    @property
+    def progress_percent(self) -> float | None:
+        """Percent of goal completed (0-100+). None if goal_km missing or zero."""
+        if not self.goal_km or self.progress_km is None:
+            return None
+        return (self.progress_km / self.goal_km) * 100

--- a/src/shared/smashrun/client.py
+++ b/src/shared/smashrun/client.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 
 import httpx
 
-from ..models import Activity, Split
+from ..models import Activity, Goal, Split
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +93,7 @@ class SmashRunAPIClient:
         # not by activity date. Only use it for incremental syncs.
         if since and incremental:
             from datetime import datetime
+
             # Convert date to Unix timestamp (start of day UTC)
             since_dt = datetime.combine(since, datetime.min.time(), tzinfo=UTC)
             params["fromDate"] = int(since_dt.timestamp())
@@ -269,6 +270,42 @@ class SmashRunAPIClient:
             ValidationError: If splits data is invalid
         """
         return [Split(**split) for split in splits_data]
+
+    def get_goal(self, year: int, month: int | None = None) -> Goal | None:
+        """
+        Fetch the goal for a given year (or year+month) for the authenticated user.
+
+        SmashRun API returns null when no goal is set for the period.
+
+        Args:
+            year: Goal year (e.g., 2026)
+            month: Optional month (1-12). If None, fetches the yearly goal.
+
+        Returns:
+            Goal model with progress, or None if no goal is set for the period.
+
+        Raises:
+            ValueError: If month is out of range.
+            httpx.HTTPStatusError: If API request fails.
+        """
+        if month is not None and not (1 <= month <= 12):
+            raise ValueError("month must be between 1 and 12")
+
+        path = f"/my/goals/{year}" if month is None else f"/my/goals/{year}/{month}"
+        logger.info(f"Fetching goal for {year}" + (f"/{month}" if month else ""))
+
+        response = self.client.get(path)
+        response.raise_for_status()
+
+        data = response.json()
+        if data is None:
+            logger.info(f"No goal set for {year}" + (f"/{month}" if month else ""))
+            return None
+
+        goal_data = cast(dict[str, Any], data)
+        # Merge period into payload so Goal can be constructed directly from API response.
+        goal_data = {**goal_data, "year": year, "month": month}
+        return Goal.model_validate(goal_data)
 
     def get_user_info(self) -> dict[str, Any]:
         """

--- a/src/shared/supabase_ops/__init__.py
+++ b/src/shared/supabase_ops/__init__.py
@@ -1,11 +1,13 @@
 """Supabase database operations for MyRunStreak.com."""
 
+from .goals_repository import GoalsRepository
 from .mappers import activity_to_run_dict, split_to_dict
 from .runs_repository import RunsRepository
 from .token_repository import TokenRepository
 from .users_repository import UsersRepository
 
 __all__ = [
+    "GoalsRepository",
     "RunsRepository",
     "TokenRepository",
     "UsersRepository",

--- a/src/shared/supabase_ops/goals_repository.py
+++ b/src/shared/supabase_ops/goals_repository.py
@@ -1,0 +1,161 @@
+"""Repository for running goals in Supabase."""
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any, cast
+from uuid import UUID
+
+from supabase import Client
+
+from ..models import Goal
+
+logger = logging.getLogger(__name__)
+
+
+class GoalsRepository:
+    """
+    Repository for yearly/monthly running goal data.
+
+    Handles caching logic: yearly and monthly goals have different staleness
+    thresholds to avoid re-fetching the same goal every sync.
+    """
+
+    def __init__(self, supabase: Client):
+        """
+        Initialize repository with Supabase client.
+
+        Args:
+            supabase: Authenticated Supabase client
+        """
+        self.supabase = supabase
+
+    def get_by_period(
+        self,
+        user_id: UUID,
+        source_id: UUID,
+        year: int,
+        month: int | None = None,
+    ) -> dict[str, Any] | None:
+        """
+        Get the stored goal row for a specific period.
+
+        Args:
+            user_id: User UUID
+            source_id: Source UUID
+            year: Goal year
+            month: Goal month (1-12) or None for yearly goal
+
+        Returns:
+            Goal row dict, or None if not stored
+        """
+        query = (
+            self.supabase.table("goals")
+            .select("*")
+            .eq("user_id", str(user_id))
+            .eq("source_id", str(source_id))
+            .eq("year", year)
+        )
+        query = query.is_("month", "null") if month is None else query.eq("month", month)
+
+        result = query.execute()
+        data_list = cast(list[dict[str, Any]], result.data)
+        return data_list[0] if data_list else None
+
+    def is_stale(
+        self,
+        row: dict[str, Any] | None,
+        max_age: timedelta,
+        now: datetime | None = None,
+    ) -> bool:
+        """
+        Check whether a stored goal row needs refreshing.
+
+        A missing row is considered stale (needs fetch). A row older than
+        max_age is also stale.
+
+        Args:
+            row: Stored goal row (or None if absent)
+            max_age: Staleness threshold
+            now: Current time for testing (defaults to datetime.now with tz)
+
+        Returns:
+            True if the row should be refreshed
+        """
+        if row is None:
+            return True
+
+        fetched_at_raw = row.get("fetched_at")
+        if not fetched_at_raw:
+            return True
+
+        fetched_at = datetime.fromisoformat(str(fetched_at_raw).replace("Z", "+00:00"))
+        current = now or datetime.now(fetched_at.tzinfo)
+        return (current - fetched_at) > max_age
+
+    def upsert(
+        self,
+        user_id: UUID,
+        source_id: UUID,
+        goal: Goal,
+    ) -> dict[str, Any]:
+        """
+        Insert or update a goal row.
+
+        Uniqueness is enforced by partial unique indexes on
+        (user_id, source_id, year) WHERE month IS NULL
+        and (user_id, source_id, year, month) WHERE month IS NOT NULL.
+
+        Args:
+            user_id: User UUID
+            source_id: Source UUID
+            goal: Goal model with data fetched from source API
+
+        Returns:
+            Inserted/updated goal row
+        """
+        existing = self.get_by_period(user_id, source_id, goal.year, goal.month)
+        now_iso = datetime.now(tz=goal.fetched_at.tzinfo if goal.fetched_at else None).isoformat()
+
+        payload: dict[str, Any] = {
+            "user_id": str(user_id),
+            "source_id": str(source_id),
+            "year": goal.year,
+            "month": goal.month,
+            "goal_text": goal.goal_text,
+            "goal_km": goal.goal_km,
+            "progress_km": goal.progress_km,
+            "fetched_at": now_iso,
+        }
+
+        if existing:
+            result = self.supabase.table("goals").update(payload).eq("id", existing["id"]).execute()
+        else:
+            result = self.supabase.table("goals").insert(payload).execute()
+
+        data_list = cast(list[dict[str, Any]], result.data)
+        logger.debug(f"Upserted goal for user {user_id} year={goal.year} month={goal.month}")
+        return data_list[0]
+
+    def mark_absent(
+        self,
+        user_id: UUID,
+        source_id: UUID,
+        year: int,
+        month: int | None,
+    ) -> dict[str, Any]:
+        """
+        Record that no goal is set for a period (API returned null).
+
+        Stores a row with null goal_km so we don't re-fetch immediately.
+
+        Args:
+            user_id: User UUID
+            source_id: Source UUID
+            year: Goal year
+            month: Goal month (or None for yearly)
+
+        Returns:
+            Inserted/updated row
+        """
+        placeholder = Goal(year=year, month=month)
+        return self.upsert(user_id, source_id, placeholder)

--- a/supabase/migrations/20260423124130_create_goals_table.sql
+++ b/supabase/migrations/20260423124130_create_goals_table.sql
@@ -1,0 +1,73 @@
+-- =====================================================
+-- Goals - SmashRun yearly/monthly running goals
+-- =====================================================
+-- Stores yearly and monthly distance goals fetched from SmashRun.
+-- Fetches are cached with a per-period staleness threshold to avoid
+-- re-fetching the same goal every sync.
+--
+-- month IS NULL      -> yearly goal for (user, source, year)
+-- month BETWEEN 1,12 -> monthly goal for (user, source, year, month)
+-- =====================================================
+
+CREATE TABLE goals (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Foreign Keys
+    user_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    source_id UUID NOT NULL REFERENCES user_sources(id) ON DELETE CASCADE,
+
+    -- Period
+    year INTEGER NOT NULL CHECK (year >= 2000 AND year <= 2100),
+    month INTEGER CHECK (month BETWEEN 1 AND 12),
+
+    -- Goal data from SmashRun (distance stored in km for consistency with runs.distance_km)
+    goal_text TEXT,
+    goal_km NUMERIC(10, 3) CHECK (goal_km IS NULL OR goal_km > 0),
+    progress_km NUMERIC(10, 3) CHECK (progress_km IS NULL OR progress_km >= 0),
+
+    -- Cache control
+    fetched_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Audit
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Unique constraints: one yearly row and one monthly row per (user, source, year[, month]).
+-- Partial indexes are required because (user_id, source_id, year, month) with NULL month
+-- would not enforce uniqueness on yearly rows (NULLs are not equal in PostgreSQL).
+CREATE UNIQUE INDEX idx_goals_yearly_unique
+    ON goals (user_id, source_id, year)
+    WHERE month IS NULL;
+
+CREATE UNIQUE INDEX idx_goals_monthly_unique
+    ON goals (user_id, source_id, year, month)
+    WHERE month IS NOT NULL;
+
+-- Lookup index for common queries
+CREATE INDEX idx_goals_user_period ON goals (user_id, year, month);
+
+COMMENT ON TABLE goals IS 'Yearly and monthly running goals fetched from source APIs';
+COMMENT ON COLUMN goals.month IS 'NULL = yearly goal, 1-12 = monthly goal';
+COMMENT ON COLUMN goals.goal_km IS 'Target distance in kilometers (SmashRun native unit)';
+COMMENT ON COLUMN goals.progress_km IS 'Progress toward goal in kilometers (snapshot at fetch time)';
+COMMENT ON COLUMN goals.fetched_at IS 'Last time this goal was refreshed from the source API';
+
+-- Enable Row Level Security
+ALTER TABLE goals ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own goals"
+    ON goals FOR SELECT
+    USING (user_id = auth.uid() OR auth.uid() IS NULL);
+
+CREATE POLICY "Users can insert their own goals"
+    ON goals FOR INSERT
+    WITH CHECK (user_id = auth.uid() OR auth.uid() IS NULL);
+
+CREATE POLICY "Users can update their own goals"
+    ON goals FOR UPDATE
+    USING (user_id = auth.uid() OR auth.uid() IS NULL);
+
+-- Auto-update updated_at
+CREATE TRIGGER update_goals_updated_at BEFORE UPDATE ON goals
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/tests/test_goals_client.py
+++ b/tests/test_goals_client.py
@@ -1,0 +1,113 @@
+"""Tests for SmashRun goals endpoint in the API client."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.shared.models import Goal
+from src.shared.smashrun import SmashRunAPIClient
+
+
+@pytest.fixture
+def api_client() -> SmashRunAPIClient:
+    """Create API client for testing."""
+    return SmashRunAPIClient(access_token="test_access_token")
+
+
+@pytest.fixture
+def sample_goal_response() -> dict[str, object]:
+    """Sample /my/goals/{year} response from SmashRun."""
+    return {
+        "goalText": "Run 2500 km in 2026",
+        "goalKilometers": 2500.0,
+        "kilometers": 847.3,
+    }
+
+
+def test_get_goal_yearly(api_client: SmashRunAPIClient, sample_goal_response: dict) -> None:
+    """Yearly goal request hits /my/goals/{year} and returns a Goal."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = sample_goal_response
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.get.return_value = mock_response
+    api_client._client = mock_client
+
+    goal = api_client.get_goal(2026)
+
+    assert isinstance(goal, Goal)
+    assert goal.year == 2026
+    assert goal.month is None
+    assert goal.is_yearly is True
+    assert goal.goal_km == 2500.0
+    assert goal.progress_km == 847.3
+    assert goal.goal_text == "Run 2500 km in 2026"
+    mock_client.get.assert_called_once_with("/my/goals/2026")
+
+
+def test_get_goal_monthly(api_client: SmashRunAPIClient, sample_goal_response: dict) -> None:
+    """Monthly goal request hits /my/goals/{year}/{month}."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = sample_goal_response
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.get.return_value = mock_response
+    api_client._client = mock_client
+
+    goal = api_client.get_goal(2026, 4)
+
+    assert goal is not None
+    assert goal.year == 2026
+    assert goal.month == 4
+    assert goal.is_yearly is False
+    mock_client.get.assert_called_once_with("/my/goals/2026/4")
+
+
+def test_get_goal_returns_none_when_no_goal_set(api_client: SmashRunAPIClient) -> None:
+    """SmashRun returns JSON null when no goal is set; client returns None."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = None
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.get.return_value = mock_response
+    api_client._client = mock_client
+
+    goal = api_client.get_goal(2026, 12)
+
+    assert goal is None
+
+
+def test_get_goal_invalid_month(api_client: SmashRunAPIClient) -> None:
+    """Month out of range raises ValueError before any HTTP call."""
+    mock_client = MagicMock()
+    api_client._client = mock_client
+
+    with pytest.raises(ValueError, match="month must be between 1 and 12"):
+        api_client.get_goal(2026, 13)
+
+    mock_client.get.assert_not_called()
+
+
+def test_goal_mile_conversion() -> None:
+    """Goal model exposes miles via property, storing km."""
+    goal = Goal(year=2026, goal_km=1609.344, progress_km=804.672)
+
+    assert goal.goal_miles == pytest.approx(1000.0, rel=1e-3)
+    assert goal.progress_miles == pytest.approx(500.0, rel=1e-3)
+    assert goal.progress_percent == pytest.approx(50.0, rel=1e-3)
+
+
+def test_goal_progress_percent_without_goal() -> None:
+    """progress_percent is None when goal_km is missing."""
+    goal = Goal(year=2026, progress_km=100.0)
+    assert goal.progress_percent is None
+
+
+def test_goal_miles_none_when_km_none() -> None:
+    """Miles properties return None when km value is None."""
+    goal = Goal(year=2026)
+    assert goal.goal_miles is None
+    assert goal.progress_miles is None

--- a/tests/test_goals_repository.py
+++ b/tests/test_goals_repository.py
@@ -1,0 +1,67 @@
+"""Tests for GoalsRepository staleness logic."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.shared.models import Goal
+from src.shared.supabase_ops import GoalsRepository
+
+
+@pytest.fixture
+def repo() -> GoalsRepository:
+    """GoalsRepository with a MagicMock Supabase client."""
+    return GoalsRepository(MagicMock())
+
+
+def test_is_stale_missing_row(repo: GoalsRepository) -> None:
+    """Missing row is always stale."""
+    assert repo.is_stale(None, timedelta(days=14)) is True
+
+
+def test_is_stale_no_fetched_at(repo: GoalsRepository) -> None:
+    """Row without fetched_at is treated as stale."""
+    assert repo.is_stale({"id": "x"}, timedelta(days=14)) is True
+
+
+def test_is_stale_recent_row_is_fresh(repo: GoalsRepository) -> None:
+    """Row fetched within TTL is fresh."""
+    now = datetime(2026, 4, 23, 12, 0, tzinfo=UTC)
+    row = {"fetched_at": (now - timedelta(days=1)).isoformat()}
+
+    assert repo.is_stale(row, timedelta(days=3), now=now) is False
+
+
+def test_is_stale_old_row_is_stale(repo: GoalsRepository) -> None:
+    """Row older than TTL is stale."""
+    now = datetime(2026, 4, 23, 12, 0, tzinfo=UTC)
+    row = {"fetched_at": (now - timedelta(days=5)).isoformat()}
+
+    assert repo.is_stale(row, timedelta(days=3), now=now) is True
+
+
+def test_is_stale_boundary_exact_ttl(repo: GoalsRepository) -> None:
+    """Row exactly at TTL is not yet stale (strict >)."""
+    now = datetime(2026, 4, 23, 12, 0, tzinfo=UTC)
+    row = {"fetched_at": (now - timedelta(days=3)).isoformat()}
+
+    assert repo.is_stale(row, timedelta(days=3), now=now) is False
+
+
+def test_is_stale_handles_z_suffix(repo: GoalsRepository) -> None:
+    """Supabase sometimes returns timestamps with a Z suffix; parser handles it."""
+    now = datetime(2026, 4, 23, 12, 0, tzinfo=UTC)
+    row = {"fetched_at": "2026-04-20T12:00:00Z"}
+
+    # 3-day-old row, TTL 3d → not stale (exactly at boundary)
+    assert repo.is_stale(row, timedelta(days=3), now=now) is False
+
+
+def test_yearly_vs_monthly_differ() -> None:
+    """Yearly goal has month=None, monthly has 1-12."""
+    yearly = Goal(year=2026)
+    monthly = Goal(year=2026, month=4)
+
+    assert yearly.is_yearly is True
+    assert monthly.is_yearly is False

--- a/tests/test_publish_status_goals.py
+++ b/tests/test_publish_status_goals.py
@@ -1,0 +1,132 @@
+"""Tests for goals block in publish_status status.json payload."""
+
+from datetime import date
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.lambdas.publish_status.handler import build_goals_block
+from src.shared.supabase_ops import GoalsRepository
+
+
+@pytest.fixture
+def goals_repo() -> GoalsRepository:
+    """GoalsRepository with a MagicMock Supabase client."""
+    return GoalsRepository(MagicMock())
+
+
+def _goal_row(goal_km: float | None, progress_km: float | None, text: str = "Test") -> dict:
+    return {
+        "goal_km": goal_km,
+        "progress_km": progress_km,
+        "goal_text": text,
+        "fetched_at": "2026-04-23T12:00:00+00:00",
+    }
+
+
+def test_goals_block_with_both_goals(goals_repo: GoalsRepository) -> None:
+    """Yearly and monthly goals both render correctly in miles."""
+    user_id = uuid4()
+    source_id = uuid4()
+    today = date(2026, 4, 23)
+
+    # Mock get_by_period: first call yearly, second monthly
+    goals_repo.get_by_period = MagicMock(  # type: ignore[method-assign]
+        side_effect=[
+            _goal_row(2500.0, 847.3, "Run 2500 km in 2026"),
+            _goal_row(200.0, 89.3, "Run 200 km in April"),
+        ]
+    )
+
+    block = build_goals_block(user_id, source_id, goals_repo, today)
+
+    assert block["yearly"] is not None
+    assert block["yearly"]["goal_mi"] == pytest.approx(1553.4, abs=0.1)
+    assert block["yearly"]["progress_mi"] == pytest.approx(526.5, abs=0.1)
+    assert block["yearly"]["percent"] == pytest.approx(33.9, abs=0.1)
+    assert block["yearly"]["text"] == "Run 2500 km in 2026"
+
+    assert block["monthly"] is not None
+    assert block["monthly"]["goal_mi"] == pytest.approx(124.3, abs=0.1)
+    assert block["monthly"]["percent"] == pytest.approx(44.65, abs=0.1)
+
+
+def test_goals_block_missing_rows(goals_repo: GoalsRepository) -> None:
+    """No rows stored → both yearly and monthly are None."""
+    user_id = uuid4()
+    source_id = uuid4()
+    today = date(2026, 4, 23)
+
+    goals_repo.get_by_period = MagicMock(return_value=None)  # type: ignore[method-assign]
+
+    block = build_goals_block(user_id, source_id, goals_repo, today)
+
+    assert block == {"yearly": None, "monthly": None}
+
+
+def test_goals_block_null_goal_km(goals_repo: GoalsRepository) -> None:
+    """Placeholder row with goal_km=None (no goal on SmashRun) renders as None."""
+    user_id = uuid4()
+    source_id = uuid4()
+    today = date(2026, 4, 23)
+
+    goals_repo.get_by_period = MagicMock(  # type: ignore[method-assign]
+        side_effect=[
+            _goal_row(None, None),
+            _goal_row(200.0, 50.0, "Monthly"),
+        ]
+    )
+
+    block = build_goals_block(user_id, source_id, goals_repo, today)
+
+    assert block["yearly"] is None
+    assert block["monthly"] is not None
+    assert block["monthly"]["goal_mi"] == pytest.approx(124.3, abs=0.1)
+
+
+def test_goals_block_no_source(goals_repo: GoalsRepository) -> None:
+    """No source_id → empty block without hitting the repo."""
+    user_id = uuid4()
+    today = date(2026, 4, 23)
+
+    goals_repo.get_by_period = MagicMock()  # type: ignore[method-assign]
+
+    block = build_goals_block(user_id, None, goals_repo, today)
+
+    assert block == {"yearly": None, "monthly": None}
+    goals_repo.get_by_period.assert_not_called()
+
+
+def test_goals_block_zero_progress(goals_repo: GoalsRepository) -> None:
+    """Zero progress yields percent=0, not error."""
+    user_id = uuid4()
+    source_id = uuid4()
+    today = date(2026, 4, 23)
+
+    goals_repo.get_by_period = MagicMock(  # type: ignore[method-assign]
+        side_effect=[_goal_row(2500.0, 0.0), _goal_row(200.0, 0.0)]
+    )
+
+    block = build_goals_block(user_id, source_id, goals_repo, today)
+
+    assert block["yearly"]["percent"] == 0.0
+    assert block["monthly"]["percent"] == 0.0
+
+
+def test_goals_block_queries_correct_period(goals_repo: GoalsRepository) -> None:
+    """Verifies yearly is queried with month=None and monthly with today.month."""
+    user_id = uuid4()
+    source_id = uuid4()
+    today = date(2026, 7, 15)
+
+    mock_get = MagicMock(return_value=None)
+    goals_repo.get_by_period = mock_get  # type: ignore[method-assign]
+
+    build_goals_block(user_id, source_id, goals_repo, today)
+
+    assert mock_get.call_count == 2
+    # First call: yearly (month=None)
+    assert mock_get.call_args_list[0].args == (user_id, source_id, 2026, None)
+    # Second call: monthly (month=7)
+    assert mock_get.call_args_list[1].args == (user_id, source_id, 2026, 7)


### PR DESCRIPTION
## Summary
- Fetches yearly + monthly SmashRun goals via new `SmashRunAPIClient.get_goal()` and persists them in a new `goals` table
- Sync Lambda refreshes goals per user with configurable staleness windows (default 14d yearly, 3d monthly) to avoid redundant API calls
- Publish-status Lambda now emits a `goals` block in `status.json` for downstream display
- Adds `scripts/restore_prod_to_local.sh` + `make restore-prod` for local dev; gitignores DB dumps

## Changes
- **Model**: `src/shared/models/goal.py` — `Goal` Pydantic model
- **Client**: `src/shared/smashrun/client.py` — `get_goal(year, month=None)`
- **Repo**: `src/shared/supabase_ops/goals_repository.py` — upsert + staleness reads
- **Migration**: `supabase/migrations/20260423124130_create_goals_table.sql` — unique `(user_id, source_id, year, month)`
- **Config**: `goal_yearly_staleness_days` + `goal_monthly_staleness_days` env-configurable
- **Lambdas**: sync_runs refreshes stale goals; publish_status emits goals block
- **Dev**: prod → local restore script, DB dump gitignore

## Test plan
- [ ] `uv run pytest tests/test_goals_client.py tests/test_goals_repository.py tests/test_publish_status_goals.py`
- [ ] `uv run ruff check . && uv run mypy src/`
- [ ] Apply migration locally, verify `goals` table + unique constraint
- [ ] Run sync Lambda locally, confirm goals upserted for active SmashRun users
- [ ] Run publish_status Lambda, verify `goals` block present in status.json
- [ ] Re-run sync within staleness window, confirm no duplicate API fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)