### PR TITLE
feat: GET /stats/goals endpoint + extract shared goals block

### DIFF
--- a/backend/goals.py
+++ b/backend/goals.py
@@ -1,0 +1,58 @@
+"""Goals-block presentation logic, shared between publish_status and /stats/goals.
+
+The shape this module emits matches the GoalProgress interface that
+qualityplaybook.dev's RunningStreak.vue expects, so the public status.json
+and the dashboard's /stats/goals endpoint return structurally identical
+goal payloads.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+from uuid import UUID
+
+from src.shared.supabase_ops import GoalsRepository
+
+KM_TO_MILES = 0.621371
+
+
+def km_to_miles(km: float) -> float:
+    return km * KM_TO_MILES
+
+
+def render_goal(row: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Convert a goals-table row into the GoalProgress payload (miles).
+
+    Returns None when the row is absent or its goal_km is null (the
+    "no goal set on SmashRun" placeholder mark_absent writes).
+    """
+    if not row or row.get("goal_km") is None:
+        return None
+    goal_km = float(row["goal_km"])
+    progress_km = float(row.get("progress_km") or 0.0)
+    percent = (progress_km / goal_km * 100) if goal_km > 0 else None
+    return {
+        "goal_mi": round(km_to_miles(goal_km), 1),
+        "progress_mi": round(km_to_miles(progress_km), 1),
+        "percent": round(percent, 1) if percent is not None else None,
+        "text": row.get("goal_text"),
+        "fetched_at": row.get("fetched_at"),
+    }
+
+
+def build_goals_block(
+    user_id: UUID,
+    source_id: UUID | None,
+    goals_repo: GoalsRepository,
+    today: date,
+) -> dict[str, Any]:
+    """Yearly + monthly goal progress, in miles. Each is None when the user
+    has no goal stored for the period (or no SmashRun source at all).
+    """
+    if source_id is None:
+        return {"yearly": None, "monthly": None}
+
+    yearly_row = goals_repo.get_by_period(user_id, source_id, today.year, None)
+    monthly_row = goals_repo.get_by_period(user_id, source_id, today.year, today.month)
+    return {"yearly": render_goal(yearly_row), "monthly": render_goal(monthly_row)}

--- a/backend/jobs/publish_status.py
+++ b/backend/jobs/publish_status.py
@@ -21,6 +21,7 @@ from typing import Any
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
+from backend.goals import build_goals_block, km_to_miles
 from dateutil.relativedelta import relativedelta
 from google.cloud import storage
 from google.oauth2 import service_account
@@ -30,13 +31,8 @@ from src.shared.supabase_ops import GoalsRepository, RunsRepository, UsersReposi
 GCS_BUCKET_NAME = "myrunstreak-public"
 GCS_OBJECT_PATH = "status.json"
 USER_TIMEZONE = ZoneInfo("America/New_York")
-KM_TO_MILES = 0.621371
 
 logger = logging.getLogger(__name__)
-
-
-def km_to_miles(km: float) -> float:
-    return km * KM_TO_MILES
 
 
 def format_streak_duration(streak_start: str | None, today: date) -> str | None:
@@ -91,40 +87,6 @@ def upload_to_gcs(data: dict[str, Any]) -> str:
     public_url = f"https://storage.googleapis.com/{GCS_BUCKET_NAME}/{GCS_OBJECT_PATH}"
     logger.info(f"Uploaded status to {public_url}")
     return public_url
