### PR TITLE
fix: wire SUPABASE_ANON_KEY into sync CronJob env

### DIFF
--- a/helm/myrunstreak/templates/cronjob-sync.yaml
+++ b/helm/myrunstreak/templates/cronjob-sync.yaml
@@ -43,6 +43,11 @@ spec:
                     secretKeyRef:
                       name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
                       key: supabase-url
+                - name: SUPABASE_ANON_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                      key: supabase-anon-key
                 - name: SUPABASE_SERVICE_ROLE_KEY
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
## Why

#70 made \`SUPABASE_ANON_KEY\` a required field on \`backend.config.Settings\` and added the env var to the backend \`Deployment\`, but missed the sync CronJob template. \`backend/jobs/sync_runs.py\` and the \`run_user_sync\` helper both call \`get_settings()\`, so once the new image rolls out the next sync CronJob fire would fail at startup with \`supabase_anon_key field required\`.

Next scheduled sync is **17:00 UTC today** — wants to land before then.

## What

- Adds \`SUPABASE_ANON_KEY\` to \`cronjob-sync.yaml\`, mirroring the wiring already present on the \`Deployment\` (via \`supabase-anon-key\` on the \`myrunstreak-secrets\` k8s Secret, materialized by the existing ExternalSecret).
- No code changes. AWS Secrets Manager already has \`supabase_anon_key\` (verified pre-#70 merge).

## Not affected

The new \`publish-status\` CronJob from #72 doesn't import \`backend.config\` and uses the separate \`src/shared/supabase_client.SupabaseSettings\` class (which has its own non-overlapping field set), so it doesn't need this fix.

## Test plan

- [x] \`helm template helm/myrunstreak --show-only templates/cronjob-sync.yaml | grep SUPABASE_ANON_KEY\` → renders the new env var
- [ ] After deploy: next sync CronJob fire (17:00 UTC) completes successfully — \`kubectl get jobs -l app.kubernetes.io/component=sync-cron\` shows COMPLETIONS=1/1
- [ ] After deploy: \`kubectl logs -l app.kubernetes.io/component=sync-cron --tail=20\` shows the synced-runs log line, not a \`ValidationError\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)