### PR TITLE
feat: restore status.json publisher to GCS

### DIFF
--- a/backend/jobs/publish_status.py
+++ b/backend/jobs/publish_status.py
@@ -1,0 +1,236 @@
+"""K8s CronJob entry point: publish status.json to gs://myrunstreak-public.
+
+Replaces the AWS Lambda that ran on EventBridge. Builds the same status
+payload (matching the StreakData interface in the qualityplaybook.dev
+RunningStreak.vue tile) and uploads it to GCS with a 5-minute Cache-Control.
+
+Service-account JSON is read from the ``GCS_SERVICE_ACCOUNT_JSON`` env var
+(materialized via ExternalSecrets from the ``myrunstreak-app-secrets`` AWS
+Secret). The SA lives in GCP project ``missing-table`` and has
+``roles/storage.objectAdmin`` on the bucket.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+from uuid import UUID
+from zoneinfo import ZoneInfo
+
+from dateutil.relativedelta import relativedelta
+from google.cloud import storage
+from google.oauth2 import service_account
+from src.shared.supabase_client import get_supabase_client
+from src.shared.supabase_ops import GoalsRepository, RunsRepository, UsersRepository
+
+GCS_BUCKET_NAME = "myrunstreak-public"
+GCS_OBJECT_PATH = "status.json"
+USER_TIMEZONE = ZoneInfo("America/New_York")
+KM_TO_MILES = 0.621371
+
+logger = logging.getLogger(__name__)
+
+
+def km_to_miles(km: float) -> float:
+    return km * KM_TO_MILES
+
+
+def format_streak_duration(streak_start: str | None, today: date) -> str | None:
+    """Render '11 years, 8 months and 9 days' from an ISO start date."""
+    if not streak_start:
+        return None
+
+    start = date.fromisoformat(streak_start)
+    delta = relativedelta(today, start)
+
+    parts: list[str] = []
+    if delta.years > 0:
+        parts.append(f"{delta.years} year{'s' if delta.years != 1 else ''}")
+    if delta.months > 0:
+        parts.append(f"{delta.months} month{'s' if delta.months != 1 else ''}")
+    if delta.days > 0 or not parts:
+        parts.append(f"{delta.days} day{'s' if delta.days != 1 else ''}")
+
+    if len(parts) == 1:
+        return parts[0]
+    if len(parts) == 2:
+        return f"{parts[0]} and {parts[1]}"
+    return f"{parts[0]}, {parts[1]} and {parts[2]}"
+
+
+def get_gcs_credentials() -> dict[str, Any]:
+    """Parse GCS service-account JSON from the GCS_SERVICE_ACCOUNT_JSON env var."""
+    raw = os.environ.get("GCS_SERVICE_ACCOUNT_JSON")
+    if not raw:
+        raise RuntimeError(
+            "GCS_SERVICE_ACCOUNT_JSON env var is empty or unset; "
+            "expected the publisher SA JSON sourced from myrunstreak-secrets."
+        )
+    creds: dict[str, Any] = json.loads(raw)
+    return creds
+
+
+def upload_to_gcs(data: dict[str, Any]) -> str:
+    """Upload ``data`` as JSON to gs://myrunstreak-public/status.json."""
+    creds_dict = get_gcs_credentials()
+    credentials = service_account.Credentials.from_service_account_info(creds_dict)  # type: ignore[no-untyped-call]
+    client = storage.Client(credentials=credentials, project=creds_dict.get("project_id"))
+
+    bucket = client.bucket(GCS_BUCKET_NAME)
+    blob = bucket.blob(GCS_OBJECT_PATH)
+    blob.cache_control = "public, max-age=300"
+
+    blob.upload_from_string(
+        json.dumps(data, indent=2, default=str),
+        content_type="application/json",
+    )
+    public_url = f"https://storage.googleapis.com/{GCS_BUCKET_NAME}/{GCS_OBJECT_PATH}"
+    logger.info(f"Uploaded status to {public_url}")
+    return public_url
+
+
+def build_goals_block(
+    user_id: UUID,
+    source_id: UUID | None,
+    goals_repo: GoalsRepository,
+    today: date,
+) -> dict[str, Any]:
+    """Yearly + monthly goal progress, in miles. Each is None when the user
+    has no goal stored for the period (or no SmashRun source at all).
+
+    Shape matches the GoalProgress interface in
+    qualityplaybook.dev/frontend/src/components/RunningStreak.vue.
+    """
+    if source_id is None:
+        return {"yearly": None, "monthly": None}
+
+    def render(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if not row or row.get("goal_km") is None:
+            return None
+        goal_km = float(row["goal_km"])
+        progress_km = float(row.get("progress_km") or 0.0)
+        percent = (progress_km / goal_km * 100) if goal_km > 0 else None
+        return {
+            "goal_mi": round(km_to_miles(goal_km), 1),
+            "progress_mi": round(km_to_miles(progress_km), 1),
+            "percent": round(percent, 1) if percent is not None else None,
+            "text": row.get("goal_text"),
+            "fetched_at": row.get("fetched_at"),
+        }
+
+    yearly_row = goals_repo.get_by_period(user_id, source_id, today.year, None)
+    monthly_row = goals_repo.get_by_period(user_id, source_id, today.year, today.month)
+    return {"yearly": render(yearly_row), "monthly": render(monthly_row)}
+
+
+def build_status_data(
+    user_id: UUID,
+    runs_repo: RunsRepository,
+    goals_repo: GoalsRepository,
+    source_id: UUID | None,
+) -> dict[str, Any]:
+    """Build the status.json payload — pre-aggregated stats with a
+    recalculate fallback if the aggregation row is missing."""
+    today = datetime.now(USER_TIMEZONE).date()
+    seven_days_ago = today - timedelta(days=7)
+
+    recent_runs = runs_repo.get_runs_by_date_range(user_id, seven_days_ago, today)
+    ran_today = any(run["start_date"] == today.isoformat() for run in recent_runs)
+
+    last_run: dict[str, Any] | None = None
+    if recent_runs:
+        latest = recent_runs[0]
+        last_run = {
+            "date": latest["start_date"],
+            "distance_mi": round(km_to_miles(float(latest["distance_km"])), 2),
+            "duration_min": round(float(latest["duration_seconds"]) / 60, 1),
+        }
+
+    last_7_days = [
+        {
+            "date": run["start_date"],
+            "distance_mi": round(km_to_miles(float(run["distance_km"])), 2),
+        }
+        for run in recent_runs
+    ]
+
+    stats = runs_repo.get_user_running_stats(user_id)
+    if not stats:
+        logger.warning(f"No pre-calculated stats for user {user_id}, recalculating")
+        try:
+            stats = runs_repo.recalculate_user_stats(user_id, timezone="America/New_York")
+        except Exception as exc:  # noqa: BLE001
+            logger.error(f"Failed to recalculate stats: {exc}; using defaults")
+            stats = {}
+
+    streak_days = stats.get("current_streak_days", 0)
+    streak_start = stats.get("current_streak_start")
+    streak_total_km = float(stats.get("current_streak_distance_km", 0))
+    month_total_km = float(stats.get("month_to_date_distance_km", 0))
+    year_total_km = float(stats.get("year_to_date_distance_km", 0))
+
+    return {
+        "updated_at": datetime.now(UTC).isoformat(),
+        "ran_today": ran_today,
+        "streak": {
+            "current_days": streak_days,
+            "started": streak_start,
+            "duration": format_streak_duration(streak_start, today),
+            "total_mi": round(km_to_miles(streak_total_km), 1),
+        },
+        "last_run": last_run,
+        "last_7_days": last_7_days,
+        "month_total_mi": round(km_to_miles(month_total_km), 1),
+        "year_total_mi": round(km_to_miles(year_total_km), 1),
+        "goals": build_goals_block(user_id, source_id, goals_repo, today),
+    }
+
+
+def resolve_user_and_source(users_repo: UsersRepository) -> tuple[UUID, UUID | None]:
+    """Pick the user whose status to publish.
+
+    Multi-user is out of scope today — there's exactly one active SmashRun
+    source. When that grows we'll iterate, but for now the shape returned
+    matches what the qualityplaybook.dev tile (and any future single-user
+    embed) expects: a single status.json per known publisher.
+    """
+    sources = users_repo.get_all_active_sources(source_type="smashrun")
+    if not sources:
+        raise RuntimeError("No active SmashRun sources found")
+
+    primary = sources[0]
+    return UUID(primary["user_id"]), UUID(primary["id"])
+
+
+def main() -> int:
+    log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+    logging.basicConfig(level=log_level)
+
+    supabase = get_supabase_client()
+    runs_repo = RunsRepository(supabase)
+    users_repo = UsersRepository(supabase)
+    goals_repo = GoalsRepository(supabase)
+
+    try:
+        user_id, source_id = resolve_user_and_source(users_repo)
+        logger.info(f"Publishing status for user {user_id}")
+
+        status = build_status_data(user_id, runs_repo, goals_repo, source_id)
+        upload_to_gcs(status)
+
+        logger.info(
+            f"Published: ran_today={status['ran_today']} "
+            f"streak={status['streak']['current_days']}"
+        )
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"publish_status failed: {exc}", exc_info=True)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "python-dateutil>=2.9.0",
     "pytz>=2024.1",
     "structlog>=24.0.0",
