### PR TITLE
feat: dashboard + runs foundation (Phase 1)

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -1,0 +1,39 @@
+name: Frontend Tests
+
+on:
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-test.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-test.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+
+      - name: Type check
+        run: npm run type-check
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
     "preview": "vite preview",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
     "format": "prettier --write src/",
-    "type-check": "vue-tsc --noEmit"
+    "type-check": "vue-tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "vue": "^3.4.15",

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -17,6 +17,7 @@
           >
             {{ link.name }}
           </RouterLink>
+          <SyncButton v-if="auth.isAuthenticated" mode="compact" />
           <button @click="handleSignOut" class="btn-secondary text-sm">
             Sign out
           </button>
@@ -64,6 +65,7 @@
 import { ref } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
+import SyncButton from '@/components/SyncButton.vue'
 
 const auth = useAuthStore()
 const router = useRouter()
@@ -72,6 +74,7 @@ const mobileMenuOpen = ref(false)
 const navLinks = [
   { name: 'Dashboard', path: '/dashboard' },
   { name: 'Runs', path: '/runs' },
+  { name: 'Settings', path: '/settings' },
 ]
 
 const handleSignOut = async () => {

--- a/frontend/src/components/EmptyState.vue
+++ b/frontend/src/components/EmptyState.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="bg-white rounded-xl border border-gray-100 shadow-sm p-10 text-center">
+    <div class="text-5xl mb-4">🏃</div>
+    <h2 class="text-xl font-bold text-gray-900 mb-2">Connect SmashRun to import your runs</h2>
+    <p class="text-gray-500 max-w-md mx-auto mb-6">
+      MyRunStreak pulls your activity from SmashRun. Authorize SmashRun once and we'll
+      keep your runs and streak in sync.
+    </p>
+    <SyncButton mode="full" @synced="$emit('synced')" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import SyncButton from './SyncButton.vue'
+
+defineEmits<{ synced: [] }>()
+</script>

--- a/frontend/src/components/RunRow.vue
+++ b/frontend/src/components/RunRow.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="flex items-center justify-between py-3 px-4 hover:bg-gray-50 transition">
+    <div class="flex flex-col">
+      <span class="text-sm font-semibold text-gray-900">{{ formatDate(date) }}</span>
+      <span v-if="weather" class="text-xs text-gray-400 mt-0.5">{{ weather }}</span>
+    </div>
+    <div class="flex items-center gap-6 text-sm text-gray-700 tabular-nums">
+      <span class="font-medium">{{ formatDistanceWithUnit(distanceKm, unit) }}</span>
+      <span>{{ duration }}</span>
+      <span class="hidden sm:inline text-gray-500">{{ formatPace(paceMinPerKm, unit) }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { formatDate, formatDistanceWithUnit, formatPace, formatDuration } from '@/utils/format'
+import type { Unit } from '@/types/runs'
+
+const props = defineProps<{
+  date: string
+  distanceKm: number
+  durationSeconds?: number
+  durationMinutes?: number
+  paceMinPerKm: number | null
+  unit: Unit
+  weather?: string | null
+}>()
+
+const duration = computed(() => {
+  if (props.durationSeconds !== undefined) return formatDuration(props.durationSeconds)
+  if (props.durationMinutes !== undefined) return formatDuration(props.durationMinutes * 60)
+  return '–'
+})
+</script>

--- a/frontend/src/components/StatCard.vue
+++ b/frontend/src/components/StatCard.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="bg-white rounded-xl border border-gray-100 shadow-sm p-5 transition hover:shadow-md">
+    <p class="text-xs font-semibold text-gray-400 uppercase tracking-wide">
+      {{ label }}
+    </p>
+    <p class="mt-2 text-3xl font-bold" :class="valueClass">
+      {{ value }}
+    </p>
+    <p v-if="sublabel" class="text-sm text-gray-500 mt-1">{{ sublabel }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  label: string
+  value: string | number
+  sublabel?: string
+  valueClass?: string
+}>()
+</script>

--- a/frontend/src/components/SyncButton.vue
+++ b/frontend/src/components/SyncButton.vue
@@ -1,0 +1,84 @@
+<template>
+  <button
+    v-if="mode === 'compact'"
+    @click="handleSync"
+    :disabled="syncing"
+    :title="tooltip"
+    class="text-gray-500 hover:text-brand-600 disabled:text-gray-300 disabled:cursor-not-allowed transition p-2"
+    aria-label="Sync runs"
+  >
+    <svg
+      class="w-5 h-5"
+      :class="{ 'animate-spin': syncing }"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+      />
+    </svg>
+  </button>
+
+  <div v-else class="flex items-center gap-3">
+    <button
+      @click="handleSync"
+      :disabled="syncing"
+      class="btn-primary inline-flex items-center gap-2"
+    >
+      <svg
+        class="w-4 h-4"
+        :class="{ 'animate-spin': syncing }"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+        />
+      </svg>
+      {{ syncing ? 'Syncing…' : 'Sync now' }}
+    </button>
+    <span class="text-xs text-gray-500">
+      Last synced: {{ formatRelativeTime(lastSyncedAt) }}
+    </span>
+    <span v-if="error" class="text-xs text-red-600">{{ error }}</span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useSync } from '@/composables/useSync'
+import { formatRelativeTime } from '@/utils/format'
+
+const props = withDefaults(
+  defineProps<{
+    mode?: 'full' | 'compact'
+  }>(),
+  { mode: 'full' },
+)
+
+const emit = defineEmits<{
+  synced: []
+}>()
+
+const { sync, syncing, error, lastSyncedAt } = useSync()
+
+const tooltip = computed(() =>
+  syncing.value ? 'Syncing…' : `Sync runs (last: ${formatRelativeTime(lastSyncedAt.value)})`,
+)
+
+const handleSync = async () => {
+  const result = await sync()
+  if (result) emit('synced')
+}
+
+// Surface mode for IDE clarity (silences unused warning even though template uses it)
+void props.mode
+</script>

--- a/frontend/src/components/__tests__/RunRow.test.ts
+++ b/frontend/src/components/__tests__/RunRow.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import RunRow from '../RunRow.vue'
+
+const baseProps = {
+  date: '2026-05-01T08:00:00',
+  distanceKm: 10,
+  durationSeconds: 3000,
+  paceMinPerKm: 5.0,
+}
+
+describe('RunRow', () => {
+  it('formats distance in km when unit=km', () => {
+    const w = mount(RunRow, { props: { ...baseProps, unit: 'km' } })
+    expect(w.text()).toContain('10.00 km')
+  })
+
+  it('converts distance to miles when unit=mi', () => {
+    // 10 km = 6.21 mi
+    const w = mount(RunRow, { props: { ...baseProps, unit: 'mi' } })
+    expect(w.text()).toContain('6.21 mi')
+  })
+
+  it('renders the formatted date', () => {
+    const w = mount(RunRow, { props: { ...baseProps, unit: 'km' } })
+    // 2026-05-01 is a Friday
+    expect(w.text()).toContain('Fri May 1')
+  })
+
+  it('renders duration as mm:ss', () => {
+    const w = mount(RunRow, { props: { ...baseProps, unit: 'km' } })
+    // 3000 seconds = 50:00
+    expect(w.text()).toContain('50:00')
+  })
+
+  it('falls back to durationMinutes when seconds not provided', () => {
+    const w = mount(RunRow, {
+      props: {
+        date: baseProps.date,
+        distanceKm: baseProps.distanceKm,
+        paceMinPerKm: baseProps.paceMinPerKm,
+        durationMinutes: 50,
+        unit: 'km',
+      },
+    })
+    expect(w.text()).toContain('50:00')
+  })
+
+  it('shows weather text when provided', () => {
+    const w = mount(RunRow, {
+      props: { ...baseProps, unit: 'km', weather: 'Sunny' },
+    })
+    expect(w.text()).toContain('Sunny')
+  })
+})

--- a/frontend/src/components/__tests__/StatCard.test.ts
+++ b/frontend/src/components/__tests__/StatCard.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import StatCard from '../StatCard.vue'
+
+describe('StatCard', () => {
+  it('renders label and value', () => {
+    const w = mount(StatCard, { props: { label: 'Total Runs', value: 234 } })
+    expect(w.text()).toContain('Total Runs')
+    expect(w.text()).toContain('234')
+  })
+
+  it('renders sublabel when provided', () => {
+    const w = mount(StatCard, {
+      props: { label: 'Distance', value: '12.5 mi', sublabel: 'this week' },
+    })
+    expect(w.text()).toContain('this week')
+  })
+
+  it('omits sublabel when absent', () => {
+    const w = mount(StatCard, { props: { label: 'X', value: 1 } })
+    const subs = w.findAll('p').filter((p) => p.classes().includes('text-gray-500'))
+    expect(subs.length).toBe(0)
+  })
+
+  it('applies custom valueClass', () => {
+    const w = mount(StatCard, {
+      props: { label: 'X', value: 1, valueClass: 'text-brand-600' },
+    })
+    const valueEl = w.findAll('p').find((p) => p.text() === '1')
+    expect(valueEl?.classes()).toContain('text-brand-600')
+  })
+})

--- a/frontend/src/composables/__tests__/useSync.test.ts
+++ b/frontend/src/composables/__tests__/useSync.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('@/config/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn().mockResolvedValue({ data: { session: { access_token: 'test-token' } } }),
+    },
+  },
+}))
+
+const fetchMock = vi.fn()
+
+describe('useSync', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock)
+    fetchMock.mockReset()
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('starts not syncing with no error', async () => {
+    const { useSync } = await import('../useSync')
+    const { syncing, error } = useSync()
+    expect(syncing.value).toBe(false)
+    expect(error.value).toBeNull()
+  })
+
+  it('flips syncing during request and stores lastSyncedAt on success', async () => {
+    const responseBody = { message: 'ok', runs_synced: 3, since: '2026-05-01', until: '2026-05-03' }
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      json: async () => responseBody,
+    })
+
+    const { useSync } = await import('../useSync')
+    const { sync, syncing, lastSyncedAt } = useSync()
+
+    expect(lastSyncedAt.value).toBeNull()
+    const result = await sync()
+
+    expect(result).toEqual(responseBody)
+    expect(syncing.value).toBe(false)
+    expect(lastSyncedAt.value).not.toBeNull()
+    expect(window.localStorage.getItem('mrs.lastSyncAt')).toBe(lastSyncedAt.value)
+  })
+
+  it('captures error on failure and leaves lastSyncedAt unchanged', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      headers: new Headers(),
+      json: async () => ({ message: 'boom' }),
+    })
+
+    const { useSync } = await import('../useSync')
+    const { sync, error, lastSyncedAt } = useSync()
+
+    const result = await sync()
+
+    expect(result).toBeNull()
+    expect(error.value).toBe('boom')
+    expect(lastSyncedAt.value).toBeNull()
+  })
+})

