### PR TITLE
ci: skip smoke test for authorizer Lambda

### DIFF
--- a/.github/workflows/lambda-deploy.yml
+++ b/.github/workflows/lambda-deploy.yml
@@ -204,8 +204,12 @@ jobs:
       # ========================================================================
       # Step 8: Run Smoke Test
       # ========================================================================
+      # The authorizer Lambda is invoked by API Gateway with a TOKEN-shaped
+      # event. A direct lambda:Invoke with a generic payload always raises
+      # "Unauthorized" by design — that's not a deploy failure, so skip it.
       - name: Smoke Test
         id: test
+        if: matrix.lambda.handler_module != 'authorizer'
         run: |
           RESULT=$(aws lambda invoke \
             --function-name ${{ matrix.lambda.function_name }} \


### PR DESCRIPTION
## Summary
- Authorizer Lambda's smoke test in PR #48 deploy failed because the dummy `lambda:Invoke` payload doesn't match the TOKEN authorizer event shape (it expects `authorizationToken` + `methodArn`)
- The Lambda correctly raises `Unauthorized`, which is the intended response for an empty/invalid token — but the workflow treats `FunctionError` as a failure and `fail-fast` then cancels Query and Publish Status Lambda deploys (which had actually succeeded individually)
- Fix: skip the smoke-test step when `handler_module == 'authorizer'`. The authorizer is verified via real API Gateway calls, not direct invocation

## Test plan
- [ ] Workflow runs on this PR's merge to main
- [ ] All four Lambda deploy jobs complete successfully (Sync, Query, Publish Status, Authorizer)
- [ ] Authorizer Smoke Test step shows as skipped, not failed
- [ ] No fail-fast cancellation of sibling jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)