### PR TITLE
fix: add SUPABASE_KEY env to backend (legacy var)

### DIFF
--- a/helm/myrunstreak/templates/backend.yaml
+++ b/helm/myrunstreak/templates/backend.yaml
@@ -49,6 +49,12 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
                   key: supabase-service-key
+            # Legacy alias used by src/shared/supabase_client.py — same value.
+            - name: SUPABASE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                  key: supabase-service-key
             - name: SUPABASE_JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/helm/myrunstreak/templates/cronjob-sync.yaml
+++ b/helm/myrunstreak/templates/cronjob-sync.yaml
@@ -48,6 +48,11 @@ spec:
                     secretKeyRef:
                       name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
                       key: supabase-service-key
+                - name: SUPABASE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                      key: supabase-service-key
                 - name: SUPABASE_JWT_SECRET
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
## Why
First real call to `/stats/overall` against the LKE backend returned 500 with:
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for SupabaseSettings
supabase_key
  Field required
```

`src/shared/supabase_client.py` (lifted into the image as-is) has a `SupabaseSettings` pydantic model that reads `SUPABASE_KEY`, but the deployment sets `SUPABASE_SERVICE_ROLE_KEY` (matching the new `backend/config.py` naming).

## Fix
Add `SUPABASE_KEY` env mapped to the same secret value (`supabase-service-key`) in both the backend Deployment and the sync CronJob. Will collapse to one var when `src/shared/` moves under `backend/` in Phase C.

## Test plan
- [ ] CI green
- [ ] Pod rolls cleanly
- [ ] `curl -H "Authorization: Bearer ..." https://api-v2.myrunstreak.run/stats/overall` returns 200 with real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)