### PR TITLE
chore: enable backend + redis on LKE (Phase A.3)

### DIFF
--- a/helm/myrunstreak/values.yaml
+++ b/helm/myrunstreak/values.yaml
@@ -65,7 +65,7 @@ externalSecret:
 # migration rolls out.
 # ============================================================================
 backend:
-  enabled: false
+  enabled: true
   replicaCount: 1
   revisionHistoryLimit: 3
 
@@ -106,7 +106,7 @@ backend:
 # Redis (cache for backend stats endpoints) — disabled by default
 # ============================================================================
 redis:
-  enabled: false
+  enabled: true
   image:
     repository: redis
     tag: "7-alpine"


### PR DESCRIPTION
Tracks #56. Tiny PR — flips two booleans in values.yaml so ArgoCD rolls the FastAPI backend, Redis cache, and sync CronJob alongside the existing frontend.

## Diff
```diff
backend:
-  enabled: false
+  enabled: true
...
redis:
-  enabled: false
+  enabled: true
```

## What ArgoCD does on merge
- Creates `myrunstreak-redis` PVC + Deployment + Service
- Creates `myrunstreak-backend` Deployment + Service (uses `myrunstreak-backend:5056db0` from PR #58's CI build)
- Creates `myrunstreak-sync` CronJob (suspended until 14:00 UTC tomorrow's first run; can be triggered manually with `kubectl create job --from=cronjob/...`)
- Updates `myrunstreak` Ingress to add `api-v2.myrunstreak.run` host → backend service. cert-manager issues a TLS cert.

## Test plan
- [ ] ArgoCD `myrunstreak` app stays Synced/Healthy
- [ ] `kubectl get pods -n myrunstreak` shows backend + redis pods Running
- [ ] `kubectl exec -it <backend-pod> -- curl localhost:8000/health` → `{"status":"ok"}`
- [ ] Add Route 53 record `api-v2.myrunstreak.run` → LKE LB IP (manual step)
- [ ] cert-manager issues TLS cert for `api-v2.myrunstreak.run`
- [ ] External: `curl https://api-v2.myrunstreak.run/health` → 200
- [ ] With JWT: `curl -H "Authorization: Bearer ..." https://api-v2.myrunstreak.run/stats/overall` → real data
- [ ] Redis: cache hits visible after second identical request

## Phase B (next)
Move the `api.myrunstreak.run` Route 53 record from API Gateway alias → LKE LB. Drop `api-v2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)