### PR TITLE
feat: restore SmashRun goal sync to backend

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -24,6 +24,9 @@ class Settings(BaseSettings):
     cache_enabled: bool = True
     cache_default_ttl_seconds: int = 60
 
+    goal_yearly_staleness_days: int = 14
+    goal_monthly_staleness_days: int = 3
+
 
 _settings: Settings | None = None
 

--- a/backend/routes/sync.py
+++ b/backend/routes/sync.py
@@ -6,17 +6,26 @@ same underlying ``run_user_sync`` helper.
 
 from __future__ import annotations
 
+import logging
 from datetime import date, timedelta
 from typing import Any
 from uuid import UUID
 
 from backend.auth import authenticate_request
 from backend.cache import invalidate_user
+from backend.config import Settings, get_settings
 from fastapi import APIRouter, Body, Depends
 from src.shared.secrets import get_smashrun_oauth_credentials
 from src.shared.smashrun import SmashRunAPIClient, SmashRunOAuthClient
 from src.shared.supabase_client import get_supabase_client
-from src.shared.supabase_ops import RunsRepository, TokenRepository, activity_to_run_dict
+from src.shared.supabase_ops import (
+    GoalsRepository,
+    RunsRepository,
+    TokenRepository,
+    activity_to_run_dict,
+)
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["sync"])
 
