### PR TITLE
fix: read SmashRun OAuth client creds from env on LKE

### DIFF
--- a/backend/tests/test_secrets.py
+++ b/backend/tests/test_secrets.py
@@ -1,0 +1,50 @@
+"""Tests for src/shared/secrets.py — primarily the env-var fast path."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from src.shared.secrets import get_smashrun_oauth_credentials
+
+
+def test_smashrun_creds_from_env_skips_aws(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Both env vars set → return them directly, no AWS call."""
+    monkeypatch.setenv("SMASHRUN_CLIENT_ID", "id-from-env")
+    monkeypatch.setenv("SMASHRUN_CLIENT_SECRET", "secret-from-env")
+
+    with patch("src.shared.secrets.get_secret") as mock_aws:
+        creds = get_smashrun_oauth_credentials()
+
+    assert creds == {"client_id": "id-from-env", "client_secret": "secret-from-env"}
+    mock_aws.assert_not_called()
+
+
+def test_smashrun_creds_falls_back_to_aws_when_env_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Either env var unset → defer to AWS Secrets Manager."""
+    monkeypatch.delenv("SMASHRUN_CLIENT_ID", raising=False)
+    monkeypatch.delenv("SMASHRUN_CLIENT_SECRET", raising=False)
+
+    expected = {"client_id": "from-aws", "client_secret": "from-aws-too"}
+    with patch("src.shared.secrets.get_secret", return_value=expected) as mock_aws:
+        creds = get_smashrun_oauth_credentials()
+
+    assert creds == expected
+    mock_aws.assert_called_once()
+
+
+def test_smashrun_creds_falls_back_when_only_one_env_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Half-set env (only id, no secret) treats env as absent — don't ship a half-cred."""
+    monkeypatch.setenv("SMASHRUN_CLIENT_ID", "id-from-env")
+    monkeypatch.delenv("SMASHRUN_CLIENT_SECRET", raising=False)
+
+    expected = {"client_id": "from-aws", "client_secret": "from-aws-too"}
+    with patch("src.shared.secrets.get_secret", return_value=expected) as mock_aws:
+        creds = get_smashrun_oauth_credentials()
+
+    assert creds == expected
+    mock_aws.assert_called_once()

--- a/src/shared/secrets.py
+++ b/src/shared/secrets.py
@@ -68,14 +68,22 @@ def get_supabase_credentials() -> dict[str, str]:
 
 def get_smashrun_oauth_credentials() -> dict[str, str]:
     """
-    Get SmashRun OAuth client credentials from Secrets Manager.
+    Get SmashRun OAuth client credentials.
+
+    Prefers env vars (``SMASHRUN_CLIENT_ID`` / ``SMASHRUN_CLIENT_SECRET``)
+    when both are set — that's how the LKE backend gets them via
+    ExternalSecrets → k8s Secret. Falls back to AWS Secrets Manager only
+    when env vars are absent (legacy Lambda path; reachable only with AWS
+    creds + region available, which the LKE pods don't have).
 
     Returns:
-        Dict with OAuth credentials including:
-        - access_token
-        - refresh_token
-        - (future: client_id, client_secret)
+        Dict with ``client_id`` and ``client_secret`` keys.
     """
+    client_id = os.environ.get("SMASHRUN_CLIENT_ID")
+    client_secret = os.environ.get("SMASHRUN_CLIENT_SECRET")
+    if client_id and client_secret:
+        return {"client_id": client_id, "client_secret": client_secret}
+
     environment = os.environ.get("ENVIRONMENT", "dev")
     secret_name = f"myrunstreak/{environment}/smashrun/oauth"
     return get_secret(secret_name)


### PR DESCRIPTION
## Why

\`sync_runs\` has been silently failing every fire since **2026-05-03 17:00 UTC** — that was the last successful sync (\`user_running_stats.last_calculated_at\`). Symptom: \`runs\` table frozen on May 3, no streak/totals updates, goals not refreshing. Six days of dropped syncs that nobody noticed because the publish_status fix unmasked it (status.json now has a fresh \`updated_at\` but stale data underneath).

## Root cause

\`backend/routes/sync.py:69\` calls \`get_smashrun_oauth_credentials()\` once the SmashRun access token is expired (which happened sometime after May 3). That helper uses **boto3 to query AWS Secrets Manager**. From inside an LKE pod, boto3 has no AWS credentials — it tries the EC2 metadata service at \`169.254.169.254\` (1s timeout, fails on Linode), then bails with \`NoRegionError: You must specify a region\`. The whole token-refresh path explodes; sync aborts before pulling new runs.

Captured the stack trace by running the sync image as a long-lived debug Pod (\`restartPolicy: Never\`) instead of a Job — Jobs delete their pods on failure too fast for \`kubectl logs\` to catch.

## Fix

Make \`get_smashrun_oauth_credentials()\` prefer env vars when both \`SMASHRUN_CLIENT_ID\` and \`SMASHRUN_CLIENT_SECRET\` are set; fall back to AWS Secrets Manager only when env is absent (legacy Lambda path).

The LKE backend Deployment + \`cronjob-sync\` + \`cronjob-publish-status\` all already wire those env vars from the ExternalSecret-materialized \`myrunstreak-secrets\` Secret, so **no helm change needed** — every caller is unblocked by the Python fix alone.

Affects three call sites in the new backend, all of which only need \`client_id\` + \`client_secret\` (token data has moved to Supabase via \`TokenRepository\`):
- \`backend/routes/sync.py:69\` (token refresh during sync)
- \`backend/routes/auth_routes.py:155\` (\`/auth/login-url\`)
- \`backend/routes/auth_routes.py:174\` (\`/auth/callback\`)

## Tests

\`backend/tests/test_secrets.py\` — 3 cases:
- Both env vars set → return them, no AWS call
- Both env vars unset → defer to \`get_secret\`
- Half-set (only \`SMASHRUN_CLIENT_ID\`) → defer to AWS, don't ship a half-cred

Full backend suite: 74/74 green.

## Test plan

- [x] Unit tests cover all three branches
- [ ] After deploy: manually fire sync — \`kubectl create job --from=cronjob/myrunstreak-sync sync-verify-\$(date +%s) -n myrunstreak\`
- [ ] Pod completes successfully (\`kubectl get jobs -n myrunstreak | grep sync-verify\`)
- [ ] Supabase \`runs\` table grows past 2026-05-03 (today's runs land)
- [ ] \`user_running_stats.last_calculated_at\` is within the last few minutes
- [ ] \`goals\` rows refreshed (yearly + current-month \`fetched_at\` recent)
- [ ] Next \`publish_status\` fire emits status.json with current streak / today's last_run / current goals — qualityplaybook.dev tile renders correctly

## Why this didn't show up earlier

- AWS Lambda decommission (Phase C, ~May 4) killed the previous sync path. The new LKE \`sync_runs\` CronJob was deployed but only worked while the SmashRun access token was still valid (until May 3). Every refresh attempt since failed silently — the CronJob's \`failedJobsHistoryLimit: 3\` rotated the oldest failures out before anyone looked.
- Backend tests don't exercise the token-refresh branch (no integration coverage of the SmashRun OAuth flow). A follow-up could add an integration test that injects an expired token row and verifies the refresh path completes; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)