### PR TITLE
feat: Helm templates for backend + redis + ExternalSecret (Phase A.2)

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -1,0 +1,61 @@
+name: Backend Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'backend/**'
+      - 'src/shared/**'
+      - 'helm/myrunstreak/**'
+      - '.github/workflows/backend-deploy.yml'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/silverbeer/myrunstreak-backend
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: backend/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Same architecture as the frontend / cluster nodes (linux/amd64).
+          platforms: linux/amd64
+
+      - name: Update Helm values image tag
+        run: |
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          sed -i "s|tag: \".*\" # backend-tag|tag: \"${SHORT_SHA}\" # backend-tag|" helm/myrunstreak/values.yaml
+
+      - name: Commit updated Helm values
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "ci: update myrunstreak-backend image tag to ${{ github.sha }} [skip ci]"
+          file_pattern: helm/myrunstreak/values.yaml

--- a/helm/myrunstreak/templates/backend.yaml
+++ b/helm/myrunstreak/templates/backend.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.backend.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "myrunstreak.fullname" . }}-backend
+  labels:
+    {{- include "myrunstreak.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  replicas: {{ .Values.backend.replicaCount | default 1 }}
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      {{- include "myrunstreak.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: backend
+  template:
+    metadata:
+      labels:
+        {{- include "myrunstreak.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: backend
+          image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy | default "IfNotPresent" }}
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            - name: ENVIRONMENT
+              value: {{ .Values.backend.env.environment | default "dev" | quote }}
+            - name: LOG_LEVEL
+              value: {{ .Values.backend.env.logLevel | default "INFO" | quote }}
+            - name: CORS_ALLOW_ORIGINS
+              value: {{ .Values.backend.env.corsAllowOrigins | default "*" | quote }}
+            - name: REDIS_URL
+              value: "redis://{{ include "myrunstreak.fullname" . }}-redis:6379/0"
+            - name: CACHE_ENABLED
+              value: {{ .Values.backend.env.cacheEnabled | default "true" | quote }}
+            - name: CACHE_DEFAULT_TTL_SECONDS
+              value: {{ .Values.backend.env.cacheDefaultTtlSeconds | default 60 | quote }}
+            - name: SUPABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                  key: supabase-url
+            - name: SUPABASE_SERVICE_ROLE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                  key: supabase-service-key
+            - name: SUPABASE_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                  key: supabase-jwt-secret
+            - name: SMASHRUN_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                  key: smashrun-client-id
+            - name: SMASHRUN_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                  key: smashrun-client-secret
+          resources:
+            {{- toYaml (.Values.backend.resources | default dict) | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "myrunstreak.fullname" . }}-backend
+  labels:
+    {{- include "myrunstreak.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8000
+      targetPort: http
+      name: http
+  selector:
+    {{- include "myrunstreak.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+{{- end }}

--- a/helm/myrunstreak/templates/cronjob-sync.yaml
+++ b/helm/myrunstreak/templates/cronjob-sync.yaml
@@ -1,0 +1,68 @@
+{{- if and .Values.backend.enabled .Values.backend.cronjobs.sync.enabled }}
+# Replaces the EventBridge → sync Lambda flow. Two schedules per day,
+# matching what was running on AWS.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "myrunstreak.fullname" . }}-sync
+  labels:
+    {{- include "myrunstreak.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sync-cron
+spec:
+  schedule: {{ .Values.backend.cronjobs.sync.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 600
+      template:
+        metadata:
+          labels:
+            {{- include "myrunstreak.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: sync-cron
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: sync
+              image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
+              imagePullPolicy: {{ .Values.backend.image.pullPolicy | default "IfNotPresent" }}
+              command: ["python", "-m", "backend.jobs.sync_runs"]
+              env:
+                - name: ENVIRONMENT
+                  value: {{ .Values.backend.env.environment | default "dev" | quote }}
+                - name: LOG_LEVEL
+                  value: {{ .Values.backend.env.logLevel | default "INFO" | quote }}
+                - name: REDIS_URL
+                  value: "redis://{{ include "myrunstreak.fullname" . }}-redis:6379/0"
+                - name: CACHE_ENABLED
+                  value: {{ .Values.backend.env.cacheEnabled | default "true" | quote }}
+                - name: SUPABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                      key: supabase-url
+                - name: SUPABASE_SERVICE_ROLE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                      key: supabase-service-key
+                - name: SUPABASE_JWT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                      key: supabase-jwt-secret
+                - name: SMASHRUN_CLIENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                      key: smashrun-client-id
+                - name: SMASHRUN_CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                      key: smashrun-client-secret
+              resources:
+                {{- toYaml (.Values.backend.cronjobs.sync.resources | default dict) | nindent 16 }}
+{{- end }}

--- a/helm/myrunstreak/templates/external-secret.yaml
+++ b/helm/myrunstreak/templates/external-secret.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.externalSecret.enabled }}
+# Pulls AWS Secrets Manager `myrunstreak-app-secrets` into a k8s Secret.
+# Replaces the previously-out-of-band kubectl-applied ExternalSecret so that
+# config changes (adding a new key) ship through the same ArgoCD pipeline as
+# the rest of the chart.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "myrunstreak.fullname" . }}-app-secrets
+  labels:
+    {{- include "myrunstreak.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecret.refreshInterval | default "1h" }}
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: {{ .Values.externalSecret.secretStoreName | default "aws-secrets-manager" }}
+  target:
+    name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: supabase-url
+      remoteRef:
+        key: {{ .Values.externalSecret.awsSecretName | default "myrunstreak-app-secrets" }}
+        property: supabase_url
+    - secretKey: supabase-anon-key
+      remoteRef:
+        key: {{ .Values.externalSecret.awsSecretName | default "myrunstreak-app-secrets" }}
+        property: supabase_anon_key
+    - secretKey: supabase-service-key
+      remoteRef:
+        key: {{ .Values.externalSecret.awsSecretName | default "myrunstreak-app-secrets" }}
+        property: supabase_service_key
+    - secretKey: supabase-jwt-secret
+      remoteRef:
+        key: {{ .Values.externalSecret.awsSecretName | default "myrunstreak-app-secrets" }}
+        property: supabase_jwt_secret
+    - secretKey: smashrun-client-id
+      remoteRef:
+        key: {{ .Values.externalSecret.awsSecretName | default "myrunstreak-app-secrets" }}
+        property: smashrun_client_id
+    - secretKey: smashrun-client-secret
+      remoteRef:
+        key: {{ .Values.externalSecret.awsSecretName | default "myrunstreak-app-secrets" }}
+        property: smashrun_client_secret
+{{- end }}

--- a/helm/myrunstreak/templates/ingress.yaml
+++ b/helm/myrunstreak/templates/ingress.yaml
@@ -14,6 +14,11 @@ spec:
         {{- range .Values.ingress.hosts }}
         - {{ . }}
         {{- end }}
+        {{- if and $.Values.backend.enabled $.Values.ingress.apiHosts }}
+        {{- range $.Values.ingress.apiHosts }}
+        - {{ . }}
+        {{- end }}
+        {{- end }}
       secretName: {{ .Values.ingress.tls.secretName }}
   rules:
     {{- range .Values.ingress.hosts }}
@@ -27,5 +32,19 @@ spec:
                 name: {{ include "myrunstreak.fullname" $ }}-frontend
                 port:
                   number: {{ $.Values.service.port }}
+    {{- end }}
+    {{- if and $.Values.backend.enabled $.Values.ingress.apiHosts }}
+    {{- range $.Values.ingress.apiHosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "myrunstreak.fullname" $ }}-backend
+                port:
+                  number: 8000
+    {{- end }}
     {{- end }}
 {{- end }}

--- a/helm/myrunstreak/templates/redis.yaml
+++ b/helm/myrunstreak/templates/redis.yaml
@@ -1,0 +1,91 @@
+{{- if .Values.redis.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "myrunstreak.fullname" . }}-redis
+  labels:
+    {{- include "myrunstreak.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.redis.persistence.size | default "1Gi" }}
+  {{- if .Values.redis.persistence.storageClass }}
+  storageClassName: {{ .Values.redis.persistence.storageClass }}
+  {{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "myrunstreak.fullname" . }}-redis
+  labels:
+    {{- include "myrunstreak.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  # Redis is a cache for myrunstreak — single replica is fine; data is
+  # disposable, the PVC just keeps a warm cache through pod restarts.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "myrunstreak.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "myrunstreak.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository | default "redis" }}:{{ .Values.redis.image.tag | default "7-alpine" }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy | default "IfNotPresent" }}
+          args:
+            - redis-server
+            - --maxmemory
+            - {{ .Values.redis.maxmemory | default "128mb" | quote }}
+            - --maxmemory-policy
+            - allkeys-lru
+          ports:
+            - containerPort: 6379
+              name: redis
+          resources:
+            {{- toYaml (.Values.redis.resources | default dict) | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          livenessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 2
+            periodSeconds: 5
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "myrunstreak.fullname" . }}-redis
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "myrunstreak.fullname" . }}-redis
+  labels:
+    {{- include "myrunstreak.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: 6379
+      name: redis
+  selector:
+    {{- include "myrunstreak.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+{{- end }}

--- a/helm/myrunstreak/values.yaml
+++ b/helm/myrunstreak/values.yaml
@@ -38,7 +38,87 @@ ingress:
   hosts:
     - myrunstreak.run
     - www.myrunstreak.run
+  # API host(s) routed to the FastAPI backend (only used when backend.enabled).
+  # Phase A.2: deploy under api-v2 alongside Lambda. Cutover (Phase B) flips
+  # api.myrunstreak.run here once we're satisfied.
+  apiHosts:
+    - api-v2.myrunstreak.run
   tls:
     secretName: myrunstreak-tls
 
 env: []
+
+# ============================================================================
+# ExternalSecret (AWS Secrets Manager → k8s Secret via ESO)
+# ============================================================================
+# Replaces the previously-out-of-band ExternalSecret applied via kubectl from
+# missingtable-platform-bootstrap. Now ArgoCD-managed via this chart.
+externalSecret:
+  enabled: true
+  refreshInterval: 1h
+  secretStoreName: aws-secrets-manager
+  awsSecretName: myrunstreak-app-secrets
+  targetName: myrunstreak-secrets
+
+# ============================================================================
+# Backend (FastAPI) — disabled by default; toggle on per-env as the LKE
+# migration rolls out.
+# ============================================================================
+backend:
+  enabled: false
+  replicaCount: 1
+  revisionHistoryLimit: 3
+
+  image:
+    repository: ghcr.io/silverbeer/myrunstreak-backend
+    tag: "latest" # backend-tag
+    pullPolicy: IfNotPresent
+
+  env:
+    environment: dev
+    logLevel: INFO
+    corsAllowOrigins: "*"
+    cacheEnabled: "true"
+    cacheDefaultTtlSeconds: 60
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  cronjobs:
+    sync:
+      enabled: true
+      # 14:00 + 17:00 UTC matches the EventBridge schedule we're replacing.
+      schedule: "0 14,17 * * *"
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+
+# ============================================================================
+# Redis (cache for backend stats endpoints) — disabled by default
+# ============================================================================
+redis:
+  enabled: false
+  image:
+    repository: redis
+    tag: "7-alpine"
+    pullPolicy: IfNotPresent
+  maxmemory: "128mb"
+  persistence:
+    size: 1Gi
+    storageClass: ""  # default storage class
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 192Mi


### PR DESCRIPTION
Tracks #56. Builds on #57's backend scaffold. **Defaults to disabled** for backend/redis — merging only ships the ExternalSecret declaration into ArgoCD ownership; no new service surface until you toggle `backend.enabled=true`.

## Templates

| File | What it does |
|---|---|
| `backend.yaml` | FastAPI Deployment + Service on :8000, env from `myrunstreak-secrets` |
| `redis.yaml` | PVC + Deployment + Service. Redis 7-alpine, LRU eviction at 128mb, persistence so cache survives pod restarts |
| `cronjob-sync.yaml` | Replaces EventBridge sync at `0 14,17 * * *` UTC |
| `external-secret.yaml` | 6-key sync from AWS `myrunstreak-app-secrets` — adds `supabase_jwt_secret`, `smashrun_client_id`, `smashrun_client_secret` on top of the original 3 |
| `ingress.yaml` | Adds optional `apiHosts` routed to backend; defaults to `api-v2.myrunstreak.run` for the no-prod-risk staging cutover |

## ExternalSecret transition (already prepped out-of-band)

The AWS `myrunstreak-app-secrets` secret has been updated to include the 3 new keys. The chart-managed ExternalSecret has the same name (`myrunstreak-app-secrets`) as the existing kubectl-applied one, so ArgoCD will adopt it on next sync. The synced k8s secret name (`myrunstreak-secrets`) is unchanged; data just gains 3 extra keys.

## CI

`backend-deploy.yml` builds `backend/Dockerfile`, pushes to `ghcr.io/silverbeer/myrunstreak-backend:<sha>`, rewrites the `backend-tag` line in `values.yaml`, and commits — same pattern as `frontend-deploy.yml`. ArgoCD picks up the values bump and rolls the deployment.

## What happens on merge
1. `backend-deploy.yml` runs → builds + pushes the backend image
2. ArgoCD sync: ExternalSecret gets adopted/updated; `myrunstreak-secrets` k8s secret expands to 6 keys
3. Frontend deployment unchanged — backend.enabled is still false

## Bringing it live (separate, manual step after merge)
Bump `backend.enabled=true` and `redis.enabled=true` in `values.yaml` in a follow-up commit. ArgoCD rolls. Then point a browser at `https://api-v2.myrunstreak.run/health` to verify before cutover.

## Test plan
- [ ] `helm lint helm/myrunstreak/` passes (verified locally — clean)
- [ ] `helm template helm/myrunstreak/ --set backend.enabled=true --set redis.enabled=true` produces all 9 expected resources (verified)
- [ ] CI: backend-deploy workflow builds + pushes image successfully
- [ ] After merge: ArgoCD sync stays Healthy/Synced
- [ ] After merge: `kubectl get secret myrunstreak-secrets -n myrunstreak -o jsonpath='{.data}'` shows 6 keys
- [ ] Toggle `backend.enabled=true` → pod rolls, `/health` reachable inside cluster
- [ ] DNS for `api-v2.myrunstreak.run` resolves to LKE LB → external `/health` reachable

## Phase B (separate PR)
Move the `api.myrunstreak.run` Route 53 record from the API Gateway alias to the LKE ingress, drop `api-v2`, and let ArgoCD reissue the cert.

## Phase C (separate PR)
Terraform destroy the Lambda + API Gateway + ECR + EventBridge resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)