--- a/frontend/src/composables/__tests__/useUserPreferences.test.ts
+++ b/frontend/src/composables/__tests__/useUserPreferences.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getUserMock = vi.fn()
+const updateUserMock = vi.fn().mockResolvedValue({ data: {}, error: null })
+
+vi.mock('@/config/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: getUserMock,
+      updateUser: updateUserMock,
+    },
+  },
+}))
+
+describe('useUserPreferences', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    getUserMock.mockReset()
+    updateUserMock.mockClear()
+    vi.resetModules()
+  })
+
+  it('defaults to mi when nothing is stored', async () => {
+    getUserMock.mockResolvedValue({ data: { user: { user_metadata: {} } } })
+    const { useUserPreferences } = await import('../useUserPreferences')
+    const { unit } = useUserPreferences()
+    expect(unit.value).toBe('mi')
+  })
+
+  it('reads unit from localStorage on initial load', async () => {
+    window.localStorage.setItem('mrs.unit', 'km')
+    getUserMock.mockResolvedValue({ data: { user: { user_metadata: {} } } })
+    const { useUserPreferences } = await import('../useUserPreferences')
+    const { unit } = useUserPreferences()
+    expect(unit.value).toBe('km')
+  })
+
+  it('overrides local with Supabase user_metadata when present', async () => {
+    window.localStorage.setItem('mrs.unit', 'mi')
+    getUserMock.mockResolvedValue({
+      data: { user: { user_metadata: { unit: 'km' } } },
+    })
+    const { useUserPreferences } = await import('../useUserPreferences')
+    const { unit, loaded } = useUserPreferences()
+    await vi.waitFor(() => expect(loaded.value).toBe(true))
+    expect(unit.value).toBe('km')
+    expect(window.localStorage.getItem('mrs.unit')).toBe('km')
+  })
+
+  it('persists changes to localStorage and Supabase via setUnit', async () => {
+    getUserMock.mockResolvedValue({ data: { user: { user_metadata: {} } } })
+    const { useUserPreferences } = await import('../useUserPreferences')
+    const { unit, setUnit } = useUserPreferences()
+
+    await setUnit('km')
+    expect(unit.value).toBe('km')
+    expect(window.localStorage.getItem('mrs.unit')).toBe('km')
+    expect(updateUserMock).toHaveBeenCalledWith({ data: { unit: 'km' } })
+  })
+})

