### PR TITLE
fix: API Gateway sensitive-cascade replacement + CORS preflight

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -363,16 +363,52 @@ module "lambda_authorizer" {
 }
 
 # ==============================================================================
+# Shared API Gateway configuration (managed by runstreak-common)
+# ==============================================================================
+# Read once here and pass plain strings into the api_gateway_consumer module.
+# Reading inside the consumer module caused AWS provider 5.100+ to cascade
+# sensitive-value markings onto every resource via rest_api_id, triggering
+# spurious "must be replaced" plans.
+
+data "aws_ssm_parameter" "shared_api_gateway_id" {
+  name = "/runstreak/shared/${var.environment}/api-gateway-id"
+}
+
+data "aws_ssm_parameter" "shared_api_gateway_root_resource_id" {
+  name = "/runstreak/shared/${var.environment}/api-gateway-root-resource-id"
+}
+
+data "aws_ssm_parameter" "shared_api_gateway_execution_arn" {
+  name = "/runstreak/shared/${var.environment}/api-gateway-execution-arn"
+}
+
+data "aws_ssm_parameter" "shared_api_gateway_stage_name" {
+  name = "/runstreak/shared/${var.environment}/api-gateway-stage-name"
+}
+
+data "aws_ssm_parameter" "shared_api_gateway_invoke_url" {
+  name = "/runstreak/shared/${var.environment}/api-gateway-invoke-url"
+}
+
+# ==============================================================================
 # Module: API Gateway Consumer
 # ==============================================================================
 # Creates routes on the shared API Gateway (managed by runstreak-common).
