### PR TITLE
fix: recalculate user_running_stats after each sync

### DIFF
--- a/backend/routes/sync.py
+++ b/backend/routes/sync.py
@@ -113,6 +113,15 @@ def run_user_sync(
         except Exception as exc:  # noqa: BLE001
             logger.warning(f"Goal sync failed for source {source_id}: {exc}")
 
+    # Refresh user_running_stats so streak/totals reflect the runs we just
+    # upserted. The aggregation row is what status.json + the dashboard
+    # both read; without this call it stays frozen at the prior sync's
+    # values (e.g. last_run_date never advances past the old streak end).
+    try:
+        runs_repo.recalculate_user_stats(user_id, timezone="America/New_York")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(f"recalculate_user_stats failed for {user_id}: {exc}")
+
     return {
         "message": "Sync completed",
         "runs_synced": runs_synced,

--- a/backend/tests/test_sync_goals.py
+++ b/backend/tests/test_sync_goals.py
@@ -127,3 +127,75 @@ def test_settings_drive_per_period_ttl() -> None:
     ttl_args = [call.args[1] for call in repo.is_stale.call_args_list]
     assert timedelta(days=settings.goal_yearly_staleness_days) in ttl_args
     assert timedelta(days=settings.goal_monthly_staleness_days) in ttl_args
+
+
+def test_run_user_sync_recalculates_user_stats() -> None:
+    """sync must call RunsRepository.recalculate_user_stats so the
+    user_running_stats aggregation row reflects the runs just upserted."""
+    user_id = uuid4()
+    source_id = uuid4()
+
+    token_repo = MagicMock()
+    token_repo.get_source_id_for_user.return_value = source_id
+    token_repo.get_user_tokens.return_value = {
+        "access_token": "tok",
+        "refresh_token": "ref",
+    }
+    token_repo.is_token_expired.return_value = False
+
+    runs_repo_instance = MagicMock()
+
+    api = MagicMock()
+    api.get_all_activities_since.return_value = []
+    api_ctx = MagicMock()
+    api_ctx.__enter__ = MagicMock(return_value=api)
+    api_ctx.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("backend.routes.sync.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.sync.RunsRepository", return_value=runs_repo_instance),
+        patch("backend.routes.sync.TokenRepository", return_value=token_repo),
+        patch("backend.routes.sync.GoalsRepository"),
+        patch("backend.routes.sync.SmashRunAPIClient", return_value=api_ctx),
+        patch("backend.routes.sync.sync_current_goals"),
+    ):
+        run_user_sync(user_id)
+
+    runs_repo_instance.recalculate_user_stats.assert_called_once_with(
+        user_id, timezone="America/New_York"
+    )
+
+
+def test_run_user_sync_swallows_recalc_failure() -> None:
+    """A recalculate_user_stats exception must not fail the whole sync."""
+    user_id = uuid4()
+    source_id = uuid4()
+
+    token_repo = MagicMock()
+    token_repo.get_source_id_for_user.return_value = source_id
+    token_repo.get_user_tokens.return_value = {
+        "access_token": "tok",
+        "refresh_token": "ref",
+    }
+    token_repo.is_token_expired.return_value = False
+
+    runs_repo_instance = MagicMock()
+    runs_repo_instance.recalculate_user_stats.side_effect = RuntimeError("supabase down")
+
+    api = MagicMock()
+    api.get_all_activities_since.return_value = []
+    api_ctx = MagicMock()
+    api_ctx.__enter__ = MagicMock(return_value=api)
+    api_ctx.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("backend.routes.sync.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.sync.RunsRepository", return_value=runs_repo_instance),
+        patch("backend.routes.sync.TokenRepository", return_value=token_repo),
+        patch("backend.routes.sync.GoalsRepository"),
+        patch("backend.routes.sync.SmashRunAPIClient", return_value=api_ctx),
+        patch("backend.routes.sync.sync_current_goals"),
+    ):
+        result = run_user_sync(user_id)
+
+    assert result["message"] == "Sync completed"


### PR DESCRIPTION
## Why

The old AWS Lambda called \`runs_repo.recalculate_user_stats(user_id, timezone=\"America/New_York\")\` at the end of every per-source sync. The LKE port (\`backend/routes/sync.py:run_user_sync\`) dropped that call. Result: runs upserted into Supabase, but the \`user_running_stats\` aggregation row — which both \`publish_status\` (status.json) and the dashboard read — stayed frozen at whatever the AWS Lambda last computed (\`last_calculated_at: 2026-05-03T17:00:16 UTC\`).

Today after #68 (publish_status restored) and #74 (sync token-refresh fixed), runs finally started flowing again — but the tile still showed \`streak_days=4271\` and \`last_run=2026-05-03\` because the aggregation row never updated. Manual call of the \`recalculate_user_stats\` RPC against prod confirmed the streak is actually **4277 days** (intact), and the tile now renders correctly.

This PR makes the recalc part of every sync going forward so the regression doesn't return.

## Change

\`backend/routes/sync.py:run_user_sync\` — after the goals-refresh block, call \`runs_repo.recalculate_user_stats(user_id, timezone=\"America/New_York\")\` and swallow any exception (same pattern as the goals-refresh failure handling already in the function).

## Tests

\`backend/tests/test_sync_goals.py\` — 2 new cases:
- \`test_run_user_sync_recalculates_user_stats\` — verifies the RPC is called exactly once per sync, with the \`America/New_York\` timezone arg
- \`test_run_user_sync_swallows_recalc_failure\` — RPC throwing must not break sync

Full backend suite: 76/76 green.

## Test plan

- [x] Unit tests cover both branches
- [x] Manual recalc via \`/tmp/recalc_stats.py\` confirmed streak math is correct (4277 days, year_to_date 762 km, last_run_date 2026-05-09)
- [ ] After deploy: fire \`kubectl create job --from=cronjob/myrunstreak-sync verify-recalc-\$(date +%s) -n myrunstreak\`
- [ ] Confirm \`user_running_stats.last_calculated_at\` advances on every successful sync, not just when the row is missing
- [ ] Tile remains correct after a few sync cycles

## Why this didn't show up earlier

The publish_status fallback already handles \"row missing\" by calling recalc. It does *not* handle \"row stale\" — that's the gap the missing sync-side recalc was hiding. With the AWS Lambda, the row was always fresh. With the LKE backend, the row was stuck at May 3 for 6 days while syncs silently failed (#74). Once syncs started succeeding again, the staleness of the aggregation row became visible.

Closes the last regression in the chain that started with the broken qualityplaybook.dev tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)