@@ -40,6 +49,8 @@ def run_user_sync(
     supabase = get_supabase_client()
     runs_repo = RunsRepository(supabase)
     token_repo = TokenRepository(supabase)
+    goals_repo = GoalsRepository(supabase)
+    settings = get_settings()
 
     source_id = token_repo.get_source_id_for_user(user_id, "smashrun")
     if not source_id:
@@ -89,12 +100,70 @@ def run_user_sync(
             except Exception:  # noqa: BLE001
                 continue
 
+        # Refresh yearly + monthly goals for the current period if stale or
+        # missing. Failure here must not fail the whole sync.
+        try:
+            sync_current_goals(
+                user_id=user_id,
+                source_id=source_id,
+                api=api,
+                goals_repo=goals_repo,
+                settings=settings,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(f"Goal sync failed for source {source_id}: {exc}")
+
     return {
         "message": "Sync completed",
         "runs_synced": runs_synced,
         "since": since_date.isoformat(),
         "until": until_date.isoformat(),
     }
+
+
+def sync_current_goals(
+    user_id: UUID,
+    source_id: UUID,
+    api: SmashRunAPIClient,
+    goals_repo: GoalsRepository,
+    settings: Settings,
+) -> None:
+    """Refresh current-year and current-month goals from SmashRun if stale.
+
+    Yearly and monthly periods have separate staleness thresholds
+    (``settings.goal_yearly_staleness_days`` / ``goal_monthly_staleness_days``)
+    so we don't re-fetch the same goal every sync. Periods with no goal set on
+    SmashRun are recorded as "absent" via :meth:`GoalsRepository.mark_absent`
+    so we don't keep hammering the API.
+    """
+    today = date.today()
+    yearly_ttl = timedelta(days=settings.goal_yearly_staleness_days)
+    monthly_ttl = timedelta(days=settings.goal_monthly_staleness_days)
+
+    periods: list[tuple[int, int | None, timedelta]] = [
+        (today.year, None, yearly_ttl),
+        (today.year, today.month, monthly_ttl),
+    ]
+
+    for year, month, ttl in periods:
+        label = f"{year}" if month is None else f"{year}/{month}"
+        existing = goals_repo.get_by_period(user_id, source_id, year, month)
+
+        if not goals_repo.is_stale(existing, ttl):
+            logger.debug(f"Goal {label} is fresh, skipping fetch")
+            continue
+
+        logger.info(f"Fetching goal {label} from SmashRun")
+        goal = api.get_goal(year, month)
+
+        if goal is None:
+            goals_repo.mark_absent(user_id, source_id, year, month)
+            logger.info(f"No goal set on SmashRun for {label}")
+        else:
+            goals_repo.upsert(user_id, source_id, goal)
+            logger.info(
+                f"Stored goal {label}: goal_km={goal.goal_km} progress_km={goal.progress_km}"
+            )
 
 
 @router.post("/sync-user")

--- a/backend/tests/test_goals_repository.py
+++ b/backend/tests/test_goals_repository.py
@@ -1,0 +1,66 @@
+"""Tests for GoalsRepository staleness logic."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from src.shared.models import Goal
+from src.shared.supabase_ops import GoalsRepository
+
+
+@pytest.fixture
+def repo() -> GoalsRepository:
+    """GoalsRepository with a MagicMock Supabase client."""
+    return GoalsRepository(MagicMock())
+
+
+def test_is_stale_missing_row(repo: GoalsRepository) -> None:
+    """Missing row is always stale."""
+    assert repo.is_stale(None, timedelta(days=14)) is True
+
+
+def test_is_stale_no_fetched_at(repo: GoalsRepository) -> None:
+    """Row without fetched_at is treated as stale."""
+    assert repo.is_stale({"id": "x"}, timedelta(days=14)) is True
+
+
+def test_is_stale_recent_row_is_fresh(repo: GoalsRepository) -> None:
+    """Row fetched within TTL is fresh."""
+    now = datetime(2026, 4, 23, 12, 0, tzinfo=UTC)
+    row = {"fetched_at": (now - timedelta(days=1)).isoformat()}
+
+    assert repo.is_stale(row, timedelta(days=3), now=now) is False
+
+
+def test_is_stale_old_row_is_stale(repo: GoalsRepository) -> None:
+    """Row older than TTL is stale."""
+    now = datetime(2026, 4, 23, 12, 0, tzinfo=UTC)
+    row = {"fetched_at": (now - timedelta(days=5)).isoformat()}
+
+    assert repo.is_stale(row, timedelta(days=3), now=now) is True
+
+
+def test_is_stale_boundary_exact_ttl(repo: GoalsRepository) -> None:
+    """Row exactly at TTL is not yet stale (strict >)."""
+    now = datetime(2026, 4, 23, 12, 0, tzinfo=UTC)
+    row = {"fetched_at": (now - timedelta(days=3)).isoformat()}
+
+    assert repo.is_stale(row, timedelta(days=3), now=now) is False
+
+
+def test_is_stale_handles_z_suffix(repo: GoalsRepository) -> None:
+    """Supabase sometimes returns timestamps with a Z suffix; parser handles it."""
+    now = datetime(2026, 4, 23, 12, 0, tzinfo=UTC)
+    row = {"fetched_at": "2026-04-20T12:00:00Z"}
+
+    # 3-day-old row, TTL 3d → not stale (exactly at boundary)
+    assert repo.is_stale(row, timedelta(days=3), now=now) is False
+
+
+def test_yearly_vs_monthly_differ() -> None:
+    """Yearly goal has month=None, monthly has 1-12."""
+    yearly = Goal(year=2026)
+    monthly = Goal(year=2026, month=4)
+
+    assert yearly.is_yearly is True
+    assert monthly.is_yearly is False

--- a/backend/tests/test_sync_goals.py
+++ b/backend/tests/test_sync_goals.py
@@ -1,0 +1,129 @@
+"""Tests for goal-refresh wiring in backend/routes/sync.py."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from backend.config import Settings
+from backend.routes.sync import run_user_sync, sync_current_goals
+from src.shared.models import Goal
+
+
+def _settings() -> Settings:
+    return Settings(
+        supabase_url="https://test.supabase.co",
+        supabase_anon_key="test-anon-key",
+        supabase_service_role_key="test-service-key",
+        supabase_jwt_secret="test-jwt-secret-needs-to-be-long-enough-for-hs256",
+        goal_yearly_staleness_days=14,
+        goal_monthly_staleness_days=3,
+    )
+
+
+def test_stale_goal_triggers_fetch_and_upsert() -> None:
+    """Stale (here: missing) rows → fetch from SmashRun and upsert each period."""
+    user_id, source_id = uuid4(), uuid4()
+    now = datetime.now(UTC)
+    api = MagicMock()
+    fetched_yearly = Goal(year=now.year, goal_km=1000.0, progress_km=500.0)
+    fetched_monthly = Goal(year=now.year, month=now.month, goal_km=80.0, progress_km=20.0)
+    api.get_goal.side_effect = [fetched_yearly, fetched_monthly]
+
+    repo = MagicMock()
+    repo.get_by_period.return_value = None  # both periods missing
+    repo.is_stale.return_value = True
+
+    sync_current_goals(user_id, source_id, api, repo, _settings())
+
+    assert api.get_goal.call_count == 2
+    assert repo.upsert.call_args_list == [
+        ((user_id, source_id, fetched_yearly),),
+        ((user_id, source_id, fetched_monthly),),
+    ]
+    repo.mark_absent.assert_not_called()
+
+
+def test_fresh_row_skips_api_call() -> None:
+    """Row inside TTL is fresh; sync must not call SmashRun."""
+    user_id, source_id = uuid4(), uuid4()
+    api = MagicMock()
+    repo = MagicMock()
+    repo.get_by_period.return_value = {"fetched_at": datetime.now(UTC).isoformat()}
+    repo.is_stale.return_value = False
+
+    sync_current_goals(user_id, source_id, api, repo, _settings())
+
+    api.get_goal.assert_not_called()
+    repo.upsert.assert_not_called()
+    repo.mark_absent.assert_not_called()
+
+
+def test_smashrun_returns_none_marks_absent() -> None:
+    """SmashRun reports no goal set → mark_absent so we don't re-fetch."""
+    user_id, source_id = uuid4(), uuid4()
+    api = MagicMock()
+    api.get_goal.return_value = None  # no goal set on either period
+
+    repo = MagicMock()
+    repo.get_by_period.return_value = None
+    repo.is_stale.return_value = True
+
+    sync_current_goals(user_id, source_id, api, repo, _settings())
+
+    assert repo.mark_absent.call_count == 2  # yearly + monthly
+    repo.upsert.assert_not_called()
+
+
+def test_run_user_sync_swallows_goal_failure() -> None:
+    """A goal-sync exception must not fail the whole sync."""
+    user_id = uuid4()
+    source_id = uuid4()
+
+    token_repo = MagicMock()
+    token_repo.get_source_id_for_user.return_value = source_id
+    token_repo.get_user_tokens.return_value = {
+        "access_token": "tok",
+        "refresh_token": "ref",
+    }
+    token_repo.is_token_expired.return_value = False
+
+    api = MagicMock()
+    api.get_all_activities_since.return_value = []
+    api_ctx = MagicMock()
+    api_ctx.__enter__ = MagicMock(return_value=api)
+    api_ctx.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("backend.routes.sync.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.sync.RunsRepository"),
+        patch("backend.routes.sync.TokenRepository", return_value=token_repo),
+        patch("backend.routes.sync.GoalsRepository"),
+        patch("backend.routes.sync.SmashRunAPIClient", return_value=api_ctx),
+        patch(
+            "backend.routes.sync.sync_current_goals",
+            side_effect=RuntimeError("smashrun on fire"),
+        ),
+    ):
+        result = run_user_sync(user_id, since=None, until=None, full=False)
+
+    assert result["runs_synced"] == 0
+    assert result["message"] == "Sync completed"
+
+
+def test_settings_drive_per_period_ttl() -> None:
+    """Yearly + monthly periods consult is_stale with their respective TTLs."""
+    user_id, source_id = uuid4(), uuid4()
+    settings = _settings()
+    api = MagicMock()
+    api.get_goal.return_value = None
+    repo = MagicMock()
+    repo.get_by_period.return_value = None
+    repo.is_stale.return_value = True
+
+    sync_current_goals(user_id, source_id, api, repo, settings)
+
+    ttl_args = [call.args[1] for call in repo.is_stale.call_args_list]
+    assert timedelta(days=settings.goal_yearly_staleness_days) in ttl_args
+    assert timedelta(days=settings.goal_monthly_staleness_days) in ttl_args

--- a/src/shared/supabase_ops/__init__.py
+++ b/src/shared/supabase_ops/__init__.py
@@ -1,11 +1,13 @@
 """Supabase database operations for MyRunStreak.com."""
 
+from .goals_repository import GoalsRepository
 from .mappers import activity_to_run_dict, split_to_dict
 from .runs_repository import RunsRepository
 from .token_repository import TokenRepository
 from .users_repository import UsersRepository
 
 __all__ = [
+    "GoalsRepository",
     "RunsRepository",
     "TokenRepository",
     "UsersRepository",

--- a/src/shared/supabase_ops/goals_repository.py
+++ b/src/shared/supabase_ops/goals_repository.py
@@ -1,0 +1,161 @@
+"""Repository for running goals in Supabase."""
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any, cast
+from uuid import UUID
+
+from supabase import Client
+
+from ..models import Goal
+
+logger = logging.getLogger(__name__)
+
+
+class GoalsRepository:
+    """
+    Repository for yearly/monthly running goal data.
+
+    Handles caching logic: yearly and monthly goals have different staleness
+    thresholds to avoid re-fetching the same goal every sync.
+    """
+
+    def __init__(self, supabase: Client):
+        """
+        Initialize repository with Supabase client.
+
+        Args:
+            supabase: Authenticated Supabase client
+        """
+        self.supabase = supabase
+
+    def get_by_period(
+        self,
+        user_id: UUID,
+        source_id: UUID,
+        year: int,
+        month: int | None = None,
+    ) -> dict[str, Any] | None:
+        """
+        Get the stored goal row for a specific period.
+
+        Args:
+            user_id: User UUID
+            source_id: Source UUID
+            year: Goal year
+            month: Goal month (1-12) or None for yearly goal
+
+        Returns:
+            Goal row dict, or None if not stored
+        """
+        query = (
+            self.supabase.table("goals")
+            .select("*")
+            .eq("user_id", str(user_id))
+            .eq("source_id", str(source_id))
+            .eq("year", year)
+        )
+        query = query.is_("month", "null") if month is None else query.eq("month", month)
+
+        result = query.execute()
+        data_list = cast(list[dict[str, Any]], result.data)
+        return data_list[0] if data_list else None
+
+    def is_stale(
+        self,
+        row: dict[str, Any] | None,
+        max_age: timedelta,
+        now: datetime | None = None,
+    ) -> bool:
+        """
+        Check whether a stored goal row needs refreshing.
+
+        A missing row is considered stale (needs fetch). A row older than
+        max_age is also stale.
+
+        Args:
+            row: Stored goal row (or None if absent)
+            max_age: Staleness threshold
+            now: Current time for testing (defaults to datetime.now with tz)
+
+        Returns:
+            True if the row should be refreshed
+        """
+        if row is None:
+            return True
+
+        fetched_at_raw = row.get("fetched_at")
+        if not fetched_at_raw:
+            return True
+
+        fetched_at = datetime.fromisoformat(str(fetched_at_raw).replace("Z", "+00:00"))
+        current = now or datetime.now(fetched_at.tzinfo)
+        return (current - fetched_at) > max_age
+
+    def upsert(
+        self,
+        user_id: UUID,
+        source_id: UUID,
+        goal: Goal,
+    ) -> dict[str, Any]:
+        """
+        Insert or update a goal row.
+
+        Uniqueness is enforced by partial unique indexes on
+        (user_id, source_id, year) WHERE month IS NULL
+        and (user_id, source_id, year, month) WHERE month IS NOT NULL.
+
+        Args:
+            user_id: User UUID
+            source_id: Source UUID
+            goal: Goal model with data fetched from source API
+
+        Returns:
+            Inserted/updated goal row
+        """
+        existing = self.get_by_period(user_id, source_id, goal.year, goal.month)
+        now_iso = datetime.now(tz=goal.fetched_at.tzinfo if goal.fetched_at else None).isoformat()
+
+        payload: dict[str, Any] = {
+            "user_id": str(user_id),
+            "source_id": str(source_id),
+            "year": goal.year,
+            "month": goal.month,
+            "goal_text": goal.goal_text,
+            "goal_km": goal.goal_km,
+            "progress_km": goal.progress_km,
+            "fetched_at": now_iso,
+        }
+
+        if existing:
+            result = self.supabase.table("goals").update(payload).eq("id", existing["id"]).execute()
+        else:
+            result = self.supabase.table("goals").insert(payload).execute()
+
+        data_list = cast(list[dict[str, Any]], result.data)
+        logger.debug(f"Upserted goal for user {user_id} year={goal.year} month={goal.month}")
+        return data_list[0]
+
+    def mark_absent(
+        self,
+        user_id: UUID,
+        source_id: UUID,
+        year: int,
+        month: int | None,
+    ) -> dict[str, Any]:
+        """
+        Record that no goal is set for a period (API returned null).
+
+        Stores a row with null goal_km so we don't re-fetch immediately.
+
+        Args:
+            user_id: User UUID
+            source_id: Source UUID
+            year: Goal year
+            month: Goal month (or None for yearly)
+
+        Returns:
+            Inserted/updated row
+        """
+        placeholder = Goal(year=year, month=month)
+        return self.upsert(user_id, source_id, placeholder)


### PR DESCRIPTION
## Summary

- Reconnects the yearly + monthly SmashRun goal refresh that was silently dropped when the AWS Lambda stack came down. The \`Goal\` model, \`SmashRunAPIClient.get_goal()\`, and the \`goals\` table all survived the cleanup; \`GoalsRepository\` and the sync wiring did not.
- Each sync (HTTP \`/sync-user\` or the K8s CronJob \`backend/jobs/sync_runs.py\`) now refreshes the current-year and current-month goals from SmashRun if stale or missing — yearly TTL 14 days, monthly 3 days, both configurable.
- Periods with no goal on SmashRun are marked absent (placeholder row, \`goal_km=NULL\`) so we don't re-hammer the API.
- Goal-refresh failure is swallowed by the caller — runs sync must not regress on goals flakiness.

## Changes

- \`src/shared/supabase_ops/goals_repository.py\` restored verbatim from \`34a5178^\` (operates on the still-present \`goals\` table)
- \`src/shared/supabase_ops/__init__.py\` re-exports \`GoalsRepository\`
- \`backend/routes/sync.py\` — new \`sync_current_goals()\` helper, called inside \`run_user_sync\` after the runs upsert loop, wrapped in try/except
- \`backend/config.py\` — \`goal_yearly_staleness_days=14\`, \`goal_monthly_staleness_days=3\`
- \`backend/tests/test_goals_repository.py\` — 7 cases ported from the old \`tests/test_goals_repository.py\` (TTL math + Z-suffix parsing + yearly-vs-monthly model)
- \`backend/tests/test_sync_goals.py\` — 5 cases on the new wiring: stale → fetch + upsert, fresh → no API call, SmashRun returns null → mark_absent, exception in goal sync → swallowed by \`run_user_sync\`, per-period TTLs threaded through \`is_stale\`

## Test plan

- [x] Backend suite: \`PYTHONPATH=. uv run pytest backend/tests/ -q\` → 44/44
- [x] Ruff: \`uv run ruff check .\` → clean (B008 noise on \`Depends/Body\` pre-existing and exempted in \`pyproject.toml\`)
- [x] No formatting drift on touched files
- [ ] After deploy: trigger sync, check Supabase → \`select user_id, year, month, goal_km, progress_km, fetched_at from goals order by fetched_at desc;\` shows fresh rows for current year (\`month IS NULL\`) and current month
- [ ] Verify second consecutive sync within 3 days does not re-call \`/my/goals\` (logs should show \"is fresh, skipping fetch\" at DEBUG)
- [ ] Verify a period with no goal set on SmashRun gets a row with \`goal_km IS NULL\` and isn't re-fetched

## Unblocks

- #68 — \`publish_status\` can now emit the goals block from live rows instead of \`{yearly: null, monthly: null}\`. qualityplaybook.dev tile gets its GOALS section back once both ship.

Closes #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)