-# Reads API Gateway configuration from SSM Parameter Store.
 
 module "api_gateway_consumer" {
   source = "../../modules/api_gateway_consumer"
 
   environment = var.environment
   aws_region  = var.aws_region
+
+  # Shared API Gateway IDs — nonsensitive() strips the sensitive marking that
+  # AWS provider 5.100+ adds to data.aws_ssm_parameter.value, so the values
+  # flow into the module as plain strings.
+  api_gateway_id               = nonsensitive(data.aws_ssm_parameter.shared_api_gateway_id.value)
+  api_gateway_root_resource_id = nonsensitive(data.aws_ssm_parameter.shared_api_gateway_root_resource_id.value)
+  api_gateway_execution_arn    = nonsensitive(data.aws_ssm_parameter.shared_api_gateway_execution_arn.value)
+  api_gateway_stage_name       = nonsensitive(data.aws_ssm_parameter.shared_api_gateway_stage_name.value)
+  api_gateway_invoke_url       = nonsensitive(data.aws_ssm_parameter.shared_api_gateway_invoke_url.value)
 
   # Sync Lambda (for /sync endpoint)
   sync_lambda_invoke_arn    = module.lambda.function_invoke_arn

--- a/terraform/modules/api_gateway_consumer/main.tf
+++ b/terraform/modules/api_gateway_consumer/main.tf
@@ -19,35 +19,18 @@
 # ==============================================================================
 
 # ------------------------------------------------------------------------------
-# Read API Gateway Configuration from SSM
+# API Gateway Configuration (passed in as variables from parent)
 # ------------------------------------------------------------------------------
-
-data "aws_ssm_parameter" "api_gateway_id" {
-  name = "/runstreak/shared/${var.environment}/api-gateway-id"
-}
-
-data "aws_ssm_parameter" "api_gateway_root_resource_id" {
-  name = "/runstreak/shared/${var.environment}/api-gateway-root-resource-id"
-}
-
-data "aws_ssm_parameter" "api_gateway_execution_arn" {
-  name = "/runstreak/shared/${var.environment}/api-gateway-execution-arn"
-}
-
-data "aws_ssm_parameter" "api_gateway_stage_name" {
-  name = "/runstreak/shared/${var.environment}/api-gateway-stage-name"
-}
-
-data "aws_ssm_parameter" "api_gateway_invoke_url" {
-  name = "/runstreak/shared/${var.environment}/api-gateway-invoke-url"
-}
+# Previously read inline via data.aws_ssm_parameter; moved to parent because
+# AWS provider 5.100+ marks data source values sensitive, which made every
+# resource that referenced rest_api_id appear "must be replaced" at plan time.
 
 locals {
-  api_gateway_id    = data.aws_ssm_parameter.api_gateway_id.value
-  root_resource_id  = data.aws_ssm_parameter.api_gateway_root_resource_id.value
-  api_execution_arn = data.aws_ssm_parameter.api_gateway_execution_arn.value
-  stage_name        = data.aws_ssm_parameter.api_gateway_stage_name.value
-  api_invoke_url    = data.aws_ssm_parameter.api_gateway_invoke_url.value
+  api_gateway_id    = var.api_gateway_id
+  root_resource_id  = var.api_gateway_root_resource_id
+  api_execution_arn = var.api_gateway_execution_arn
+  stage_name        = var.api_gateway_stage_name
+  api_invoke_url    = var.api_gateway_invoke_url
 }
 
 # ==============================================================================

--- a/terraform/modules/api_gateway_consumer/variables.tf
+++ b/terraform/modules/api_gateway_consumer/variables.tf
@@ -50,3 +50,34 @@ variable "authorizer_lambda_function_name" {
   description = "Name of the JWT authorizer Lambda function (for permissions)"
   type        = string
 }
+
+# Shared API Gateway IDs.
+# These were previously read inline via aws_ssm_parameter data sources, but
+# AWS provider 5.100+ marks data source values as sensitive, which cascaded
+# "(sensitive value) # forces replacement" onto every resource that referenced
+# rest_api_id/parent_id at plan time. Reading in the parent and passing as
+# plain string variables breaks that chain.
+variable "api_gateway_id" {
+  description = "ID of the shared REST API (from runstreak-common SSM)"
+  type        = string
+}
+
+variable "api_gateway_root_resource_id" {
+  description = "Root resource ID of the shared REST API"
+  type        = string
+}
+
+variable "api_gateway_execution_arn" {
+  description = "Execution ARN of the shared REST API"
+  type        = string
+}
+
+variable "api_gateway_stage_name" {
+  description = "Stage name (e.g., dev, prod)"
+  type        = string
+}
+
+variable "api_gateway_invoke_url" {
+  description = "Base invoke URL of the shared REST API stage"
+  type        = string
+}


### PR DESCRIPTION
## Background
PR #53 merged but its Terraform Apply failed because every API Gateway resource (\`/sync\`, \`/stats\`, \`/runs\`, \`/auth\`, etc.) was marked \`must be replaced\` and the create-then-destroy collided with existing AWS resources. CORS is still broken in prod because the deployment never picked up the new OPTIONS routes.

## Root cause
AWS provider 5.100+ marks \`data.aws_ssm_parameter.value\` as sensitive regardless of parameter Type. Inside the \`api_gateway_consumer\` module, those values flowed into \`rest_api_id\` and \`parent_id\` — both force-new attributes. Terraform plan saw \`(sensitive value) # forces replacement\` and cascaded a destroy/recreate over the whole API Gateway. PR #48's apply only succeeded because its plan was 0/0/0 (the user had pre-applied locally).

\`nonsensitive()\` inside the module didn't fix it because data sources were being deferred to apply, so the value stayed unknown at plan time.

## Fix
- Move the 5 \`data.aws_ssm_parameter\` reads to the parent (\`terraform/environments/dev/main.tf\`) where they're not consumed by force-new attributes — terraform happily reads them at plan time
- Pass plain strings into the module through new variables, wrapping with \`nonsensitive()\` at the module boundary
- Module no longer reads SSM at all

Plan diff confirms: existing resources are now in-place updates, only the new \`cors_options\` resources are created, the api gateway deployment is replaced (expected — redeployment trigger changed) with \`create_before_destroy\`.

Also lands the original CORS goal of PR #53:
- 7× OPTIONS+MOCK routes (\`/stats/{proxy+}\`, \`/runs\`, \`/runs/{proxy+}\`, \`/sync-user\`, \`/auth/store-tokens\`, \`/auth/login-url\`, \`/auth/callback\`)
- \`Access-Control-Allow-Origin: *\`, \`...-Headers: Authorization,Content-Type,X-Api-Key\`, \`...-Methods: GET,POST,OPTIONS\`
- Query Lambda gets Powertools \`CORSConfig\` so successful responses include ACAO

## Test plan
- [ ] Terraform Plan in CI shows ~0 destroys (just the deployment replacement)
- [ ] Terraform Apply succeeds on merge
- [ ] After apply: \`curl -X OPTIONS https://api.myrunstreak.run/stats/overall -H 'Origin: https://myrunstreak.run' -H 'Access-Control-Request-Method: GET' -H 'Access-Control-Request-Headers: authorization,content-type'\` returns 200 with ACAO header
- [ ] Browser: Dashboard at https://myrunstreak.run loads stats and recent runs (no CORS errors in DevTools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)