### PR TITLE
chore: drop api-v2.myrunstreak.run after cutover (Phase B step 3)

### DIFF
--- a/helm/myrunstreak/values.yaml
+++ b/helm/myrunstreak/values.yaml
@@ -39,12 +39,8 @@ ingress:
     - myrunstreak.run
     - www.myrunstreak.run
   # API host(s) routed to the FastAPI backend (only used when backend.enabled).
-  # Phase B step 1: declare api.myrunstreak.run on the ingress alongside api-v2
-  # so cert-manager has it ready when the Route 53 record flips. Step 2 is the
-  # DNS cutover. api-v2 stays for the moment as a fallback; removed in step 3.
   apiHosts:
     - api.myrunstreak.run
-    - api-v2.myrunstreak.run
   tls:
     secretName: myrunstreak-tls
 


### PR DESCRIPTION
Phase B step 3 — final cleanup. `api.myrunstreak.run` is now serving from LKE end-to-end (verified: 4-host cert, real-traffic test against `/stats/overall`). Removing the api-v2 fallback.

## Diff
```diff
apiHosts:
   - api.myrunstreak.run
-  - api-v2.myrunstreak.run
```

## Out-of-band step (already done)
Deleted `api-v2.myrunstreak.run` Route 53 A record.

## What ArgoCD does on merge
- Updates the ingress to remove the api-v2 host
- cert-manager renews the cert without api-v2 in subjectAltName

## Test plan
- [ ] ArgoCD sync stays Synced/Healthy
- [ ] `dig api-v2.myrunstreak.run` returns nothing (already deleted)
- [ ] `dig api.myrunstreak.run` still returns 143.42.127.151
- [ ] Dashboard at https://myrunstreak.run continues loading stats from LKE

🤖 Generated with [Claude Code](https://claude.com/claude-code)