--- a/frontend/src/composables/useRecentRuns.ts
+++ b/frontend/src/composables/useRecentRuns.ts
@@ -1,0 +1,24 @@
+import { ref } from 'vue'
+import { apiCall } from '@/config/api'
+import type { RecentRun, RecentRunsResponse } from '@/types/runs'
+
+export function useRecentRuns(limit = 7) {
+  const runs = ref<RecentRun[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const load = async (): Promise<void> => {
+    loading.value = true
+    error.value = null
+    try {
+      const res = await apiCall<RecentRunsResponse>(`/runs/recent?limit=${limit}`)
+      runs.value = res.runs
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load recent runs'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { runs, loading, error, load }
+}

--- a/frontend/src/composables/useRuns.ts
+++ b/frontend/src/composables/useRuns.ts
@@ -1,0 +1,59 @@
+import { ref, computed } from 'vue'
+import { apiCall } from '@/config/api'
+import type { PaginatedRun, RunsResponse } from '@/types/runs'
+
+export function useRuns(pageSize = 25) {
+  const runs = ref<PaginatedRun[]>([])
+  const total = ref(0)
+  const offset = ref(0)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const page = computed(() => Math.floor(offset.value / pageSize) + 1)
+  const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)))
+  const hasPrev = computed(() => offset.value > 0)
+  const hasNext = computed(() => offset.value + pageSize < total.value)
+
+  const load = async (): Promise<void> => {
+    loading.value = true
+    error.value = null
+    try {
+      const res = await apiCall<RunsResponse>(
+        `/runs?offset=${offset.value}&limit=${pageSize}`,
+      )
+      runs.value = res.runs
+      total.value = res.total
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load runs'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  const next = async (): Promise<void> => {
+    if (!hasNext.value) return
+    offset.value += pageSize
+    await load()
+  }
+
+  const prev = async (): Promise<void> => {
+    if (!hasPrev.value) return
+    offset.value = Math.max(0, offset.value - pageSize)
+    await load()
+  }
+
+  return {
+    runs,
+    total,
+    offset,
+    loading,
+    error,
+    page,
+    totalPages,
+    hasPrev,
+    hasNext,
+    load,
+    next,
+    prev,
+  }
+}

--- a/frontend/src/composables/useStats.ts
+++ b/frontend/src/composables/useStats.ts
@@ -1,0 +1,29 @@
+import { ref } from 'vue'
+import { apiCall } from '@/config/api'
+import type { OverallStats, StreakInfo } from '@/types/runs'
+
+export function useStats() {
+  const stats = ref<OverallStats | null>(null)
+  const streak = ref<StreakInfo | null>(null)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const load = async (): Promise<void> => {
+    loading.value = true
+    error.value = null
+    try {
+      const [overall, streaks] = await Promise.all([
+        apiCall<OverallStats>('/stats/overall'),
+        apiCall<StreakInfo>('/stats/streaks'),
+      ])
+      stats.value = overall
+      streak.value = streaks
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load stats'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { stats, streak, loading, error, load }
+}

--- a/frontend/src/composables/useSync.ts
+++ b/frontend/src/composables/useSync.ts
@@ -1,0 +1,41 @@
+import { ref } from 'vue'
+import { apiCall } from '@/config/api'
+import type { SyncResponse } from '@/types/runs'
+
+const LAST_SYNC_KEY = 'mrs.lastSyncAt'
+
+const syncing = ref(false)
+const error = ref<string | null>(null)
+const lastSyncedAt = ref<string | null>(loadLastSync())
+
+function loadLastSync(): string | null {
+  if (typeof window === 'undefined') return null
+  return window.localStorage.getItem(LAST_SYNC_KEY)
+}
+
+function persistLastSync(iso: string): void {
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(LAST_SYNC_KEY, iso)
+  }
+}
+
+export function useSync() {
+  const sync = async (): Promise<SyncResponse | null> => {
+    syncing.value = true
+    error.value = null
+    try {
+      const res = await apiCall<SyncResponse>('/sync-user', { method: 'POST' })
+      const now = new Date().toISOString()
+      lastSyncedAt.value = now
+      persistLastSync(now)
+      return res
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Sync failed'
+      return null
+    } finally {
+      syncing.value = false
+    }
+  }
+
+  return { sync, syncing, error, lastSyncedAt }
+}

--- a/frontend/src/composables/useUserPreferences.ts
+++ b/frontend/src/composables/useUserPreferences.ts
@@ -1,0 +1,48 @@
+import { ref, watch } from 'vue'
+import { supabase } from '@/config/supabase'
+import type { Unit } from '@/types/runs'
+
+const STORAGE_KEY = 'mrs.unit'
+const DEFAULT_UNIT: Unit = 'mi'
+
+const unit = ref<Unit>(loadInitialUnit())
+const loaded = ref(false)
+
+function loadInitialUnit(): Unit {
+  if (typeof window === 'undefined') return DEFAULT_UNIT
+  const stored = window.localStorage.getItem(STORAGE_KEY)
+  return stored === 'mi' || stored === 'km' ? stored : DEFAULT_UNIT
+}
+
+function persistLocally(value: Unit): void {
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(STORAGE_KEY, value)
+  }
+}
+
+async function syncFromSupabase(): Promise<void> {
+  const { data } = await supabase.auth.getUser()
+  const remote = data.user?.user_metadata?.unit as Unit | undefined
+  if (remote === 'mi' || remote === 'km') {
+    unit.value = remote
+    persistLocally(remote)
+  }
+  loaded.value = true
+}
+
+async function setUnit(value: Unit): Promise<void> {
+  unit.value = value
+  persistLocally(value)
+  await supabase.auth.updateUser({ data: { unit: value } })
+}
+
+export function useUserPreferences() {
+  if (!loaded.value) {
+    void syncFromSupabase()
+  }
+  return { unit, setUnit, loaded }
+}
+
+if (typeof window !== 'undefined') {
+  watch(unit, persistLocally)
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -31,6 +31,12 @@ const router = createRouter({
       component: () => import('@/views/RunsView.vue'),
       meta: { requiresAuth: true },
     },
+    {
+      path: '/settings',
+      name: 'settings',
+      component: () => import('@/views/SettingsView.vue'),
+      meta: { requiresAuth: true },
+    },
   ],
   scrollBehavior(_to, _from, savedPosition) {
     return savedPosition ?? { top: 0 }

--- a/frontend/src/types/runs.ts
+++ b/frontend/src/types/runs.ts
@@ -1,0 +1,75 @@
+export type Unit = 'mi' | 'km'
+
+export interface OverallStats {
+  total_runs: number
+  total_km: number
+  avg_km: number
+  longest_run_km: number
+  avg_pace_min_per_km: number
+}
+
+export interface StreakInfo {
+  current_streak: number
+  longest_streak: number
+  top_streaks: TopStreak[]
+}
+
+export interface TopStreak {
+  start_date: string | null
+  end_date: string | null
+  length_days: number
+  is_current: boolean
+}
+
+export interface RecentRun {
+  activity_id: string
+  date: string
+  distance_km: number
+  duration_seconds: number
+  duration_minutes: number
+  avg_pace_min_per_km: number | null
+  heart_rate_avg: number | null
+  temperature_celsius: number | null
+  weather: string | null
+}
+
+export interface PaginatedRun {
+  activity_id: string
+  date: string
+  distance_km: number
+  duration_minutes: number
+  avg_pace_min_per_km: number | null
+}
+
+export interface RecentRunsResponse {
+  count: number
+  runs: RecentRun[]
+}
+
+export interface RunsResponse {
+  total: number
+  offset: number
+  limit: number
+  count: number
+  runs: PaginatedRun[]
+}
+
+export interface MonthlyStats {
+  month: string
+  run_count: number
+  total_km: number
+  avg_km: number
+  avg_pace_min_per_km: number | null
+}
+
+export interface MonthlyStatsResponse {
+  count: number
+  months: MonthlyStats[]
+}
+
+export interface SyncResponse {
+  message: string
+  runs_synced: number
+  since: string
+  until: string
+}

--- a/frontend/src/utils/__tests__/format.test.ts
+++ b/frontend/src/utils/__tests__/format.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  formatDistance,
+  formatDistanceWithUnit,
+  formatPace,
+  formatDuration,
+  formatDate,
+  formatRelativeTime,
+  distanceLabel,
+} from '../format'
+
+describe('distanceLabel', () => {
+  it('returns mi for miles', () => {
+    expect(distanceLabel('mi')).toBe('mi')
+  })
+  it('returns km for kilometers', () => {
+    expect(distanceLabel('km')).toBe('km')
+  })
+})
+
+describe('formatDistance', () => {
+  it('returns km value as-is when unit is km', () => {
+    expect(formatDistance(5.0, 'km')).toBe('5.00')
+  })
+  it('converts km to miles when unit is mi', () => {
+    // 10 km = 6.21 mi (1.609344 km/mi)
+    expect(formatDistance(10, 'mi')).toBe('6.21')
+  })
+  it('respects custom decimals', () => {
+    expect(formatDistance(5.0, 'km', 0)).toBe('5')
+    expect(formatDistance(5.0, 'km', 1)).toBe('5.0')
+  })
+  it('handles zero', () => {
+    expect(formatDistance(0, 'km')).toBe('0.00')
+    expect(formatDistance(0, 'mi')).toBe('0.00')
+  })
+})
+
+describe('formatDistanceWithUnit', () => {
+  it('formats km with unit suffix', () => {
+    expect(formatDistanceWithUnit(5.0, 'km')).toBe('5.00 km')
+  })
+  it('formats miles with unit suffix', () => {
+    expect(formatDistanceWithUnit(10, 'mi')).toBe('6.21 mi')
+  })
+})
+
+describe('formatPace', () => {
+  it('formats km pace correctly', () => {
+    // 5.18 min/km = 5:11 /km
+    expect(formatPace(5.18, 'km')).toBe('5:11 /km')
+  })
+  it('converts km pace to mi pace', () => {
+    // 5.0 min/km × 1.609344 = 8.047 min/mi = 8:03 /mi
+    expect(formatPace(5.0, 'mi')).toBe('8:03 /mi')
+  })
+  it('rounds seconds correctly', () => {
+    // 4.5 min/km = 4:30 /km
+    expect(formatPace(4.5, 'km')).toBe('4:30 /km')
+  })
+  it('pads single-digit seconds', () => {
+    // 5.05 min/km = 5:03 /km
+    expect(formatPace(5.05, 'km')).toBe('5:03 /km')
+  })
+  it('returns dash for null', () => {
+    expect(formatPace(null, 'km')).toBe('–')
+    expect(formatPace(undefined, 'mi')).toBe('–')
+  })
+  it('returns dash for zero or negative', () => {
+    expect(formatPace(0, 'km')).toBe('–')
+    expect(formatPace(-1, 'km')).toBe('–')
+  })
+})
+
+describe('formatDuration', () => {
+  it('formats minutes:seconds', () => {
+    expect(formatDuration(125)).toBe('2:05')
+  })
+  it('formats hours:minutes:seconds when over an hour', () => {
+    expect(formatDuration(3725)).toBe('1:02:05')
+  })
+  it('handles zero', () => {
+    expect(formatDuration(0)).toBe('0:00')
+  })
+  it('rounds fractional seconds', () => {
+    expect(formatDuration(60.7)).toBe('1:01')
+  })
+})
+
+describe('formatDate', () => {
+  it('formats ISO date as Weekday Mon Day', () => {
+    // 2026-05-03 is a Sunday
+    expect(formatDate('2026-05-03T10:00:00')).toBe('Sun May 3')
+  })
+  it('handles different months', () => {
+    expect(formatDate('2026-01-15T10:00:00')).toBe('Thu Jan 15')
+    expect(formatDate('2026-12-25T10:00:00')).toBe('Fri Dec 25')
+  })
+  it('returns input on invalid date', () => {
+    expect(formatDate('not-a-date')).toBe('not-a-date')
+  })
+})
+
+describe('formatRelativeTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-03T12:00:00Z'))
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns "Never" for null', () => {
+    expect(formatRelativeTime(null)).toBe('Never')
+    expect(formatRelativeTime(undefined)).toBe('Never')
+  })
+  it('returns "Just now" for less than a minute ago', () => {
+    expect(formatRelativeTime('2026-05-03T11:59:30Z')).toBe('Just now')
+  })
+  it('returns minutes for under an hour', () => {
+    expect(formatRelativeTime('2026-05-03T11:30:00Z')).toBe('30m ago')
+  })
+  it('returns hours for under a day', () => {
+    expect(formatRelativeTime('2026-05-03T10:00:00Z')).toBe('2h ago')
+  })
+  it('returns days for under a week', () => {
+    expect(formatRelativeTime('2026-05-01T12:00:00Z')).toBe('2d ago')
+  })
+  it('falls back to absolute date past a week', () => {
+    expect(formatRelativeTime('2026-04-20T12:00:00Z')).toMatch(/\w{3} Apr 20/)
+  })
+})

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,0 +1,59 @@
+import type { Unit } from '@/types/runs'
+
+const KM_PER_MI = 1.609344
+
+export const distanceLabel = (unit: Unit): string => (unit === 'mi' ? 'mi' : 'km')
+
+export const formatDistance = (km: number, unit: Unit, decimals = 2): string => {
+  const value = unit === 'mi' ? km / KM_PER_MI : km
+  return value.toFixed(decimals)
+}
+
+export const formatDistanceWithUnit = (km: number, unit: Unit, decimals = 2): string =>
+  `${formatDistance(km, unit, decimals)} ${distanceLabel(unit)}`
+
+export const formatPace = (minPerKm: number | null | undefined, unit: Unit): string => {
+  if (minPerKm === null || minPerKm === undefined || minPerKm <= 0) return '–'
+  const minPerUnit = unit === 'mi' ? minPerKm * KM_PER_MI : minPerKm
+  const totalSeconds = Math.round(minPerUnit * 60)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}:${seconds.toString().padStart(2, '0')} /${distanceLabel(unit)}`
+}
+
+export const formatDuration = (seconds: number): string => {
+  const hours = Math.floor(seconds / 3600)
+  const mins = Math.floor((seconds % 3600) / 60)
+  const secs = Math.round(seconds % 60)
+  if (hours > 0) {
+    return `${hours}:${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`
+  }
+  return `${mins}:${secs.toString().padStart(2, '0')}`
+}
+
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+const MONTHS = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+]
+
+export const formatDate = (iso: string): string => {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return `${WEEKDAYS[d.getDay()]} ${MONTHS[d.getMonth()]} ${d.getDate()}`
+}
+
+export const formatRelativeTime = (iso: string | null | undefined): string => {
+  if (!iso) return 'Never'
+  const d = new Date(iso)
+  const diffMs = Date.now() - d.getTime()
+  if (diffMs < 0) return 'Just now'
+  const diffMin = Math.floor(diffMs / 60_000)
+  if (diffMin < 1) return 'Just now'
+  if (diffMin < 60) return `${diffMin}m ago`
+  const diffHr = Math.floor(diffMin / 60)
+  if (diffHr < 24) return `${diffHr}h ago`
+  const diffDays = Math.floor(diffHr / 24)
+  if (diffDays < 7) return `${diffDays}d ago`
+  return formatDate(iso)
+}

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1,41 +1,133 @@
 <template>
   <div class="container-app py-8">
-    <div class="mb-6">
-      <h1 class="text-2xl font-bold text-gray-900">Dashboard</h1>
-      <p class="text-gray-500 text-sm mt-1">Welcome back, {{ userEmail }}</p>
+    <div class="flex items-center justify-between mb-8">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900">Dashboard</h1>
+        <p class="text-gray-500 text-sm mt-1">Welcome back, {{ userEmail }}</p>
+      </div>
+      <SyncButton mode="full" @synced="reload" />
     </div>
 
-    <!-- Streak card placeholder -->
-    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
-      <div class="bg-white rounded-xl border border-gray-100 shadow-sm p-5">
-        <p class="text-xs font-semibold text-gray-400 uppercase tracking-wide">Current Streak</p>
-        <p class="mt-2 text-4xl font-bold text-brand-600">–</p>
-        <p class="text-sm text-gray-500 mt-1">days</p>
+    <div v-if="initialLoading" class="space-y-4">
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div v-for="i in 4" :key="i" class="h-28 bg-white rounded-xl border border-gray-100 animate-pulse" />
       </div>
-      <div class="bg-white rounded-xl border border-gray-100 shadow-sm p-5">
-        <p class="text-xs font-semibold text-gray-400 uppercase tracking-wide">Longest Streak</p>
-        <p class="mt-2 text-4xl font-bold text-gray-700">–</p>
-        <p class="text-sm text-gray-500 mt-1">days</p>
-      </div>
-      <div class="bg-white rounded-xl border border-gray-100 shadow-sm p-5">
-        <p class="text-xs font-semibold text-gray-400 uppercase tracking-wide">Total Runs</p>
-        <p class="mt-2 text-4xl font-bold text-gray-700">–</p>
-        <p class="text-sm text-gray-500 mt-1">all time</p>
-      </div>
+      <div class="h-64 bg-white rounded-xl border border-gray-100 animate-pulse" />
     </div>
 
-    <div class="bg-white rounded-xl border border-gray-100 shadow-sm p-6 text-center text-gray-400">
-      <p class="text-4xl mb-3">🏗️</p>
-      <p class="font-medium">Run data coming soon</p>
-      <p class="text-sm mt-1">Stats and history will appear here once the API is wired up.</p>
+    <div v-else-if="loadError" class="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-700">
+      {{ loadError }}
     </div>
+
+    <EmptyState v-else-if="isNewUser" @synced="reload" />
+
+    <template v-else>
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+        <StatCard
+          label="Current streak"
+          :value="`${streak?.current_streak ?? 0}`"
+          sublabel="days"
+          value-class="text-brand-600"
+        />
+        <StatCard
+          label="Longest streak"
+          :value="`${streak?.longest_streak ?? 0}`"
+          sublabel="days"
+          value-class="text-gray-800"
+        />
+        <StatCard
+          label="Total runs"
+          :value="`${stats?.total_runs ?? 0}`"
+          sublabel="all time"
+          value-class="text-gray-800"
+        />
+        <StatCard
+          label="Total distance"
+          :value="formatDistance(stats?.total_km ?? 0, unit, 0)"
+          :sublabel="`${distanceLabel(unit)} all time`"
+          value-class="text-gray-800"
+        />
+      </div>
+
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-8">
+        <StatCard
+          label="Longest run"
+          :value="formatDistanceWithUnit(stats?.longest_run_km ?? 0, unit)"
+          sublabel="personal best"
+        />
+        <StatCard
+          label="Average pace"
+          :value="formatPace(stats?.avg_pace_min_per_km ?? null, unit)"
+          sublabel="across all runs"
+        />
+      </div>
+
+      <div class="bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden">
+        <div class="flex items-center justify-between px-5 py-4 border-b border-gray-100">
+          <h2 class="font-semibold text-gray-900">Recent runs</h2>
+          <RouterLink to="/runs" class="text-sm text-brand-600 hover:text-brand-700">
+            View all →
+          </RouterLink>
+        </div>
+        <div v-if="recentRuns.length === 0" class="p-8 text-center text-gray-400 text-sm">
+          No recent runs.
+        </div>
+        <div v-else class="divide-y divide-gray-100">
+          <RunRow
+            v-for="run in recentRuns"
+            :key="run.activity_id"
+            :date="run.date"
+            :distance-km="run.distance_km"
+            :duration-seconds="run.duration_seconds"
+            :pace-min-per-km="run.avg_pace_min_per_km"
+            :unit="unit"
+            :weather="run.weather"
+          />
+        </div>
+      </div>
+    </template>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onMounted } from 'vue'
+import { RouterLink } from 'vue-router'
+import StatCard from '@/components/StatCard.vue'
+import RunRow from '@/components/RunRow.vue'
+import SyncButton from '@/components/SyncButton.vue'
+import EmptyState from '@/components/EmptyState.vue'
+import { useStats } from '@/composables/useStats'
+import { useRecentRuns } from '@/composables/useRecentRuns'
+import { useUserPreferences } from '@/composables/useUserPreferences'
 import { useAuthStore } from '@/stores/auth'
+import {
+  formatDistance,
+  formatDistanceWithUnit,
+  formatPace,
+  distanceLabel,
+} from '@/utils/format'
 
 const auth = useAuthStore()
 const userEmail = computed(() => auth.user?.email ?? 'runner')
+
+const { stats, streak, loading: statsLoading, error: statsError, load: loadStats } = useStats()
+const {
+  runs: recentRuns,
+  loading: recentLoading,
+  error: recentError,
+  load: loadRecent,
+} = useRecentRuns(7)
+const { unit } = useUserPreferences()
+
+const initialLoading = computed(
+  () => (statsLoading.value || recentLoading.value) && !stats.value && recentRuns.value.length === 0,
+)
+const loadError = computed(() => statsError.value || recentError.value)
+const isNewUser = computed(() => stats.value !== null && stats.value.total_runs === 0)
+
+const reload = async () => {
+  await Promise.all([loadStats(), loadRecent()])
+}
+
+onMounted(reload)
 </script>

--- a/frontend/src/views/RunsView.vue
+++ b/frontend/src/views/RunsView.vue
@@ -1,14 +1,86 @@
 <template>
   <div class="container-app py-8">
-    <h1 class="text-2xl font-bold text-gray-900 mb-6">Run History</h1>
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900">Run history</h1>
+        <p class="text-sm text-gray-500 mt-1">
+          {{ total > 0 ? `${total} total runs` : 'No runs yet' }}
+        </p>
+      </div>
+      <SyncButton mode="full" @synced="reload" />
+    </div>
 
-    <div class="bg-white rounded-xl border border-gray-100 shadow-sm p-6 text-center text-gray-400">
-      <p class="text-4xl mb-3">🏗️</p>
-      <p class="font-medium">Run history coming soon</p>
-      <p class="text-sm mt-1">Your runs will appear here once the API is wired up.</p>
+    <div v-if="loading && runs.length === 0" class="space-y-2">
+      <div v-for="i in 5" :key="i" class="bg-white rounded-lg border border-gray-100 h-14 animate-pulse" />
+    </div>
+
+    <div v-else-if="error" class="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-700">
+      {{ error }}
+    </div>
+
+    <div
+      v-else-if="runs.length === 0"
+      class="bg-white rounded-xl border border-gray-100 shadow-sm p-10 text-center text-gray-500"
+    >
+      <p>No runs to show yet. Click <span class="font-semibold">Sync now</span> to import.</p>
+    </div>
+
+    <div v-else class="bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden">
+      <div class="hidden sm:flex items-center justify-between px-4 py-2 text-xs font-semibold text-gray-400 uppercase tracking-wide border-b border-gray-100">
+        <span>Date</span>
+        <div class="flex gap-6">
+          <span>Distance</span>
+          <span>Duration</span>
+          <span>Pace</span>
+        </div>
+      </div>
+      <div class="divide-y divide-gray-100">
+        <RunRow
+          v-for="run in runs"
+          :key="run.activity_id"
+          :date="run.date"
+          :distance-km="run.distance_km"
+          :duration-minutes="run.duration_minutes"
+          :pace-min-per-km="run.avg_pace_min_per_km"
+          :unit="unit"
+        />
+      </div>
+    </div>
+
+    <div v-if="runs.length > 0" class="flex items-center justify-between mt-4 text-sm">
+      <button
+        @click="prev"
+        :disabled="!hasPrev || loading"
+        class="btn-secondary disabled:opacity-50"
+      >
+        ← Prev
+      </button>
+      <span class="text-gray-500">Page {{ page }} of {{ totalPages }}</span>
+      <button
+        @click="next"
+        :disabled="!hasNext || loading"
+        class="btn-secondary disabled:opacity-50"
+      >
+        Next →
+      </button>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { onMounted } from 'vue'
+import RunRow from '@/components/RunRow.vue'
+import SyncButton from '@/components/SyncButton.vue'
+import { useRuns } from '@/composables/useRuns'
+import { useUserPreferences } from '@/composables/useUserPreferences'
+
+const { runs, total, loading, error, page, totalPages, hasPrev, hasNext, load, next, prev } =
+  useRuns(25)
+const { unit } = useUserPreferences()
+
+const reload = async () => {
+  await load()
+}
+
+onMounted(reload)
 </script>

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="container-app py-8 max-w-2xl">
+    <h1 class="text-2xl font-bold text-gray-900 mb-6">Settings</h1>
+
+    <div class="bg-white rounded-xl border border-gray-100 shadow-sm p-6">
+      <h2 class="text-lg font-semibold text-gray-900 mb-1">Units</h2>
+      <p class="text-sm text-gray-500 mb-4">
+        Choose how distance and pace are displayed across the app.
+      </p>
+
+      <div class="inline-flex rounded-lg border border-gray-200 p-1 bg-gray-50">
+        <button
+          v-for="option in options"
+          :key="option.value"
+          type="button"
+          @click="selectUnit(option.value)"
+          :class="[
+            'px-4 py-2 text-sm font-semibold rounded-md transition',
+            unit === option.value
+              ? 'bg-white text-brand-600 shadow-sm'
+              : 'text-gray-500 hover:text-gray-800',
+          ]"
+        >
+          {{ option.label }}
+        </button>
+      </div>
+
+      <p v-if="saved" class="text-xs text-green-600 mt-3">Saved</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useUserPreferences } from '@/composables/useUserPreferences'
+import type { Unit } from '@/types/runs'
+
+const { unit, setUnit } = useUserPreferences()
+const saved = ref(false)
+
+const options: { value: Unit; label: string }[] = [
+  { value: 'mi', label: 'Miles' },
+  { value: 'km', label: 'Kilometers' },
+]
+
+const selectUnit = async (value: Unit) => {
+  if (unit.value === value) return
+  await setUnit(value)
+  saved.value = true
+  setTimeout(() => (saved.value = false), 2000)
+}
+</script>

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+import { fileURLToPath, URL } from 'node:url'
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  test: {
+    environment: 'happy-dom',
+    globals: true,
+    include: ['src/**/*.{test,spec}.{ts,js}'],
+  },
+})


### PR DESCRIPTION
Closes #50

## Summary
Wires the protected API to the frontend with a working signed-in experience.

**New composables** (`useStats`, `useRecentRuns`, `useRuns`, `useSync`, `useUserPreferences`) handle data fetching and per-user miles/kilometers preference (stored in Supabase `user_metadata`, mirrored to localStorage).

**New components**
- `StatCard` — reusable KPI card
- `RunRow` — shared between Dashboard recent-list and RunsView
- `SyncButton` — `mode='full'` (button + last-synced) or `mode='compact'` (icon for the header)
- `EmptyState` — \"Connect SmashRun\" CTA shown when total_runs === 0

**Views**
- `DashboardView` (rewritten) — streak number, 4 stat cards (current/longest streak, total runs, total distance), longest-run + avg-pace cards, last 7 runs, sync button. Empty state for new users.
- `RunsView` (rewritten) — paginated table (25/page), Prev/Next, sync button
- `SettingsView` (new) — Miles/Kilometers toggle, persists to Supabase user_metadata

**Header**: Settings link added; compact sync icon visible when authenticated.

**Testing**
- `vitest.config.ts` (happy-dom) with `@/` alias
- 44 unit tests across formatters, composables, components
- Critical coverage: km↔mi conversion math, pace formatting, sync state transitions, preference read/write
- `frontend-test.yml` workflow runs type-check + tests + build on every PR

**Architecture decisions**
- Composables over Pinia stores (simple, idiomatic, no shared mutation needed)
- Single global `unit` ref via composable (instances share state)
- Last-sync time stored client-side in localStorage (lightweight; no backend column needed yet)

## Test plan
- [ ] CI green: type-check, vitest, build
- [ ] Sign in → Dashboard shows real stats and last 7 runs
- [ ] Switching unit in Settings updates pace/distance everywhere immediately
- [ ] New user with zero runs sees the \"Connect SmashRun\" CTA
- [ ] Click \"Sync now\" → spinner, then refreshed data
- [ ] /runs paginates correctly; Prev/Next disable at boundaries
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)