-
-
-def build_goals_block(
-    user_id: UUID,
-    source_id: UUID | None,
-    goals_repo: GoalsRepository,
-    today: date,
-) -> dict[str, Any]:
-    """Yearly + monthly goal progress, in miles. Each is None when the user
-    has no goal stored for the period (or no SmashRun source at all).
-
-    Shape matches the GoalProgress interface in
-    qualityplaybook.dev/frontend/src/components/RunningStreak.vue.
-    """
-    if source_id is None:
-        return {"yearly": None, "monthly": None}
-
-    def render(row: dict[str, Any] | None) -> dict[str, Any] | None:
-        if not row or row.get("goal_km") is None:
-            return None
-        goal_km = float(row["goal_km"])
-        progress_km = float(row.get("progress_km") or 0.0)
-        percent = (progress_km / goal_km * 100) if goal_km > 0 else None
-        return {
-            "goal_mi": round(km_to_miles(goal_km), 1),
-            "progress_mi": round(km_to_miles(progress_km), 1),
-            "percent": round(percent, 1) if percent is not None else None,
-            "text": row.get("goal_text"),
-            "fetched_at": row.get("fetched_at"),
-        }
-
-    yearly_row = goals_repo.get_by_period(user_id, source_id, today.year, None)
-    monthly_row = goals_repo.get_by_period(user_id, source_id, today.year, today.month)
-    return {"yearly": render(yearly_row), "monthly": render(monthly_row)}
 
 
 def build_status_data(

--- a/backend/routes/stats.py
+++ b/backend/routes/stats.py
@@ -12,10 +12,11 @@ from zoneinfo import ZoneInfo
 
 from backend.auth import authenticate_request
 from backend.cache import cached
+from backend.goals import build_goals_block
 from backend.streaks import compute_streaks
 from fastapi import APIRouter, Depends, Query
 from src.shared.supabase_client import get_supabase_client
-from src.shared.supabase_ops import RunsRepository
+from src.shared.supabase_ops import GoalsRepository, RunsRepository, TokenRepository
 
 router = APIRouter(prefix="/stats", tags=["stats"])
 
@@ -179,3 +180,28 @@ async def get_records(
     user_id: UUID = Depends(authenticate_request),
 ) -> dict[str, Any]:
     return await _records(user_id)
+
+
+@cached(ttl=60, key_prefix="stats:goals")
+async def _goals(user_id: UUID) -> dict[str, Any]:
+    supabase = get_supabase_client()
+    token_repo = TokenRepository(supabase)
+    goals_repo = GoalsRepository(supabase)
+
+    source_id = token_repo.get_source_id_for_user(user_id, "smashrun")
+    return build_goals_block(user_id, source_id, goals_repo, _today_local())
+
+
+@router.get("/goals")
+async def get_goals(
+    user_id: UUID = Depends(authenticate_request),
+) -> dict[str, Any]:
+    """Current-year and current-month distance goals for the authenticated user.
+
+    Reads from the ``goals`` table (populated on each sync). Either field is
+    null when no goal is stored for that period or no SmashRun source is
+    linked. Shape matches what the publish_status job emits to status.json,
+    so the dashboard and the public qualityplaybook.dev tile share the same
+    GoalProgress structure.
+    """
+    return await _goals(user_id)

--- a/backend/tests/test_goals_module.py
+++ b/backend/tests/test_goals_module.py
@@ -1,0 +1,91 @@
+"""Tests for backend.goals — shared goals-block presentation."""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from backend.goals import build_goals_block, km_to_miles, render_goal
+
+
+def test_km_to_miles() -> None:
+    assert km_to_miles(1.609344) == pytest.approx(1.0, abs=0.001)
+
+
+def test_render_goal_returns_none_for_missing_row() -> None:
+    assert render_goal(None) is None
+
+
+def test_render_goal_returns_none_when_goal_km_is_null() -> None:
+    """Placeholder 'absent' row from GoalsRepository.mark_absent."""
+    row = {"goal_km": None, "progress_km": None, "fetched_at": "2026-05-09T19:00:00Z"}
+    assert render_goal(row) is None
+
+
+def test_render_goal_full_payload() -> None:
+    row = {
+        "goal_km": 1931.2,
+        "progress_km": 762.0,
+        "goal_text": "1200 mi this year",
+        "fetched_at": "2026-05-09T19:31:44Z",
+    }
+    result = render_goal(row)
+    assert result is not None
+    assert result["goal_mi"] == pytest.approx(1200.0, abs=0.2)
+    assert result["progress_mi"] == pytest.approx(473.5, abs=0.2)
+    assert result["percent"] == pytest.approx(39.5, abs=0.2)
+    assert result["text"] == "1200 mi this year"
+    assert result["fetched_at"] == "2026-05-09T19:31:44Z"
+
+
+def test_render_goal_zero_goal_km_yields_null_percent() -> None:
+    """Belt-and-suspenders — the schema CHECK forbids goal_km <= 0,
+    but if a 0 ever leaked through we shouldn't divide by zero."""
+    row = {"goal_km": 0.0, "progress_km": 0.0, "fetched_at": "2026-05-09T19:00:00Z"}
+    # goal_km == 0 means no goal worth showing — render_goal treats it as
+    # absent only when goal_km is *None*; with 0.0 it returns a row but
+    # percent = None (not a divide-by-zero crash).
+    result = render_goal(row)
+    assert result is not None
+    assert result["percent"] is None
+
+
+def test_build_goals_block_no_source_returns_nulls() -> None:
+    repo = MagicMock()
+    result = build_goals_block(uuid4(), None, repo, date(2026, 5, 9))
+
+    assert result == {"yearly": None, "monthly": None}
+    repo.get_by_period.assert_not_called()
+
+
+def test_build_goals_block_queries_yearly_and_monthly() -> None:
+    user_id, source_id = uuid4(), uuid4()
+    repo = MagicMock()
+    repo.get_by_period.side_effect = [
+        {"goal_km": 1931.2, "progress_km": 762.0, "goal_text": "year", "fetched_at": "Z"},
+        {"goal_km": 201.2, "progress_km": 62.5, "goal_text": "month", "fetched_at": "Z"},
+    ]
+
+    result = build_goals_block(user_id, source_id, repo, date(2026, 5, 9))
+
+    assert repo.get_by_period.call_args_list[0].args == (user_id, source_id, 2026, None)
+    assert repo.get_by_period.call_args_list[1].args == (user_id, source_id, 2026, 5)
+    assert result["yearly"]["text"] == "year"
+    assert result["monthly"]["text"] == "month"
+
+
+def test_build_goals_block_handles_one_period_missing() -> None:
+    """One period stored, the other absent — render only the populated one."""
+    user_id, source_id = uuid4(), uuid4()
+    repo = MagicMock()
+    repo.get_by_period.side_effect = [
+        None,  # no yearly row
+        {"goal_km": 201.2, "progress_km": 62.5, "fetched_at": "Z"},
+    ]
+
+    result = build_goals_block(user_id, source_id, repo, date(2026, 5, 9))
+
+    assert result["yearly"] is None
+    assert result["monthly"] is not None

--- a/backend/tests/test_stats_goals.py
+++ b/backend/tests/test_stats_goals.py
@@ -1,0 +1,128 @@
+"""Tests for the GET /stats/goals route."""
+
+from __future__ import annotations
+
+import importlib
+from datetime import date
+from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make @cached a no-op so each test exercises the real fetch path
+    without needing a Redis (or worrying about cross-test bleed)."""
+    monkeypatch.setenv("CACHE_ENABLED", "false")
+    import backend.cache
+    import backend.config
+    import backend.routes.stats
+
+    importlib.reload(backend.config)
+    importlib.reload(backend.cache)
+    importlib.reload(backend.routes.stats)
+
+
+@pytest.fixture
+def user_id() -> str:
+    return str(uuid4())
+
+
+async def _call(user_id: str) -> dict:
+    """Invoke the cached _goals helper directly so tests don't require a
+    full FastAPI ASGI client."""
+    from backend.routes.stats import _goals
+
+    return await _goals(UUID(user_id))
+
+
+@pytest.mark.asyncio
+async def test_goals_returns_yearly_and_monthly(user_id: str) -> None:
+    """Both periods stored → both rendered, fields in miles."""
+    source_id = uuid4()
+    token_repo = MagicMock()
+    token_repo.get_source_id_for_user.return_value = source_id
+
+    goals_repo = MagicMock()
+    goals_repo.get_by_period.side_effect = [
+        {"goal_km": 1931.2, "progress_km": 762.0, "goal_text": "1200 mi", "fetched_at": "Z"},
+        {"goal_km": 201.2, "progress_km": 62.5, "goal_text": "125 mi", "fetched_at": "Z"},
+    ]
+
+    with (
+        patch("backend.routes.stats.get_supabase_client"),
+        patch("backend.routes.stats.TokenRepository", return_value=token_repo),
+        patch("backend.routes.stats.GoalsRepository", return_value=goals_repo),
+    ):
+        result = await _call(user_id)
+
+    assert result["yearly"]["goal_mi"] == pytest.approx(1200.0, abs=0.2)
+    assert result["yearly"]["text"] == "1200 mi"
+    assert result["monthly"]["goal_mi"] == pytest.approx(125.0, abs=0.2)
+    assert result["monthly"]["text"] == "125 mi"
+
+
+@pytest.mark.asyncio
+async def test_goals_returns_nulls_when_no_source(user_id: str) -> None:
+    """User has no SmashRun source linked → both periods null, no goals query."""
+    token_repo = MagicMock()
+    token_repo.get_source_id_for_user.return_value = None
+
+    goals_repo = MagicMock()
+
+    with (
+        patch("backend.routes.stats.get_supabase_client"),
+        patch("backend.routes.stats.TokenRepository", return_value=token_repo),
+        patch("backend.routes.stats.GoalsRepository", return_value=goals_repo),
+    ):
+        result = await _call(user_id)
+
+    assert result == {"yearly": None, "monthly": None}
+    goals_repo.get_by_period.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_goals_returns_nulls_when_periods_unfetched(user_id: str) -> None:
+    """User has source but no goals stored yet → both null."""
+    source_id = uuid4()
+    token_repo = MagicMock()
+    token_repo.get_source_id_for_user.return_value = source_id
+
+    goals_repo = MagicMock()
+    goals_repo.get_by_period.return_value = None
+
+    with (
+        patch("backend.routes.stats.get_supabase_client"),
+        patch("backend.routes.stats.TokenRepository", return_value=token_repo),
+        patch("backend.routes.stats.GoalsRepository", return_value=goals_repo),
+    ):
+        result = await _call(user_id)
+
+    assert result == {"yearly": None, "monthly": None}
+
+
+@pytest.mark.asyncio
+async def test_goals_uses_current_year_month_in_ny_tz(user_id: str) -> None:
+    """build_goals_block must be called with today() in America/New_York,
+    so the 'current month' is consistent with publish_status."""
+    source_id = uuid4()
+    token_repo = MagicMock()
+    token_repo.get_source_id_for_user.return_value = source_id
+
+    goals_repo = MagicMock()
+    goals_repo.get_by_period.return_value = None
+
+    fixed_date = date(2026, 5, 9)
+    with (
+        patch("backend.routes.stats.get_supabase_client"),
+        patch("backend.routes.stats.TokenRepository", return_value=token_repo),
+        patch("backend.routes.stats.GoalsRepository", return_value=goals_repo),
+        patch("backend.routes.stats._today_local", return_value=fixed_date),
+    ):
+        await _call(user_id)
+
+    yearly_call = goals_repo.get_by_period.call_args_list[0]
+    monthly_call = goals_repo.get_by_period.call_args_list[1]
+    assert yearly_call.args[2] == 2026 and yearly_call.args[3] is None
+    assert monthly_call.args[2] == 2026 and monthly_call.args[3] == 5


### PR DESCRIPTION
## Summary

First half of #76 — backend support for the goals dashboard work.

- **New endpoint \`GET /stats/goals\`** — JWT-gated, 60s cached. Returns the user's current-year and current-month distance goals from the \`goals\` table.
- **Extract \`build_goals_block\` to \`backend/goals.py\`** — same logic was inline in \`backend/jobs/publish_status.py\`. Both call sites (route + status.json publisher) now share one source of truth so the dashboard and the public qualityplaybook.dev tile emit structurally identical payloads.

## Response shape

Matches the existing \`GoalProgress\` interface in \`qualityplaybook.dev/frontend/src/components/RunningStreak.vue\`:

\`\`\`json
{
  \"yearly\":  { \"goal_mi\": 1200.0, \"progress_mi\": 762.0, \"percent\": 63.5, \"text\": \"...\", \"fetched_at\": \"...\" },
  \"monthly\": { \"goal_mi\": 125.0,  \"progress_mi\": 38.8,  \"percent\": 31.0, \"text\": \"...\", \"fetched_at\": \"...\" }
}
\`\`\`

Either field is \`null\` when:
- No row stored for the period
- \`goal_km\` is null (the placeholder \`GoalsRepository.mark_absent\` writes when the user has no goal set on SmashRun for that period)
- The user has no SmashRun source linked

\"Current month\" uses the same \`America/New_York\` anchor that \`publish_status\` uses, via the existing \`_today_local()\` helper in \`stats.py\`.

## Tests

- \`backend/tests/test_goals_module.py\` — 8 cases on the extracted helpers (\`km_to_miles\`, \`render_goal\` for null/missing/zero/full, \`build_goals_block\` for no-source/both-periods/one-missing)
- \`backend/tests/test_stats_goals.py\` — 4 cases on the route (both populated, no source, periods unfetched, current-year-month resolution)
- Existing \`test_publish_status.py\` — 18/18 still pass after the extraction (\`build_goals_block\` re-exposed on the publish_status module via from-import)

## Test plan

- [x] Backend suite: 88/88 green (\`PYTHONPATH=. uv run pytest backend/tests/ -q\`)
- [x] \`uv run ruff check .\` clean
- [ ] After deploy: \`curl -H \"Authorization: Bearer \$TOKEN\" https://api.myrunstreak.run/stats/goals\` returns the expected shape with current goal data
- [ ] Confirm cache works — second call within 60s should hit Redis (not visible in payload but visible in backend logs as \"cache hit\")
- [ ] \`status.json\` (qualityplaybook tile) still renders correctly post-rollout — the publish_status refactor is import-only, no behavior change, but worth a sanity check after the next CronJob fire

## Sequencing

Frontend wiring (compact \`StreakHero\` + new \`GoalsCard\` + \`DashboardView\` layout change) follows in a second PR. Splitting them keeps each diff reviewable and lets the backend ship independently — frontend can stub against this once merged.

Part of #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)