+    "google-cloud-storage>=3.10.1",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/test_publish_status.py
+++ b/backend/tests/test_publish_status.py
@@ -1,0 +1,331 @@
+"""Tests for backend.jobs.publish_status."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from backend.jobs.publish_status import (
+    build_goals_block,
+    build_status_data,
+    format_streak_duration,
+    get_gcs_credentials,
+    km_to_miles,
+    resolve_user_and_source,
+    upload_to_gcs,
+)
+
+# ---------------------------------------------------------------------------
+# format_streak_duration
+# ---------------------------------------------------------------------------
+
+
+def test_format_streak_duration_returns_none_when_no_start() -> None:
+    assert format_streak_duration(None, date(2026, 5, 9)) is None
+
+
+def test_format_streak_duration_full_form() -> None:
+    assert format_streak_duration("2014-08-23", date(2026, 5, 9)) == "11 years, 8 months and 16 days"
+
+
+def test_format_streak_duration_singular_units() -> None:
+    assert format_streak_duration("2025-04-08", date(2026, 5, 9)) == "1 year, 1 month and 1 day"
+
+
+def test_format_streak_duration_only_days() -> None:
+    assert format_streak_duration("2026-05-04", date(2026, 5, 9)) == "5 days"
+
+
+def test_format_streak_duration_zero_days_same_date() -> None:
+    """Same start + today should still render '0 days' (not blank)."""
+    assert format_streak_duration("2026-05-09", date(2026, 5, 9)) == "0 days"
+
+
+# ---------------------------------------------------------------------------
+# km_to_miles
+# ---------------------------------------------------------------------------
+
+
+def test_km_to_miles_round_trip() -> None:
+    assert km_to_miles(1.609344) == pytest.approx(1.0, abs=0.001)
+
+
+# ---------------------------------------------------------------------------
+# build_goals_block
+# ---------------------------------------------------------------------------
+
+
+def test_build_goals_block_no_source_returns_nulls() -> None:
+    repo = MagicMock()
+    result = build_goals_block(uuid4(), None, repo, date(2026, 5, 9))
+
+    assert result == {"yearly": None, "monthly": None}
+    repo.get_by_period.assert_not_called()
+
+
+def test_build_goals_block_renders_yearly_and_monthly() -> None:
+    user_id, source_id = uuid4(), uuid4()
+    repo = MagicMock()
+    repo.get_by_period.side_effect = [
+        {
+            "goal_km": 1931.0,  # ~1200 mi
+            "progress_km": 721.4,  # ~448.1 mi
+            "goal_text": "1200 mi this year",
+            "fetched_at": "2026-05-09T12:00:00Z",
+        },
+        {
+            "goal_km": 201.2,  # ~125 mi
+            "progress_km": 21.7,  # ~13.5 mi
+            "goal_text": "125 mi this month",
+            "fetched_at": "2026-05-09T12:00:00Z",
+        },
+    ]
+
+    result = build_goals_block(user_id, source_id, repo, date(2026, 5, 9))
+
+    assert result["yearly"]["goal_mi"] == pytest.approx(1200.0, abs=0.2)
+    assert result["yearly"]["progress_mi"] == pytest.approx(448.1, abs=0.2)
+    assert result["yearly"]["percent"] == pytest.approx(37.4, abs=0.5)
+    assert result["yearly"]["text"] == "1200 mi this year"
+
+    assert result["monthly"]["goal_mi"] == pytest.approx(125.0, abs=0.2)
+    assert result["monthly"]["progress_mi"] == pytest.approx(13.5, abs=0.2)
+    assert result["monthly"]["percent"] == pytest.approx(10.8, abs=0.5)
+
+
+def test_build_goals_block_null_goal_km_renders_as_none() -> None:
+    """A row exists but goal_km is null (no goal set on SmashRun) → None."""
+    user_id, source_id = uuid4(), uuid4()
+    repo = MagicMock()
+    repo.get_by_period.side_effect = [
+        {"goal_km": None, "progress_km": None, "fetched_at": "2026-05-09T12:00:00Z"},
+        None,  # not even a row stored for monthly
+    ]
+
+    result = build_goals_block(user_id, source_id, repo, date(2026, 5, 9))
+
+    assert result == {"yearly": None, "monthly": None}
+
+
+# ---------------------------------------------------------------------------
+# build_status_data
+# ---------------------------------------------------------------------------
+
+
+def _runs_repo_with(stats: dict | None, recent_runs: list[dict]) -> MagicMock:
+    repo = MagicMock()
+    repo.get_runs_by_date_range.return_value = recent_runs
+    repo.get_user_running_stats.return_value = stats
+    return repo
+
+
+def test_build_status_data_full_payload_shape() -> None:
+    """Top-level keys + types match the StreakData interface qualityplaybook.dev expects."""
+    user_id, source_id = uuid4(), uuid4()
+    today_iso = "2026-05-09"
+    runs_repo = _runs_repo_with(
+        stats={
+            "current_streak_days": 4272,
+            "current_streak_start": "2014-08-23",
+            "current_streak_distance_km": 30210.0,
+            "month_to_date_distance_km": 30.5,
+            "year_to_date_distance_km": 730.0,
+        },
+        recent_runs=[
+            {"start_date": today_iso, "distance_km": 6.5, "duration_seconds": 2400},
+            {"start_date": "2026-05-08", "distance_km": 5.0, "duration_seconds": 2100},
+        ],
+    )
+    goals_repo = MagicMock()
+    goals_repo.get_by_period.return_value = None  # no goals stored
+
+    with patch(
+        "backend.jobs.publish_status.datetime"
+    ) as mock_dt:
+        mock_dt.now.return_value.date.return_value = date(2026, 5, 9)
+        # Let datetime.now(UTC).isoformat() produce something deterministic
+        mock_dt.now.return_value.isoformat.return_value = "2026-05-09T14:00:00+00:00"
+        result = build_status_data(user_id, runs_repo, goals_repo, source_id)
+
+    # Top-level shape
+    assert set(result.keys()) >= {
+        "updated_at",
+        "ran_today",
+        "streak",
+        "last_run",
+        "last_7_days",
+        "month_total_mi",
+        "year_total_mi",
+        "goals",
+    }
+
+    # ran_today flag
+    assert result["ran_today"] is True
+
+    # Streak block
+    assert result["streak"]["current_days"] == 4272
+    assert result["streak"]["started"] == "2014-08-23"
+    assert result["streak"]["total_mi"] == round(km_to_miles(30210.0), 1)
+    assert "year" in result["streak"]["duration"]  # "11 years, ..."
+
+    # Last run + last 7 days are in miles
+    assert result["last_run"]["date"] == today_iso
+    assert result["last_run"]["distance_mi"] == pytest.approx(km_to_miles(6.5), abs=0.01)
+    assert result["last_run"]["duration_min"] == 40.0
+    assert len(result["last_7_days"]) == 2
+
+    # Period totals in miles
+    assert result["month_total_mi"] == round(km_to_miles(30.5), 1)
+    assert result["year_total_mi"] == round(km_to_miles(730.0), 1)
+
+    # Goals are null when nothing stored
+    assert result["goals"] == {"yearly": None, "monthly": None}
+
+
+def test_build_status_data_ran_today_false_when_no_run_today() -> None:
+    user_id, source_id = uuid4(), uuid4()
+    runs_repo = _runs_repo_with(
+        stats={"current_streak_days": 0},
+        recent_runs=[
+            {"start_date": "2026-05-08", "distance_km": 5.0, "duration_seconds": 2100},
+        ],
+    )
+    goals_repo = MagicMock()
+    goals_repo.get_by_period.return_value = None
+
+    with patch("backend.jobs.publish_status.datetime") as mock_dt:
+        mock_dt.now.return_value.date.return_value = date(2026, 5, 9)
+        mock_dt.now.return_value.isoformat.return_value = "2026-05-09T14:00:00+00:00"
+        result = build_status_data(user_id, runs_repo, goals_repo, source_id)
+
+    assert result["ran_today"] is False
+
+
+def test_build_status_data_falls_back_to_recalculate_when_stats_missing() -> None:
+    """Missing user_running_stats row triggers recalculate_user_stats."""
+    user_id, source_id = uuid4(), uuid4()
+    runs_repo = MagicMock()
+    runs_repo.get_runs_by_date_range.return_value = []
+    runs_repo.get_user_running_stats.return_value = None
+    runs_repo.recalculate_user_stats.return_value = {
+        "current_streak_days": 1,
+        "current_streak_start": "2026-05-09",
+    }
+
+    goals_repo = MagicMock()
+    goals_repo.get_by_period.return_value = None
+
+    with patch("backend.jobs.publish_status.datetime") as mock_dt:
+        mock_dt.now.return_value.date.return_value = date(2026, 5, 9)
+        mock_dt.now.return_value.isoformat.return_value = "2026-05-09T14:00:00+00:00"
+        result = build_status_data(user_id, runs_repo, goals_repo, source_id)
+
+    runs_repo.recalculate_user_stats.assert_called_once_with(
+        user_id, timezone="America/New_York"
+    )
+    assert result["streak"]["current_days"] == 1
+
+
+def test_build_status_data_uses_defaults_when_recalc_explodes() -> None:
+    """Even if recalculate also fails, we publish a sensible empty-ish payload."""
+    user_id, source_id = uuid4(), uuid4()
+    runs_repo = MagicMock()
+    runs_repo.get_runs_by_date_range.return_value = []
+    runs_repo.get_user_running_stats.return_value = None
+    runs_repo.recalculate_user_stats.side_effect = RuntimeError("supabase down")
+
+    goals_repo = MagicMock()
+    goals_repo.get_by_period.return_value = None
+
+    with patch("backend.jobs.publish_status.datetime") as mock_dt:
+        mock_dt.now.return_value.date.return_value = date(2026, 5, 9)
+        mock_dt.now.return_value.isoformat.return_value = "2026-05-09T14:00:00+00:00"
+        result = build_status_data(user_id, runs_repo, goals_repo, source_id)
+
+    assert result["streak"]["current_days"] == 0
+    assert result["last_run"] is None
+    assert result["last_7_days"] == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_user_and_source
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_user_and_source_returns_first_active() -> None:
+    user_id, src_id = str(uuid4()), str(uuid4())
+    users_repo = MagicMock()
+    users_repo.get_all_active_sources.return_value = [
+        {"user_id": user_id, "id": src_id},
+    ]
+
+    got_user, got_src = resolve_user_and_source(users_repo)
+
+    assert str(got_user) == user_id
+    assert str(got_src) == src_id
+    users_repo.get_all_active_sources.assert_called_once_with(source_type="smashrun")
+
+
+def test_resolve_user_and_source_raises_on_no_sources() -> None:
+    users_repo = MagicMock()
+    users_repo.get_all_active_sources.return_value = []
+
+    with pytest.raises(RuntimeError, match="No active SmashRun sources"):
+        resolve_user_and_source(users_repo)
+
+
+# ---------------------------------------------------------------------------
+# get_gcs_credentials
+# ---------------------------------------------------------------------------
+
+
+def test_get_gcs_credentials_parses_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {"type": "service_account", "project_id": "missing-table"}
+    monkeypatch.setenv("GCS_SERVICE_ACCOUNT_JSON", json.dumps(payload))
+
+    assert get_gcs_credentials() == payload
+
+
+def test_get_gcs_credentials_raises_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GCS_SERVICE_ACCOUNT_JSON", raising=False)
+
+    with pytest.raises(RuntimeError, match="GCS_SERVICE_ACCOUNT_JSON"):
+        get_gcs_credentials()
+
+
+# ---------------------------------------------------------------------------
+# upload_to_gcs (mocked GCS client)
+# ---------------------------------------------------------------------------
+
+
+def test_upload_to_gcs_writes_payload_with_cache_control(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "GCS_SERVICE_ACCOUNT_JSON",
+        json.dumps({"type": "service_account", "project_id": "missing-table"}),
+    )
+
+    blob = MagicMock()
+    bucket = MagicMock()
+    bucket.blob.return_value = blob
+    client = MagicMock()
+    client.bucket.return_value = bucket
+
+    with (
+        patch("backend.jobs.publish_status.service_account.Credentials.from_service_account_info"),
+        patch("backend.jobs.publish_status.storage.Client", return_value=client),
+    ):
+        url = upload_to_gcs({"ran_today": True})
+
+    assert url == "https://storage.googleapis.com/myrunstreak-public/status.json"
+    client.bucket.assert_called_once_with("myrunstreak-public")
+    bucket.blob.assert_called_once_with("status.json")
+    assert blob.cache_control == "public, max-age=300"
+    blob.upload_from_string.assert_called_once()
+    args, kwargs = blob.upload_from_string.call_args
+    assert kwargs["content_type"] == "application/json"
+    # Body must be valid JSON containing the input fields
+    body = json.loads(args[0])
+    assert body["ran_today"] is True

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -3,7 +3,8 @@ revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
+    "python_full_version >= '3.13' and python_full_version < '3.15'",
+    "python_full_version < '3.13'",
 ]
 
 [[package]]
@@ -454,6 +455,112 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.30.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.52.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/f8/80d2493cbedece1c623dc3e3cb1883300871af0dcdae254409522985ac23/google_auth-2.52.0.tar.gz", hash = "sha256:01f30e1a9e3638698d89464f5e603ce29d18e1c0e63ec31ac570aba4e164aaf5", size = 335027, upload-time = "2026-05-07T19:45:24.033Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/fc/2cdc74252746f547f81ff3f02d4d4234a3f411b5de5b61af97e633a060b9/google_auth-2.52.0-py3-none-any.whl", hash = "sha256:aee92803ba0ff93a70a3b8a35c7b4797837751cd6380b63ff38372b98f3ed627", size = 245614, upload-time = "2026-05-07T19:45:21.914Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/dd/1eef226e470369b26824a505c34482c0b493bc35fe8e0c6b003b5feca21a/google_cloud_core-2.6.0.tar.gz", hash = "sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83", size = 36001, upload-time = "2026-05-07T08:04:04.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl", hash = "sha256:6d63ac8e5eca6d9e4319d0a1e2265fadcd7f1049904378caecfa01cf52dd869e", size = 29390, upload-time = "2026-05-07T08:02:34.672Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "3.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/47/205eb8e9a1739b5345843e5a425775cbdc472cc38e7eda082ba5b8d02450/google_cloud_storage-3.10.1.tar.gz", hash = "sha256:97db9aa4460727982040edd2bd13ff3d5e2260b5331ad22895802da1fc2a5286", size = 17309950, upload-time = "2026-03-23T09:35:23.409Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/ff/ca9ab2417fa913d75aae38bf40bf856bb2749a604b2e0f701b37cfcd23cc/google_cloud_storage-3.10.1-py3-none-any.whl", hash = "sha256:a72f656759b7b99bda700f901adcb3425a828d4a29f911bc26b3ea79c5b1217f", size = 324453, upload-time = "2026-03-23T09:35:21.368Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/4b/0b235beccc310d0a48adbc7246b719d173cca6c88c572dfa4b090e39143c/google_resumable_media-2.9.0.tar.gz", hash = "sha256:f7cfb224846a9dd444d125115dfbe8ef02a2b893e78f087762fe716a255a734b", size = 2164534, upload-time = "2026-05-07T08:04:44.236Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/73/3518e63deb1667c5409a4579e28daf5e84479a87a72c547e0487f7883dcd/google_resumable_media-2.9.0-py3-none-any.whl", hash = "sha256:c8901e88e389af8bed64d9696c74d8bad961865eb2236e13e0bfca9bb0a65ca3", size = 81507, upload-time = "2026-05-07T08:03:23.809Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
 ]
 
 [[package]]
@@ -919,6 +1026,7 @@ dependencies = [
     { name = "authlib" },
     { name = "boto3" },
     { name = "fastapi" },
+    { name = "google-cloud-storage" },
     { name = "httpx" },
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
@@ -948,6 +1056,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.35.0" },
     { name = "fakeredis", marker = "extra == 'dev'", specifier = ">=2.20.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "google-cloud-storage", specifier = ">=3.10.1" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
@@ -1091,6 +1200,54 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "proto-plus"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/56/e647b0c675392d2da368da7b6f158f7368b18542fd6f7d7400a2f39de000/proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9", size = 57221, upload-time = "2026-05-07T08:04:50.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl", hash = "sha256:a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8", size = 50410, upload-time = "2026-05-07T08:03:31.962Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
+    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]

--- a/helm/myrunstreak/templates/cronjob-publish-status.yaml
+++ b/helm/myrunstreak/templates/cronjob-publish-status.yaml
@@ -1,0 +1,60 @@
+{{- if and .Values.backend.enabled .Values.backend.cronjobs.publishStatus.enabled }}
+# Replaces the EventBridge → publish_status Lambda flow. Builds the
+# myrunstreak-public/status.json payload from Supabase and uploads it to GCS,
+# so the qualityplaybook.dev tile (and any other embed) gets fresh data.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "myrunstreak.fullname" . }}-publish-status
+  labels:
+    {{- include "myrunstreak.labels" . | nindent 4 }}
+    app.kubernetes.io/component: publish-status-cron
+spec:
+  schedule: {{ .Values.backend.cronjobs.publishStatus.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 300
+      template:
+        metadata:
+          labels:
+            {{- include "myrunstreak.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: publish-status-cron
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: publish-status
+              image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
+              imagePullPolicy: {{ .Values.backend.image.pullPolicy | default "IfNotPresent" }}
+              command: ["python", "-m", "backend.jobs.publish_status"]
+              env:
+                - name: ENVIRONMENT
+                  value: {{ .Values.backend.env.environment | default "dev" | quote }}
+                - name: LOG_LEVEL
+                  value: {{ .Values.backend.env.logLevel | default "INFO" | quote }}
+                - name: SUPABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                      key: supabase-url
+                - name: SUPABASE_SERVICE_ROLE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                      key: supabase-service-key
+                - name: SUPABASE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                      key: supabase-service-key
+                - name: GCS_SERVICE_ACCOUNT_JSON
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                      key: gcs-service-account-json
+              resources:
+                {{- toYaml (.Values.backend.cronjobs.publishStatus.resources | default dict) | nindent 16 }}
+{{- end }}

--- a/helm/myrunstreak/templates/external-secret.yaml
+++ b/helm/myrunstreak/templates/external-secret.yaml
@@ -43,4 +43,8 @@ spec:
       remoteRef:
         key: {{ .Values.externalSecret.awsSecretName | default "myrunstreak-app-secrets" }}
         property: smashrun_client_secret
+    - secretKey: gcs-service-account-json
+      remoteRef:
+        key: {{ .Values.externalSecret.awsSecretName | default "myrunstreak-app-secrets" }}
+        property: gcs_service_account_json
 {{- end }}

--- a/helm/myrunstreak/values.yaml
+++ b/helm/myrunstreak/values.yaml
@@ -99,6 +99,19 @@ backend:
         limits:
           cpu: 500m
           memory: 512Mi
+    publishStatus:
+      enabled: true
+      # Every 15 min — matches what AWS EventBridge ran. The bucket itself
+      # has Cache-Control: max-age=300, so consumers never see > 5 min of
+      # extra staleness on top of the publish cadence.
+      schedule: "*/15 * * * *"
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi
 
 # ============================================================================
 # Redis (cache for backend stats endpoints) — disabled by default


### PR DESCRIPTION
## Summary

Brings back the qualityplaybook.dev \"Did I Run Today?\" tile, which has been stuck on May 3 data since the AWS Lambda that wrote \`gs://myrunstreak-public/status.json\` was decommissioned in Phase C.

- New \`backend/jobs/publish_status.py\` — K8s CronJob entry point (\`python -m backend.jobs.publish_status\`). Builds the same status payload as the old Lambda (preserves the \`StreakData\` shape that \`RunningStreak.vue\` expects) and uploads to GCS with \`Cache-Control: public, max-age=300\`.
- Reads pre-aggregated stats from \`user_running_stats\`, falls back to the \`recalculate_user_stats\` RPC if the row is missing.
- Goals block reads from the \`goals\` table via \`GoalsRepository.get_by_period\` (now populated by #71). When no goal is stored or \`goal_km\` is null, emits \`{yearly: null, monthly: null}\` — \`RunningStreak.vue\` already hides the GOALS section in that case.
- GCS service-account JSON read from \`GCS_SERVICE_ACCOUNT_JSON\` env var (parsed at startup). The publisher SA (\`myrunstreak-publisher@missing-table.iam.gserviceaccount.com\`) and the bucket itself survived the AWS cleanup — only the SA key JSON had to be regenerated and re-injected into \`myrunstreak-app-secrets\`.

## Helm

- New \`cronjob-publish-status.yaml\` CronJob, scheduled \`*/15 * * * *\` (matches the old EventBridge cadence; bucket has 5-min cache so consumers see at most ~20 min staleness).
- \`external-secret.yaml\` extended: \`gcs_service_account_json\` (AWS) → \`gcs-service-account-json\` (k8s Secret key) → \`GCS_SERVICE_ACCOUNT_JSON\` (CronJob pod env).
- \`values.yaml\`: \`backend.cronjobs.publishStatus\` block with schedule and resource requests/limits.

## Tests

\`backend/tests/test_publish_status.py\` — 18 cases:
- Payload shape (top-level keys match \`StreakData\` interface), \`ran_today\` true/false
- \`last_run\` / \`last_7_days\` km→mi conversion
- Goals block: yearly + monthly populated, null when not stored, null when \`goal_km\` is null, no-source short-circuit
- \`format_streak_duration\` pluralization, zero-day boundary
- \`get_user_running_stats\` fallback to \`recalculate_user_stats\`
- Sensible defaults when both stats sources fail
- \`resolve_user_and_source\` picks first active SmashRun source / raises if none
- \`get_gcs_credentials\` parses env var / raises when unset
- \`upload_to_gcs\` writes to correct bucket/blob with cache-control (mocked GCS client)

## Test plan

- [x] Backend suite: 71/71 green
- [x] \`uv run ruff check .\` from backend/ → clean
- [x] \`helm template helm/myrunstreak --show-only templates/cronjob-publish-status.yaml\` renders cleanly
- [x] AWS Secrets Manager \`myrunstreak-app-secrets.gcs_service_account_json\` populated and verified (round-trip read after write)
- [ ] After deploy: \`kubectl logs -n <ns> -l app.kubernetes.io/component=publish-status-cron --tail=50\` shows successful upload
- [ ] After deploy: \`curl https://storage.googleapis.com/myrunstreak-public/status.json | jq .updated_at\` shows a timestamp within the last 15 min
- [ ] Reload qualityplaybook.dev (or clear localStorage \`running_streak_data\`) — \"Did I Run Today?\" tile shows current data, GOALS section visible if goals are stored

## Sequencing notes

- Depends on #71 (merged) — \`goals\` table needs to be populated for the GOALS section to render. If a sync hasn't run yet when this lands, the tile will render without GOALS until the first sync populates the table.
- The new CronJob doesn't need SmashRun creds — it only reads from Supabase and writes to GCS. No SMASHRUN_* env vars wired.

Closes #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)