### PR TITLE
chore: add api.myrunstreak.run to ingress (Phase B step 1)

### DIFF
--- a/helm/myrunstreak/values.yaml
+++ b/helm/myrunstreak/values.yaml
@@ -39,9 +39,11 @@ ingress:
     - myrunstreak.run
     - www.myrunstreak.run
   # API host(s) routed to the FastAPI backend (only used when backend.enabled).
-  # Phase A.2: deploy under api-v2 alongside Lambda. Cutover (Phase B) flips
-  # api.myrunstreak.run here once we're satisfied.
+  # Phase B step 1: declare api.myrunstreak.run on the ingress alongside api-v2
+  # so cert-manager has it ready when the Route 53 record flips. Step 2 is the
+  # DNS cutover. api-v2 stays for the moment as a fallback; removed in step 3.
   apiHosts:
+    - api.myrunstreak.run
     - api-v2.myrunstreak.run
   tls:
     secretName: myrunstreak-tls


### PR DESCRIPTION
Phase B step 1 of 3.

## Diff
```diff
apiHosts:
+  - api.myrunstreak.run
   - api-v2.myrunstreak.run
```

## What happens on merge
- ArgoCD applies updated ingress: now declares both `api.myrunstreak.run` and `api-v2.myrunstreak.run` as backend routes.
- cert-manager tries to issue a renewed cert that includes `api.myrunstreak.run`. The HTTP-01 challenge will **fail** until step 2 because the DNS record still points at API Gateway. **This is fine** — the existing cert (covering myrunstreak.run, www, api-v2) keeps serving for the existing hosts. api-v2 keeps working.
- `api.myrunstreak.run` continues to be served by AWS API Gateway → Lambda. No traffic shift yet.

## Step 2 (next, manual)
Update the Route 53 A record for `api.myrunstreak.run`:
- Was: ALIAS to `d-7oxftr7si7.execute-api.us-east-2.amazonaws.com`
- Becomes: A record pointing to `143.42.127.151` (LKE LB)

DNS propagates (~30s), cert-manager retries HTTP-01 → succeeds, cert now covers all 4 hosts. Traffic moves to LKE.

## Step 3 (cleanup PR)
Remove api-v2 from `apiHosts` and delete the api-v2 Route 53 record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)