### PR TITLE
feat: stk CLI auth via backend proxy

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,7 @@ LOG_LEVEL=INFO
 CORS_ALLOW_ORIGINS=*
 
 SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 SUPABASE_JWT_SECRET=your-jwt-secret
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -13,6 +13,7 @@ class Settings(BaseSettings):
     cors_allow_origins: str = "*"
 
     supabase_url: str
+    supabase_anon_key: str
     supabase_service_role_key: str
     supabase_jwt_secret: str
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
-    "pydantic>=2.9.0",
+    "pydantic[email]>=2.9.0",
     "pydantic-settings>=2.5.0",
     "redis>=5.0.0",
     "PyJWT[crypto]>=2.9.0",
@@ -15,7 +15,7 @@ dependencies = [
     "httpx>=0.27.0",
     "authlib>=1.3.0",
     "boto3>=1.35.0",  # Pulled in via src/shared/smashrun. Will go away once we
-                      # cut over to k8s-secret-driven config in Phase 2.
+    # cut over to k8s-secret-driven config in Phase 2.
     "python-dateutil>=2.9.0",
     "pytz>=2024.1",
     "structlog>=24.0.0",

--- a/backend/routes/auth_routes.py
+++ b/backend/routes/auth_routes.py
@@ -1,7 +1,11 @@
-"""/auth/* — SmashRun OAuth flow + token storage.
+"""/auth/* — Supabase Auth proxy + SmashRun OAuth linking.
 
-Only /auth/store-tokens requires Supabase auth; the others are public so an
-unauthenticated user can begin the OAuth handshake.
+The signup/login/refresh endpoints proxy to Supabase Auth so that clients
+(stk CLI, web frontend) only need to know about api.myrunstreak.run.
+Supabase URL/keys never leave the backend.
+
+The link/login-url + link/callback endpoints handle SmashRun OAuth account
+linking after a user is authenticated.
 """
 
 from __future__ import annotations
@@ -10,8 +14,11 @@ import logging
 from typing import Any
 from uuid import UUID
 
+import httpx
 from backend.auth import authenticate_request
+from backend.config import get_settings
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from pydantic import BaseModel, EmailStr
 from src.shared.secrets import get_smashrun_oauth_credentials
 from src.shared.smashrun import SmashRunAPIClient, SmashRunOAuthClient
 from src.shared.supabase_client import get_supabase_client
@@ -20,6 +27,125 @@ from src.shared.supabase_ops import TokenRepository, UsersRepository
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/auth", tags=["auth"])
+
+_SUPABASE_TIMEOUT = 10.0
+
+
+class SignupRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str
+
+
+def _supabase_auth_url(path: str) -> str:
+    settings = get_settings()
+    return f"{settings.supabase_url.rstrip('/')}/auth/v1{path}"
+
+
+def _supabase_headers() -> dict[str, str]:
+    settings = get_settings()
+    return {
+        "apikey": settings.supabase_anon_key,
+        "Content-Type": "application/json",
+    }
+
+
+def _proxy_supabase_auth(path: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """POST to Supabase Auth and surface its error JSON on failure.
+
+    Supabase returns ``{"msg": "..."}`` on most auth errors; we forward both
+    the status code and a sanitized message so the CLI/frontend can show
+    something useful without leaking implementation details.
+    """
+    try:
+        response = httpx.post(
+            _supabase_auth_url(path),
+            headers=_supabase_headers(),
+            json=payload,
+            timeout=_SUPABASE_TIMEOUT,
+        )
+    except httpx.RequestError as exc:
+        logger.exception("Supabase auth request failed")
+        raise HTTPException(status_code=503, detail="Auth service unavailable") from exc
+
+    if response.status_code >= 400:
+        detail = "Authentication failed"
+        try:
+            body = response.json()
+            if isinstance(body, dict):
+                detail = body.get("msg") or body.get("error_description") or body.get("error") or detail
+        except ValueError:
+            pass
+        raise HTTPException(status_code=response.status_code, detail=detail)
+
+    result: dict[str, Any] = response.json()
+    return result
+
+
+@router.post("/signup")
+async def signup(body: SignupRequest) -> dict[str, Any]:
+    """Create a new myrunstreak account.
+
+    Returns a session immediately when email-confirmation is disabled.
+    When enabled, returns ``session=None`` and a message instructing the
+    user to confirm via email before logging in.
+    """
+    data = _proxy_supabase_auth("/signup", {"email": body.email, "password": body.password})
+    user = data.get("user") or {}
+    session = data.get("session")
+    if session:
+        return {
+            "user": {"id": user.get("id"), "email": user.get("email")},
+            "access_token": session["access_token"],
+            "refresh_token": session["refresh_token"],
+            "expires_in": session.get("expires_in"),
+            "message": "Account created.",
+        }
+    return {
+        "user": {"id": user.get("id"), "email": user.get("email")},
+        "access_token": None,
+        "refresh_token": None,
+        "expires_in": None,
+        "message": "Account created. Check your email to confirm before logging in.",
+    }
+
+
+@router.post("/login")
+async def login(body: LoginRequest) -> dict[str, Any]:
+    """Exchange email + password for an access/refresh token pair."""
+    data = _proxy_supabase_auth(
+        "/token?grant_type=password",
+        {"email": body.email, "password": body.password},
+    )
+    user = data.get("user") or {}
+    return {
+        "access_token": data["access_token"],
+        "refresh_token": data["refresh_token"],
+        "expires_in": data.get("expires_in"),
+        "user": {"id": user.get("id"), "email": user.get("email")},
+    }
+
+
+@router.post("/refresh")
+async def refresh(body: RefreshRequest) -> dict[str, Any]:
+    """Exchange a refresh token for a fresh access/refresh pair."""
+    data = _proxy_supabase_auth(
+        "/token?grant_type=refresh_token",
+        {"refresh_token": body.refresh_token},
+    )
+    return {
+        "access_token": data["access_token"],
+        "refresh_token": data["refresh_token"],
+        "expires_in": data.get("expires_in"),
+    }
 
 
 @router.get("/login-url")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -6,6 +6,7 @@ Sets the env vars Settings() requires before any backend module is imported.
 import os
 
 os.environ.setdefault("SUPABASE_URL", "https://test.supabase.co")
+os.environ.setdefault("SUPABASE_ANON_KEY", "test-anon-key")
 os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "test-service-key")
 os.environ.setdefault(
     "SUPABASE_JWT_SECRET", "test-jwt-secret-needs-to-be-long-enough-for-hs256"

--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -1,0 +1,168 @@
+"""Tests for /auth/{signup,login,refresh} — the Supabase Auth proxy.
+
+We mock httpx.post so the endpoints can be exercised without a real Supabase.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _client() -> TestClient:
+    from backend.app import create_app
+
+    return TestClient(create_app())
+
+
+def _mock_response(status_code: int, body: Any) -> MagicMock:
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.json.return_value = body
+    return response
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return _client()
+
+
+# ---------------------------------------------------------------------------
+# /auth/signup
+# ---------------------------------------------------------------------------
+
+
+def test_signup_returns_session_when_email_confirmation_disabled(client: TestClient) -> None:
+    supabase_body = {
+        "user": {"id": "00000000-0000-0000-0000-000000000001", "email": "new@example.com"},
+        "session": {
+            "access_token": "atk",
+            "refresh_token": "rtk",
+            "expires_in": 3600,
+        },
+    }
+    with patch("backend.routes.auth_routes.httpx.post", return_value=_mock_response(200, supabase_body)):
+        r = client.post("/auth/signup", json={"email": "new@example.com", "password": "hunter2hunter2"})
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["access_token"] == "atk"
+    assert body["refresh_token"] == "rtk"
+    assert body["user"] == {"id": "00000000-0000-0000-0000-000000000001", "email": "new@example.com"}
+    assert "Account created" in body["message"]
+
+
+def test_signup_returns_no_session_when_confirmation_required(client: TestClient) -> None:
+    supabase_body = {
+        "user": {"id": "00000000-0000-0000-0000-000000000002", "email": "pending@example.com"},
+        "session": None,
+    }
+    with patch("backend.routes.auth_routes.httpx.post", return_value=_mock_response(200, supabase_body)):
+        r = client.post(
+            "/auth/signup", json={"email": "pending@example.com", "password": "hunter2hunter2"}
+        )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["access_token"] is None
+    assert body["refresh_token"] is None
+    assert "Check your email" in body["message"]
+
+
+def test_signup_propagates_supabase_error(client: TestClient) -> None:
+    supabase_body = {"msg": "User already registered"}
+    with patch(
+        "backend.routes.auth_routes.httpx.post",
+        return_value=_mock_response(422, supabase_body),
+    ):
+        r = client.post("/auth/signup", json={"email": "dup@example.com", "password": "hunter2hunter2"})
+
+    assert r.status_code == 422
+    assert r.json()["detail"] == "User already registered"
+
+
+def test_signup_rejects_invalid_email(client: TestClient) -> None:
+    r = client.post("/auth/signup", json={"email": "not-an-email", "password": "hunter2hunter2"})
+    assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# /auth/login
+# ---------------------------------------------------------------------------
+
+
+def test_login_returns_session(client: TestClient) -> None:
+    supabase_body = {
+        "access_token": "atk",
+        "refresh_token": "rtk",
+        "expires_in": 3600,
+        "user": {"id": "00000000-0000-0000-0000-000000000003", "email": "u@example.com"},
+    }
+    with patch("backend.routes.auth_routes.httpx.post", return_value=_mock_response(200, supabase_body)):
+        r = client.post("/auth/login", json={"email": "u@example.com", "password": "hunter2hunter2"})
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["access_token"] == "atk"
+    assert body["refresh_token"] == "rtk"
+    assert body["user"]["email"] == "u@example.com"
+
+
+def test_login_propagates_invalid_credentials(client: TestClient) -> None:
+    supabase_body = {"error": "invalid_grant", "error_description": "Invalid login credentials"}
+    with patch(
+        "backend.routes.auth_routes.httpx.post",
+        return_value=_mock_response(400, supabase_body),
+    ):
+        r = client.post("/auth/login", json={"email": "u@example.com", "password": "wrong"})
+
+    assert r.status_code == 400
+    assert r.json()["detail"] == "Invalid login credentials"
+
+
+# ---------------------------------------------------------------------------
+# /auth/refresh
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_returns_new_tokens(client: TestClient) -> None:
+    supabase_body = {
+        "access_token": "atk2",
+        "refresh_token": "rtk2",
+        "expires_in": 3600,
+    }
+    with patch("backend.routes.auth_routes.httpx.post", return_value=_mock_response(200, supabase_body)):
+        r = client.post("/auth/refresh", json={"refresh_token": "rtk1"})
+
+    assert r.status_code == 200
+    assert r.json() == {"access_token": "atk2", "refresh_token": "rtk2", "expires_in": 3600}
+
+
+def test_refresh_rejects_expired_token(client: TestClient) -> None:
+    supabase_body = {"error": "invalid_grant", "error_description": "Refresh token expired"}
+    with patch(
+        "backend.routes.auth_routes.httpx.post",
+        return_value=_mock_response(400, supabase_body),
+    ):
+        r = client.post("/auth/refresh", json={"refresh_token": "expired"})
+
+    assert r.status_code == 400
+    assert r.json()["detail"] == "Refresh token expired"
+
+
+# ---------------------------------------------------------------------------
+# Network/transport failure surfaces 503
+# ---------------------------------------------------------------------------
+
+
+def test_supabase_unreachable_returns_503(client: TestClient) -> None:
+    with patch(
+        "backend.routes.auth_routes.httpx.post",
+        side_effect=httpx.ConnectError("connection refused"),
+    ):
+        r = client.post("/auth/login", json={"email": "u@example.com", "password": "hunter2hunter2"})
+
+    assert r.status_code == 503
+    assert "unavailable" in r.json()["detail"].lower()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -397,6 +397,28 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
 name = "fakeredis"
 version = "2.35.1"
 source = { registry = "https://pypi.org/simple" }
@@ -898,7 +920,7 @@ dependencies = [
     { name = "boto3" },
     { name = "fastapi" },
     { name = "httpx" },
-    { name = "pydantic" },
+    { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-dateutil" },
@@ -929,7 +951,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
-    { name = "pydantic", specifier = ">=2.9.0" },
+    { name = "pydantic", extras = ["email"], specifier = ">=2.9.0" },
     { name = "pydantic-settings", specifier = ">=2.5.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.9.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
@@ -1093,6 +1115,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981, upload-time = "2026-04-20T14:46:41.402Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
 ]
 
 [[package]]

--- a/helm/myrunstreak/templates/backend.yaml
+++ b/helm/myrunstreak/templates/backend.yaml
@@ -44,6 +44,11 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
                   key: supabase-url
+            - name: SUPABASE_ANON_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                  key: supabase-anon-key
             - name: SUPABASE_SERVICE_ROLE_KEY
               valueFrom:
                 secretKeyRef:

--- a/src/cli/api.py
+++ b/src/cli/api.py
@@ -1,85 +1,138 @@
-"""API client for stk CLI."""
+"""API client for stk CLI.
 
-import json
+Talks only to api.myrunstreak.run. Bearer JWTs come from cli.session;
+the CLI never knows the underlying auth provider's URL or anon key.
+"""
+
+from __future__ import annotations
+
 import os
 import sys
-from pathlib import Path
 from typing import Any
 
 import httpx
 
+from cli import session as session_mod
 from cli.display import display_error, display_info
 
 DEFAULT_API_URL = "https://api.myrunstreak.run"
 TIMEOUT = 30.0
 
-# Config paths
-CONFIG_DIR = Path.home() / ".config" / "stk"
-CONFIG_FILE = CONFIG_DIR / "config.json"
-
 
 def get_api_url() -> str:
-    """Get API base URL from environment or use default."""
+    """Base URL for the myrunstreak API. Override with $STK_API_URL for dev."""
     return os.getenv("STK_API_URL", os.getenv("API_BASE_URL", DEFAULT_API_URL))
 
 
-def get_user_id() -> str | None:
-    """Get user_id from config file."""
-    if not CONFIG_FILE.exists():
-        return None
+# ---------------------------------------------------------------------------
+# Unauthenticated calls — login/signup/refresh use these.
+# ---------------------------------------------------------------------------
+
+
+def post_unauth(
+    endpoint: str,
+    data: dict[str, Any] | None = None,
+    timeout: float | None = None,
+) -> dict[str, Any]:
+    """POST without injecting auth — for /auth/login, /auth/signup, /auth/refresh."""
+    url = f"{get_api_url()}/{endpoint.lstrip('/')}"
     try:
-        with open(CONFIG_FILE) as f:
-            config: dict[str, str] = json.load(f)
-            user_id: str | None = config.get("user_id")
-            return user_id
-    except (json.JSONDecodeError, OSError):
-        return None
-
-
-def request(endpoint: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
-    """
-    Make HTTP GET request to API endpoint.
-
-    Automatically includes user_id from config in all requests.
-
-    Args:
-        endpoint: API endpoint path (without leading slash)
-        params: Optional query parameters
-
-    Returns:
-        JSON response data
-
-    Raises:
-        SystemExit: On request failure
-    """
-    # Get user_id from config
-    user_id = get_user_id()
-    if not user_id:
-        display_error("Not logged in or missing user ID")
-        display_info("Run 'stk auth login' to authenticate")
-        sys.exit(1)
-
-    # Add user_id to params
-    if params is None:
-        params = {}
-    params["user_id"] = user_id
-
-    url = f"{get_api_url()}/{endpoint}"
-
-    try:
-        response = httpx.get(url, params=params, timeout=TIMEOUT)
+        response = httpx.post(url, json=data, timeout=timeout or TIMEOUT)
         response.raise_for_status()
         result: dict[str, Any] = response.json()
         return result
-    except httpx.TimeoutException:
-        display_error(f"Request timed out after {TIMEOUT}s")
-        sys.exit(1)
     except httpx.HTTPStatusError as e:
-        display_error(f"HTTP {e.response.status_code}: {e.response.text}")
+        _exit_with_error(e.response)
+    except httpx.TimeoutException:
+        display_error(f"Request timed out after {timeout or TIMEOUT}s")
         sys.exit(1)
     except httpx.RequestError as e:
         display_error(f"Request failed: {e}")
         sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated calls — load session, attach Bearer, refresh on 401.
+# ---------------------------------------------------------------------------
+
+
+def _require_session() -> session_mod.Session:
+    s = session_mod.load()
+    if s is None:
+        display_error("Not logged in")
+        display_info("Run 'stk auth login' to authenticate")
+        sys.exit(1)
+    return s
+
+
+def _refresh_session(s: session_mod.Session) -> session_mod.Session | None:
+    """Try to refresh; return new session or None if refresh failed."""
+    try:
+        data = post_unauth("auth/refresh", {"refresh_token": s.refresh_token})
+    except SystemExit:
+        return None
+    return session_mod.save(
+        access_token=data["access_token"],
+        refresh_token=data["refresh_token"],
+        expires_in=data.get("expires_in"),
+        email=s.email,
+    )
+
+
+def _ensure_fresh(s: session_mod.Session) -> session_mod.Session:
+    if not s.is_expired():
+        return s
+    refreshed = _refresh_session(s)
+    if refreshed is None:
+        display_error("Session expired and refresh failed")
+        display_info("Run 'stk auth login' to sign in again")
+        sys.exit(1)
+    return refreshed
+
+
+def _auth_headers(s: session_mod.Session) -> dict[str, str]:
+    return {"Authorization": f"Bearer {s.access_token}"}
+
+
+def _exit_with_error(response: httpx.Response) -> None:
+    """Print a useful message from a non-2xx response, then exit."""
+    detail = response.text
+    try:
+        body = response.json()
+        if isinstance(body, dict):
+            detail = body.get("detail") or body.get("message") or detail
+    except ValueError:
+        pass
+    display_error(f"HTTP {response.status_code}: {detail}")
+    sys.exit(1)
+
+
+def request(endpoint: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Authenticated GET. Refreshes the access token transparently on expiry/401."""
+    s = _ensure_fresh(_require_session())
+    url = f"{get_api_url()}/{endpoint.lstrip('/')}"
+    try:
+        response = httpx.get(url, params=params, headers=_auth_headers(s), timeout=TIMEOUT)
+    except httpx.TimeoutException:
+        display_error(f"Request timed out after {TIMEOUT}s")
+        sys.exit(1)
+    except httpx.RequestError as e:
+        display_error(f"Request failed: {e}")
+        sys.exit(1)
+
+    if response.status_code == 401:
+        refreshed = _refresh_session(s)
+        if refreshed is None:
+            display_error("Session expired")
+            display_info("Run 'stk auth login' to sign in again")
+            sys.exit(1)
+        response = httpx.get(url, params=params, headers=_auth_headers(refreshed), timeout=TIMEOUT)
+
+    if response.status_code >= 400:
+        _exit_with_error(response)
+
+    result: dict[str, Any] = response.json()
+    return result
 
 
 def post_request(
@@ -88,55 +141,41 @@ def post_request(
     params: dict[str, Any] | None = None,
     timeout: float | None = None,
 ) -> dict[str, Any]:
-    """
-    Make HTTP POST request to API endpoint.
-
-    Automatically includes user_id from config in query params.
-
-    Args:
-        endpoint: API endpoint path (without leading slash)
-        data: Request body as JSON
-        params: Optional query parameters
-        timeout: Optional custom timeout (for long-running operations)
-
-    Returns:
-        JSON response data
-
-    Raises:
-        SystemExit: On request failure
-    """
-    # Get user_id from config
-    user_id = get_user_id()
-    if not user_id:
-        display_error("Not logged in or missing user ID")
-        display_info("Run 'stk auth login' to authenticate")
-        sys.exit(1)
-
-    # Add user_id to params
-    if params is None:
-        params = {}
-    params["user_id"] = user_id
-
-    url = f"{get_api_url()}/{endpoint}"
+    """Authenticated POST. Same auto-refresh behavior as request()."""
+    s = _ensure_fresh(_require_session())
+    url = f"{get_api_url()}/{endpoint.lstrip('/')}"
     request_timeout = timeout if timeout else TIMEOUT
-
     try:
-        response = httpx.post(url, json=data, params=params, timeout=request_timeout)
-        response.raise_for_status()
-        result: dict[str, Any] = response.json()
-        return result
+        response = httpx.post(
+            url,
+            json=data,
+            params=params,
+            headers=_auth_headers(s),
+            timeout=request_timeout,
+        )
     except httpx.TimeoutException:
         display_error(f"Request timed out after {request_timeout}s")
-        sys.exit(1)
-    except httpx.HTTPStatusError as e:
-        # Try to parse error message from response
-        try:
-            error_data = e.response.json()
-            error_msg = error_data.get("message", e.response.text)
-        except Exception:
-            error_msg = e.response.text
-        display_error(f"HTTP {e.response.status_code}: {error_msg}")
         sys.exit(1)
     except httpx.RequestError as e:
         display_error(f"Request failed: {e}")
         sys.exit(1)
+
+    if response.status_code == 401:
+        refreshed = _refresh_session(s)
+        if refreshed is None:
+            display_error("Session expired")
+            display_info("Run 'stk auth login' to sign in again")
+            sys.exit(1)
+        response = httpx.post(
+            url,
+            json=data,
+            params=params,
+            headers=_auth_headers(refreshed),
+            timeout=request_timeout,
+        )
+
+    if response.status_code >= 400:
+        _exit_with_error(response)
+
+    result: dict[str, Any] = response.json()
+    return result

--- a/src/cli/session.py
+++ b/src/cli/session.py
@@ -1,0 +1,74 @@
+"""Session storage for stk CLI.
+
+A session is the access/refresh token pair returned by the backend's
+/auth/login (or /auth/signup) endpoint, plus the email it belongs to and
+the absolute expiry timestamp of the access token.
+
+Stored at ``~/.config/stk/session.json``. The CLI never sees Supabase
+URLs or anon keys — those stay on the backend.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+CONFIG_DIR = Path.home() / ".config" / "stk"
+SESSION_FILE = CONFIG_DIR / "session.json"
+
+# Refresh proactively when fewer than this many seconds remain on the access
+# token, so a long-running command doesn't get a 401 mid-flight.
+_REFRESH_LEEWAY_SECONDS = 60
+
+
+@dataclass
+class Session:
+    access_token: str
+    refresh_token: str
+    expires_at: float
+    email: str
+
+    def is_expired(self) -> bool:
+        return time.time() >= self.expires_at - _REFRESH_LEEWAY_SECONDS
+
+
+def save(
+    *,
+    access_token: str,
+    refresh_token: str,
+    expires_in: int | None,
+    email: str,
+) -> Session:
+    """Persist a fresh session, computing expires_at from expires_in."""
+    expires_at = time.time() + (expires_in if expires_in else 3600)
+    session = Session(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        expires_at=expires_at,
+        email=email,
+    )
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    SESSION_FILE.write_text(json.dumps(asdict(session), indent=2))
+    os.chmod(SESSION_FILE, 0o600)
+    return session
+
+
+def load() -> Session | None:
+    if not SESSION_FILE.exists():
+        return None
+    try:
+        data = json.loads(SESSION_FILE.read_text())
+        return Session(**data)
+    except (json.JSONDecodeError, OSError, TypeError):
+        return None
+
+
+def clear() -> bool:
+    """Delete the session file. Returns True if a file existed."""
+    if SESSION_FILE.exists():
+        SESSION_FILE.unlink()
+        return True
+    return False


### PR DESCRIPTION
## Summary

- Adds `/auth/signup`, `/auth/login`, and `/auth/refresh` endpoints that proxy Supabase Auth, so the stk CLI (and any future client) only needs to know about `api.myrunstreak.run` — Supabase URL and anon key stay on the backend.
- New stk session storage at `~/.config/stk/session.json` (`src/cli/session.py`) with proactive refresh leeway so long-running commands don't 401 mid-flight.
- Threads `SUPABASE_ANON_KEY` through `Settings`, `.env.example`, `conftest`, and the backend Helm Deployment (sourced from the existing `myrunstreak-secrets` ExternalSecret entry).
- Adds `pydantic[email]` for `EmailStr` request validation; rewires `src/cli/api.py` to call the new proxy endpoints instead of going to Supabase directly.

## Test plan

- [x] Backend suite green locally: `PYTHONPATH=. uv run pytest backend/tests/ -q` → 41/41
- [x] Diff coherent with branch scope; no secrets, only placeholders in `.env.example` / conftest
- [ ] After deploy: `curl -X POST $API/auth/login -d '{"email":"...","password":"..."}'` returns access/refresh tokens
- [ ] After deploy: `curl -X POST $API/auth/refresh -d '{"refresh_token":"..."}'` rotates tokens
- [ ] After deploy: `stk login` (or equivalent) writes a valid session file at `~/.config/stk/session.json`
- [ ] Confirm the AWS Secrets Manager `myrunstreak-app-secrets` contains a `supabase_anon_key` field, otherwise the new env var won't materialize and the backend pod will fail to start (Settings requires it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)