### PR TITLE
feat: real longest_streak + top_streaks

### DIFF
--- a/backend/routes/stats.py
+++ b/backend/routes/stats.py
@@ -6,11 +6,14 @@ heavy ones are wrapped in @cached.
 
 from __future__ import annotations
 
+from datetime import date
 from typing import Any, cast
 from uuid import UUID
+from zoneinfo import ZoneInfo
 
 from backend.auth import authenticate_request
 from backend.cache import cached
+from backend.streaks import compute_streaks
 from fastapi import APIRouter, Depends, Query
 from src.shared.supabase_client import get_supabase_client
 from src.shared.supabase_ops import RunsRepository
@@ -34,22 +37,49 @@ async def get_overall_stats(
 @cached(ttl=60, key_prefix="stats:streaks")
 async def _streaks(user_id: UUID) -> dict[str, Any]:
     supabase = get_supabase_client()
-    runs_repo = RunsRepository(supabase)
-    current_streak = runs_repo.get_current_streak(user_id)
+
+    # Pull every distinct run-date for this user. With 4-5k rows the
+    # round-trip is fine; if a user ever exceeds 10k we'd push this into
+    # a Supabase RPC.
+    rows = (
+        supabase.table("runs")
+        .select("start_date")
+        .eq("user_id", str(user_id))
+        .order("start_date", desc=False)
+        .limit(10000)
+        .execute()
+    )
+    data = cast(list[dict[str, Any]], rows.data)
+    run_dates = [date.fromisoformat(r["start_date"]) for r in data]
+
+    today = _today_local()
+    streaks = compute_streaks(run_dates, today)
+
+    current = next((s for s in streaks if s.is_current), None)
+    longest_length = streaks[0].length_days if streaks else 0
+
+    top = [
+        {
+            "start_date": s.start_date.isoformat(),
+            "end_date": s.end_date.isoformat(),
+            "length_days": s.length_days,
+            "is_current": s.is_current,
+        }
+        for s in streaks[:5]
+    ]
+
     return {
-        "current_streak": current_streak,
-        "longest_streak": current_streak,  # TODO: compute longest properly
-        "top_streaks": [
-            {
-                "start_date": None,
-                "end_date": None,
-                "length_days": current_streak,
-                "is_current": True,
-            }
-        ]
-        if current_streak > 0
-        else [],
+        "current_streak": current.length_days if current else 0,
+        "longest_streak": longest_length,
+        "top_streaks": top,
     }
+
+
+def _today_local() -> date:
+    """Match get_current_streak's America/New_York anchor so /streaks
+    agrees with the legacy single-streak endpoint about what "today" is."""
+    from datetime import datetime
+    return datetime.now(ZoneInfo("America/New_York")).date()
 
 
 @router.get("/streaks")

--- a/backend/streaks.py
+++ b/backend/streaks.py
@@ -1,0 +1,56 @@
+"""Pure streak computation — no I/O, fully unit-testable.
+
+Given a set of dates the user ran, walks them to identify every
+maximal run of consecutive days and tags whichever one (if any)
+is still active today.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import date, timedelta
+
+
+@dataclass(frozen=True)
+class Streak:
+    start_date: date
+    end_date: date
+    length_days: int
+    is_current: bool
+
+
+def compute_streaks(run_dates: Iterable[date], today: date) -> list[Streak]:
+    """Group run_dates into maximal consecutive-day windows.
+
+    A streak is ``is_current`` if its end_date is ``today`` or ``today - 1``.
+    The "yesterday" allowance matches get_current_streak's behavior so the
+    user doesn't see "Current: 0" before they've had a chance to run today.
+
+    Returns the streaks sorted descending by length, then by end_date.
+    """
+    unique = sorted(set(run_dates))
+    if not unique:
+        return []
+
+    streaks: list[Streak] = []
+    start = unique[0]
+    prev = unique[0]
+
+    for d in unique[1:]:
+        if d == prev + timedelta(days=1):
+            prev = d
+            continue
+        streaks.append(_make(start, prev, today))
+        start = d
+        prev = d
+    streaks.append(_make(start, prev, today))
+
+    streaks.sort(key=lambda s: (-s.length_days, -s.end_date.toordinal()))
+    return streaks
+
+
+def _make(start: date, end: date, today: date) -> Streak:
+    length = (end - start).days + 1
+    is_current = end == today or end == today - timedelta(days=1)
+    return Streak(start_date=start, end_date=end, length_days=length, is_current=is_current)

--- a/backend/tests/test_streaks.py
+++ b/backend/tests/test_streaks.py
@@ -1,0 +1,89 @@
+"""Tests for streak computation."""
+
+from datetime import date
+
+from backend.streaks import compute_streaks
+
+TODAY = date(2026, 5, 3)
+
+
+class TestComputeStreaks:
+    def test_empty(self) -> None:
+        assert compute_streaks([], TODAY) == []
+
+    def test_single_day(self) -> None:
+        s = compute_streaks([TODAY], TODAY)
+        assert len(s) == 1
+        assert s[0].length_days == 1
+        assert s[0].is_current is True
+
+    def test_consecutive_days_one_streak(self) -> None:
+        days = [date(2026, 5, 1), date(2026, 5, 2), date(2026, 5, 3)]
+        s = compute_streaks(days, TODAY)
+        assert len(s) == 1
+        assert s[0].length_days == 3
+        assert s[0].start_date == date(2026, 5, 1)
+        assert s[0].end_date == date(2026, 5, 3)
+        assert s[0].is_current is True
+
+    def test_two_separate_streaks(self) -> None:
+        days = [
+            date(2026, 4, 1), date(2026, 4, 2), date(2026, 4, 3),  # 3-day
+            date(2026, 5, 1), date(2026, 5, 2),  # 2-day, ending yesterday
+        ]
+        s = compute_streaks(days, TODAY)
+        assert len(s) == 2
+        assert s[0].length_days == 3
+        assert s[0].is_current is False
+        assert s[1].length_days == 2
+        assert s[1].is_current is True  # yesterday counts
+
+    def test_streak_ending_yesterday_is_current(self) -> None:
+        days = [date(2026, 5, 1), date(2026, 5, 2)]  # 2-day, ends yesterday
+        s = compute_streaks(days, TODAY)
+        assert s[0].is_current is True
+
+    def test_streak_ending_two_days_ago_is_not_current(self) -> None:
+        days = [date(2026, 5, 1)]  # ends 2 days ago
+        s = compute_streaks(days, TODAY)
+        assert s[0].is_current is False
+
+    def test_dedupes_same_day_runs(self) -> None:
+        days = [date(2026, 5, 1), date(2026, 5, 1), date(2026, 5, 2)]
+        s = compute_streaks(days, TODAY)
+        assert len(s) == 1
+        assert s[0].length_days == 2  # not 3
+
+    def test_unsorted_input(self) -> None:
+        days = [date(2026, 5, 3), date(2026, 5, 1), date(2026, 5, 2)]
+        s = compute_streaks(days, TODAY)
+        assert len(s) == 1
+        assert s[0].length_days == 3
+
+    def test_sorted_descending_by_length(self) -> None:
+        days = [
+            date(2026, 1, 1), date(2026, 1, 2),  # 2-day (older)
+            date(2026, 4, 1), date(2026, 4, 2), date(2026, 4, 3),  # 3-day
+            date(2026, 5, 3),  # 1-day, today
+        ]
+        s = compute_streaks(days, TODAY)
+        assert [x.length_days for x in s] == [3, 2, 1]
+
+    def test_long_streak(self) -> None:
+        # 100-day streak ending today
+        days = [date(2026, 5, 3) - __import__("datetime").timedelta(days=i) for i in range(100)]
+        s = compute_streaks(days, TODAY)
+        assert len(s) == 1
+        assert s[0].length_days == 100
+        assert s[0].is_current is True
+
+    def test_gap_of_one_day_breaks_streak(self) -> None:
+        days = [
+            date(2026, 5, 1), date(2026, 5, 2),  # 2-day
+            # missing 5/3
+            date(2026, 5, 4),  # 1-day
+        ]
+        s = compute_streaks(days, date(2026, 5, 4))
+        assert len(s) == 2
+        assert s[0].length_days == 2
+        assert s[1].length_days == 1


### PR DESCRIPTION
## Why
\`/stats/streaks\` returned \`current_streak\` as \`longest_streak\` — a placeholder. Today they happen to match because the user's current streak is also their longest, but the moment a rest day breaks the current streak, the "Longest" tile would drop along with it.

## What
- \`backend/streaks.py\` — pure \`compute_streaks(dates, today)\` walker. No I/O.
- \`backend/routes/stats.py\` — endpoint pulls every distinct \`runs.start_date\` for the user, runs the walker locally, returns:
  - \`current_streak\`: length of the streak ending today/yesterday (0 if neither has a run)
  - \`longest_streak\`: max length across all of history
  - \`top_streaks\`: top 5 by length, each with real \`start_date\` / \`end_date\` / \`is_current\`
- 11 unit tests on the pure function (\`backend/tests/test_streaks.py\`)

## Notes
- Date arithmetic anchored to America/New_York to match the existing \`get_current_streak\` repo method
- For users with >10k runs we'd push the walker into a Supabase RPC; current scale (~5k) is fine in Python
- The Phase 2 frontend dashboard already reads \`current_streak\` and \`longest_streak\` from this endpoint, so the StreakHero will switch from "Longest = same as current" to the real lifetime max as soon as this rolls out

## Test plan
- [ ] CI green (32 tests total in backend/)
- [ ] After backend image redeploys: \`curl -H "Authorization: Bearer ..." https://api.myrunstreak.run/stats/streaks | jq\` shows real longest_streak and a populated top_streaks array
- [ ] Dashboard "Longest streak" tile shows the lifetime max (matches current today; will diverge the day a rest day ends the current streak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)