### PR TITLE
fix: CORS preflight on protected API routes

### DIFF
--- a/src/lambdas/query_runs/handler.py
+++ b/src/lambdas/query_runs/handler.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 import boto3
 from aws_lambda_powertools import Logger, Metrics
-from aws_lambda_powertools.event_handler import APIGatewayRestResolver
+from aws_lambda_powertools.event_handler import APIGatewayRestResolver, CORSConfig
 from aws_lambda_powertools.metrics import MetricUnit
 from aws_lambda_powertools.utilities.typing import LambdaContext
 
@@ -26,8 +26,16 @@ from src.shared.supabase_ops import (
 logger = Logger(service="myrunstreak-query")
 metrics = Metrics(namespace="MyRunStreak", service="myrunstreak-query")
 
-# API Gateway event handler
-app = APIGatewayRestResolver()
+# CORS: Bearer-token auth means ACAO="*" is safe (no cookie credentials).
+# Powertools auto-injects ACAO and handles OPTIONS preflight for any route
+# whose method is registered — but the OPTIONS request still needs a route
+# in API Gateway, which is added in terraform/modules/api_gateway_consumer.
+cors_config = CORSConfig(
+    allow_origin="*",
+    allow_headers=["Authorization", "Content-Type"],
+    max_age=300,
+)
+app = APIGatewayRestResolver(cors=cors_config)
 
 
 def get_user_id_from_request() -> UUID:
@@ -715,6 +723,10 @@ def lambda_handler(event: dict[str, Any], context: LambdaContext) -> dict[str, A
     Uses Lambda Powertools API Gateway resolver to handle routing.
     All endpoints require user_id query parameter.
     """
+    cors_headers = {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+    }
     try:
         return app.resolve(event, context)
     except ValueError as e:
@@ -722,13 +734,13 @@ def lambda_handler(event: dict[str, Any], context: LambdaContext) -> dict[str, A
         logger.warning(f"Validation error: {e}")
         return {
             "statusCode": 400,
-            "headers": {"Content-Type": "application/json"},
+            "headers": cors_headers,
             "body": json.dumps({"error": "Bad request", "message": str(e)}),
         }
     except Exception as e:
         logger.exception(f"Query failed: {e}")
         return {
             "statusCode": 500,
-            "headers": {"Content-Type": "application/json"},
+            "headers": cors_headers,
             "body": json.dumps({"error": "Internal server error", "message": str(e)}),
         }

--- a/terraform/modules/api_gateway_consumer/main.tf
+++ b/terraform/modules/api_gateway_consumer/main.tf
@@ -371,6 +371,83 @@ resource "aws_api_gateway_integration" "auth_callback" {
 }
 
 # ==============================================================================
+# CORS preflight (OPTIONS) for protected routes
+# ==============================================================================
+# Browsers send a preflight OPTIONS for any cross-origin request that includes
+# Authorization or Content-Type: application/json. The protected routes below
+# previously had no OPTIONS method, so preflight returned 403 and the browser
+# blocked the actual request with a generic "CORS error". Each block below adds
+# a MOCK integration that responds 200 + CORS headers, mirroring the existing
+# /sync OPTIONS pattern.
+#
+# Bearer-token auth (no cookies) means ACAO="*" is safe.
+
+locals {
+  cors_options_resources = {
+    stats_proxy       = aws_api_gateway_resource.stats_proxy.id
+    runs              = aws_api_gateway_resource.runs.id
+    runs_proxy        = aws_api_gateway_resource.runs_proxy.id
+    sync_user         = aws_api_gateway_resource.sync_user.id
+    auth_store_tokens = aws_api_gateway_resource.auth_store_tokens.id
+    auth_login_url    = aws_api_gateway_resource.auth_login_url.id
+    auth_callback     = aws_api_gateway_resource.auth_callback.id
+  }
+}
+
+resource "aws_api_gateway_method" "cors_options" {
+  for_each      = local.cors_options_resources
+  rest_api_id   = local.api_gateway_id
+  resource_id   = each.value
+  http_method   = "OPTIONS"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "cors_options" {
+  for_each    = local.cors_options_resources
+  rest_api_id = local.api_gateway_id
+  resource_id = each.value
+  http_method = aws_api_gateway_method.cors_options[each.key].http_method
+  type        = "MOCK"
+  request_templates = {
+    "application/json" = jsonencode({ statusCode = 200 })
+  }
+}
+
+resource "aws_api_gateway_method_response" "cors_options" {
+  for_each    = local.cors_options_resources
+  rest_api_id = local.api_gateway_id
+  resource_id = each.value
+  http_method = aws_api_gateway_method.cors_options[each.key].http_method
+  status_code = "200"
+
+  response_models = {
+    "application/json" = "Empty"
+  }
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = true
+    "method.response.header.Access-Control-Allow-Methods" = true
+    "method.response.header.Access-Control-Allow-Origin"  = true
+  }
+}
+
+resource "aws_api_gateway_integration_response" "cors_options" {
+  for_each    = local.cors_options_resources
+  rest_api_id = local.api_gateway_id
+  resource_id = each.value
+  http_method = aws_api_gateway_method.cors_options[each.key].http_method
+  status_code = aws_api_gateway_method_response.cors_options[each.key].status_code
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = "'Authorization,Content-Type,X-Api-Key'"
+    "method.response.header.Access-Control-Allow-Methods" = "'GET,POST,OPTIONS'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+  }
+
+  depends_on = [aws_api_gateway_integration.cors_options]
+}
+
+# ==============================================================================
 # Lambda Permissions for API Gateway
 # ==============================================================================
 
@@ -435,6 +512,9 @@ resource "aws_api_gateway_deployment" "myrunstreak" {
       aws_api_gateway_resource.auth_callback.id,
       aws_api_gateway_method.auth_callback_post.id,
       aws_api_gateway_integration.auth_callback.id,
+      # CORS preflight (OPTIONS) for all protected routes
+      jsonencode([for k, v in aws_api_gateway_method.cors_options : v.id]),
+      jsonencode([for k, v in aws_api_gateway_integration.cors_options : v.id]),
     ]))
   }
 
@@ -452,6 +532,8 @@ resource "aws_api_gateway_deployment" "myrunstreak" {
     aws_api_gateway_integration.auth_store_tokens,
     aws_api_gateway_integration.auth_login_url,
     aws_api_gateway_integration.auth_callback,
+    aws_api_gateway_integration.cors_options,
+    aws_api_gateway_integration_response.cors_options,
   ]
 }
 


### PR DESCRIPTION
## Summary
The dashboard couldn't fetch `/stats/overall`, `/stats/streaks`, or `/runs/recent` from the browser even though the Lambda + authorizer were healthy. Browser DevTools showed 3× preflight `OPTIONS` returning 403 followed by 3× `CORS error` on the GETs.

Cause: only `/sync` had an OPTIONS method; the protected routes never did. Browsers preflight any cross-origin request with `Authorization` or `Content-Type: application/json`, so without OPTIONS, every dashboard request was blocked.

## Changes
- **terraform/modules/api_gateway_consumer/main.tf**: adds OPTIONS + MOCK integration on `/stats/{proxy+}`, `/runs`, `/runs/{proxy+}`, `/sync-user`, `/auth/store-tokens`, `/auth/login-url`, `/auth/callback` via a `for_each` over a locals map. Returns `Access-Control-Allow-Origin: *`, `Access-Control-Allow-Headers: Authorization,Content-Type,X-Api-Key`, `Access-Control-Allow-Methods: GET,POST,OPTIONS`. Added to the deployment trigger and `depends_on` so a redeploy ships them.
- **src/lambdas/query_runs/handler.py**: adds Powertools `CORSConfig(allow_origin="*", ...)` to the resolver so successful GET/POST responses include ACAO. Also decorates the manual 400/500 responses in `lambda_handler` with the same header.

Bearer-token auth (no cookies) makes `ACAO="*"` safe — it's allowed without `Access-Control-Allow-Credentials`.

## Test plan
- [ ] CI: terraform plan/apply green
- [ ] CI: query Lambda image rebuilds and updates
- [ ] After merge: `curl -X OPTIONS https://api.myrunstreak.run/stats/overall -H 'Origin: https://myrunstreak.run' -H 'Access-Control-Request-Method: GET' -H 'Access-Control-Request-Headers: authorization,content-type'` returns 200 with ACAO header
- [ ] Browser: Dashboard at https://myrunstreak.run loads stats and recent runs without CORS errors
- [ ] Browser: Sync button works
- [ ] /sync still works (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)