### PR TITLE
feat: goals card on dashboard hero

### DIFF
--- a/frontend/src/components/GoalsCard.vue
+++ b/frontend/src/components/GoalsCard.vue
@@ -1,0 +1,180 @@
+<template>
+  <div class="bg-white rounded-2xl shadow-md p-6 h-full border border-gray-100">
+    <div class="flex items-center gap-2 mb-4">
+      <span class="text-lg">🎯</span>
+      <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-700">
+        Goals
+      </h3>
+    </div>
+
+    <!-- Empty state: no goals stored at all -->
+    <div
+      v-if="!yearly && !monthly"
+      class="text-sm text-gray-500"
+    >
+      No goals set on SmashRun for this period.
+    </div>
+
+    <!-- Monthly goal -->
+    <div v-if="monthly" class="mb-4">
+      <div class="flex items-start justify-between gap-2 mb-1">
+        <span class="text-xs font-medium text-gray-700">
+          📅 {{ currentMonthName }}
+          <span v-if="monthlyPercent >= 100" class="ml-1">🎉</span>
+        </span>
+        <span class="text-xs font-semibold text-gray-900 whitespace-nowrap">
+          {{ monthly.progress_mi.toFixed(1) }} / {{ monthly.goal_mi.toFixed(0) }} mi
+        </span>
+      </div>
+      <p
+        v-if="monthly.text"
+        class="text-xs text-gray-500 italic mb-1.5 line-clamp-2"
+        :title="monthly.text ?? undefined"
+      >
+        {{ monthly.text }}
+      </p>
+      <div class="w-full bg-gray-200 rounded-full h-2 overflow-hidden">
+        <div
+          class="h-2 rounded-full transition-all duration-500"
+          :class="progressBarColor(monthlyPercent, monthlyPaceDelta)"
+          :style="{ width: Math.min(monthlyPercent, 100) + '%' }"
+        ></div>
+      </div>
+      <div class="flex justify-between items-center mt-1 text-xs">
+        <span class="text-gray-500">
+          {{ monthlyPercent.toFixed(1) }}%
+        </span>
+        <span v-if="monthlyPercent >= 100" class="text-green-600 font-medium">
+          🎉 Goal achieved!
+        </span>
+        <span v-else :class="paceColor(monthlyPaceDelta)">
+          {{ formatMilesDelta(monthlyMilesDelta) }}
+        </span>
+      </div>
+    </div>
+
+    <!-- Yearly goal -->
+    <div v-if="yearly">
+      <div class="flex items-start justify-between gap-2 mb-1">
+        <span class="text-xs font-medium text-gray-700">
+          🎯 {{ currentYear }}
+          <span v-if="yearlyPercent >= 100" class="ml-1">🎉</span>
+        </span>
+        <span class="text-xs font-semibold text-gray-900 whitespace-nowrap">
+          {{ yearly.progress_mi.toFixed(1) }} / {{ yearly.goal_mi.toFixed(0) }} mi
+        </span>
+      </div>
+      <p
+        v-if="yearly.text"
+        class="text-xs text-gray-500 italic mb-1.5 line-clamp-2"
+        :title="yearly.text ?? undefined"
+      >
+        {{ yearly.text }}
+      </p>
+      <div class="w-full bg-gray-200 rounded-full h-2 overflow-hidden">
+        <div
+          class="h-2 rounded-full transition-all duration-500"
+          :class="progressBarColor(yearlyPercent, yearlyPaceDelta)"
+          :style="{ width: Math.min(yearlyPercent, 100) + '%' }"
+        ></div>
+      </div>
+      <div class="flex justify-between items-center mt-1 text-xs">
+        <span class="text-gray-500">
+          {{ yearlyPercent.toFixed(1) }}%
+        </span>
+        <span v-if="yearlyPercent >= 100" class="text-green-600 font-medium">
+          🎉 Goal achieved!
+        </span>
+        <span v-else :class="paceColor(yearlyPaceDelta)">
+          {{ formatMilesDelta(yearlyMilesDelta) }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { GoalProgress } from '@/types/runs'
+
+const props = defineProps<{
+  yearly: GoalProgress | null
+  monthly: GoalProgress | null
+}>()
+
+const now = new Date()
+const currentYear = now.getFullYear()
+const currentMonthName = now.toLocaleDateString('en-US', { month: 'long' })
+
+// Pace math — compare actual % against expected % (day-of-period / days-in-period).
+// Backend's percent field can lag the live progress_mi if it was computed against
+// stale progress_km; recompute locally so the bar matches what we display above.
+const monthlyPercent = computed((): number => {
+  if (!props.monthly || props.monthly.goal_mi <= 0) return 0
+  return (props.monthly.progress_mi / props.monthly.goal_mi) * 100
+})
+
+const yearlyPercent = computed((): number => {
+  if (!props.yearly || props.yearly.goal_mi <= 0) return 0
+  return (props.yearly.progress_mi / props.yearly.goal_mi) * 100
+})
+
+const expectedMonthlyPct = computed((): number => {
+  const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate()
+  return (now.getDate() / daysInMonth) * 100
+})
+
+const expectedYearlyPct = computed((): number => {
+  const start = new Date(now.getFullYear(), 0, 0)
+  const dayOfYear = Math.floor((now.getTime() - start.getTime()) / 86400000)
+  const isLeap =
+    (now.getFullYear() % 4 === 0 && now.getFullYear() % 100 !== 0) ||
+    now.getFullYear() % 400 === 0
+  return (dayOfYear / (isLeap ? 366 : 365)) * 100
+})
+
+const monthlyPaceDelta = computed((): number | null =>
+  props.monthly ? monthlyPercent.value - expectedMonthlyPct.value : null,
+)
+
+const yearlyPaceDelta = computed((): number | null =>
+  props.yearly ? yearlyPercent.value - expectedYearlyPct.value : null,
+)
+
+const monthlyMilesDelta = computed((): number | null => {
+  const delta = monthlyPaceDelta.value
+  if (delta === null || !props.monthly) return null
+  return (delta / 100) * props.monthly.goal_mi
+})
+
+const yearlyMilesDelta = computed((): number | null => {
+  const delta = yearlyPaceDelta.value
+  if (delta === null || !props.yearly) return null
+  return (delta / 100) * props.yearly.goal_mi
+})
+
+const formatMilesDelta = (milesDelta: number | null): string => {
+  if (milesDelta === null) return ''
+  const abs = Math.abs(milesDelta).toFixed(1)
+  if (milesDelta >= 0.1) return `${abs} mi ahead of pace`
+  if (milesDelta <= -0.1) return `${abs} mi behind pace`
+  return 'on pace'
+}
+
+const paceColor = (delta: number | null): string => {
+  if (delta === null) return 'text-gray-500'
+  if (delta >= 0.5) return 'text-green-600 font-medium'
+  if (delta <= -5) return 'text-red-600 font-medium'
+  if (delta <= -0.5) return 'text-amber-600 font-medium'
+  return 'text-gray-500'
+}
+
+const progressBarColor = (percent: number, delta: number | null): string => {
+  if (percent >= 100) return 'bg-green-500'
+  if (delta === null) return 'bg-blue-500'
+  if (delta >= 0.5) return 'bg-green-500'
+  if (delta <= -5) return 'bg-red-500'
+  if (delta <= -0.5) return 'bg-amber-500'
+  return 'bg-blue-500'
+}
+</script>

--- a/frontend/src/components/StreakHero.vue
+++ b/frontend/src/components/StreakHero.vue
@@ -1,35 +1,35 @@
 <template>
   <div
-    class="relative overflow-hidden rounded-2xl shadow-md text-white p-8 sm:p-10 mb-6"
+    class="relative overflow-hidden rounded-2xl shadow-md text-white p-6 h-full"
     :class="gradientClass"
   >
     <div class="absolute inset-0 opacity-20">
-      <div class="absolute -top-16 -right-16 w-72 h-72 rounded-full bg-white blur-3xl" />
-      <div class="absolute -bottom-20 -left-10 w-72 h-72 rounded-full bg-white blur-3xl" />
+      <div class="absolute -top-12 -right-12 w-56 h-56 rounded-full bg-white blur-3xl" />
+      <div class="absolute -bottom-16 -left-8 w-56 h-56 rounded-full bg-white blur-3xl" />
     </div>
 
-    <div class="relative flex flex-col sm:flex-row items-start sm:items-end justify-between gap-6">
-      <div>
-        <div class="flex items-center gap-2 text-white/80 text-sm font-semibold uppercase tracking-wide mb-1">
-          <span class="text-xl">🔥</span>
-          <span>Current streak</span>
-        </div>
-        <p class="text-7xl sm:text-8xl font-extrabold leading-none tabular-nums">
-          {{ animatedCurrent }}
-        </p>
-        <p class="text-white/80 text-base mt-2">
-          {{ current === 1 ? 'day' : 'days' }} of running
-        </p>
+    <div class="relative flex flex-col h-full">
+      <div class="flex items-center gap-2 text-white/80 text-xs font-semibold uppercase tracking-wide mb-1">
+        <span class="text-lg">🔥</span>
+        <span>Current streak</span>
       </div>
+      <p class="text-5xl sm:text-6xl font-extrabold leading-none tabular-nums">
+        {{ animatedCurrent }}
+      </p>
+      <p class="text-white/80 text-sm mt-1">
+        {{ current === 1 ? 'day' : 'days' }} of running
+      </p>
 
-      <div class="sm:text-right">
-        <p class="text-white/70 text-xs font-semibold uppercase tracking-wide">
+      <div class="mt-auto pt-4 border-t border-white/15">
+        <p class="text-white/70 text-[11px] font-semibold uppercase tracking-wide">
           Longest streak
         </p>
-        <p class="text-3xl sm:text-4xl font-bold tabular-nums">
+        <p class="text-2xl font-bold tabular-nums leading-tight">
           {{ animatedLongest }}
+          <span class="text-white/70 text-sm font-normal ml-1">
+            {{ longest === 1 ? 'day' : 'days' }}
+          </span>
         </p>
-        <p class="text-white/70 text-sm">{{ longest === 1 ? 'day' : 'days' }}</p>
       </div>
     </div>
   </div>

--- a/frontend/src/components/__tests__/GoalsCard.test.ts
+++ b/frontend/src/components/__tests__/GoalsCard.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import GoalsCard from '../GoalsCard.vue'
+import type { GoalProgress } from '@/types/runs'
+
+// Anchor the suite to a fixed date so pace math is deterministic.
+// 2026 is non-leap; mid-May → ~36% of year, ~30% of month.
+const FIXED_NOW = new Date('2026-05-09T12:00:00Z')
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(FIXED_NOW)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+const yearlyOnPace: GoalProgress = {
+  goal_mi: 1200,
+  progress_mi: 432,
+  percent: 36,
+  text: '1200 mi this year',
+  fetched_at: '2026-05-09T12:00:00Z',
+}
+
+const monthlyBehind: GoalProgress = {
+  goal_mi: 125,
+  progress_mi: 13.5,
+  percent: 10.8,
+  text: 'In May I will run 125 miles',
+  fetched_at: '2026-05-09T12:00:00Z',
+}
+
+const monthlyComplete: GoalProgress = {
+  goal_mi: 100,
+  progress_mi: 110,
+  percent: 110,
+  text: null,
+  fetched_at: null,
+}
+
+describe('GoalsCard', () => {
+  it('shows empty-state when both goals are null', () => {
+    const w = mount(GoalsCard, { props: { yearly: null, monthly: null } })
+    expect(w.text()).toContain('No goals set on SmashRun')
+  })
+
+  it('renders only yearly when monthly is null', () => {
+    const w = mount(GoalsCard, { props: { yearly: yearlyOnPace, monthly: null } })
+    expect(w.text()).toContain('1200')
+    expect(w.text()).not.toContain('125')
+  })
+
+  it('renders only monthly when yearly is null', () => {
+    const w = mount(GoalsCard, { props: { yearly: null, monthly: monthlyBehind } })
+    expect(w.text()).toContain('125')
+    expect(w.text()).not.toContain('1200')
+  })
+
+  it('renders progress in mi for both periods', () => {
+    const w = mount(GoalsCard, { props: { yearly: yearlyOnPace, monthly: monthlyBehind } })
+    expect(w.text()).toContain('432.0 / 1200 mi')
+    expect(w.text()).toContain('13.5 / 125 mi')
+  })
+
+  it('shows goal text when present and omits the italic when null', () => {
+    const w = mount(GoalsCard, { props: { yearly: yearlyOnPace, monthly: monthlyComplete } })
+    expect(w.text()).toContain('1200 mi this year')
+    // monthlyComplete has text: null → no italic paragraph for it
+    const italicParas = w.findAll('p.italic')
+    expect(italicParas.length).toBe(1)
+  })
+
+  it('flags a completed goal with celebration text', () => {
+    const w = mount(GoalsCard, { props: { yearly: null, monthly: monthlyComplete } })
+    expect(w.text()).toContain('Goal achieved!')
+  })
+
+  it('flags a behind-pace goal with the appropriate footer text', () => {
+    // May 9 → expected ~9/31 ≈ 29%; actual 10.8% → behind by ~18% × 125 mi ≈ 22.6 mi behind
+    const w = mount(GoalsCard, { props: { yearly: null, monthly: monthlyBehind } })
+    expect(w.text()).toMatch(/behind pace/)
+    expect(w.text()).not.toMatch(/ahead of pace/)
+  })
+
+  it('uses the current month name in the monthly header', () => {
+    // FIXED_NOW is 2026-05-09 → "May"
+    const w = mount(GoalsCard, { props: { yearly: null, monthly: monthlyBehind } })
+    expect(w.text()).toContain('May')
+  })
+
+  it('uses the current year in the yearly header', () => {
+    const w = mount(GoalsCard, { props: { yearly: yearlyOnPace, monthly: null } })
+    expect(w.text()).toContain('2026')
+  })
+})

--- a/frontend/src/composables/useGoals.ts
+++ b/frontend/src/composables/useGoals.ts
@@ -1,0 +1,23 @@
+import { ref } from 'vue'
+import { apiCall } from '@/config/api'
+import type { GoalsData } from '@/types/runs'
+
+export function useGoals() {
+  const goals = ref<GoalsData | null>(null)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const load = async (): Promise<void> => {
+    loading.value = true
+    error.value = null
+    try {
+      goals.value = await apiCall<GoalsData>('/stats/goals')
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load goals'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { goals, loading, error, load }
+}

--- a/frontend/src/types/runs.ts
+++ b/frontend/src/types/runs.ts
@@ -73,3 +73,16 @@ export interface SyncResponse {
   since: string
   until: string
 }
+
+export interface GoalProgress {
+  goal_mi: number
+  progress_mi: number
+  percent: number | null
+  text: string | null
+  fetched_at: string | null
+}
+
+export interface GoalsData {
+  yearly: GoalProgress | null
+  monthly: GoalProgress | null
+}

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -24,10 +24,16 @@
     <EmptyState v-else-if="isNewUser" @synced="reload" />
 
     <template v-else>
-      <StreakHero
-        :current="streak?.current_streak ?? 0"
-        :longest="streak?.longest_streak ?? 0"
-      />
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+        <StreakHero
+          :current="streak?.current_streak ?? 0"
+          :longest="streak?.longest_streak ?? 0"
+        />
+        <GoalsCard
+          :yearly="goals?.yearly ?? null"
+          :monthly="goals?.monthly ?? null"
+        />
+      </div>
 
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         <StatCard
@@ -99,9 +105,11 @@ import EmptyState from '@/components/EmptyState.vue'
 import StreakHero from '@/components/StreakHero.vue'
 import StreakHeatmap from '@/components/StreakHeatmap.vue'
 import MonthlyDistanceChart from '@/components/MonthlyDistanceChart.vue'
+import GoalsCard from '@/components/GoalsCard.vue'
 import { useStats } from '@/composables/useStats'
 import { useRecentRuns } from '@/composables/useRecentRuns'
 import { useMonthlyStats } from '@/composables/useMonthlyStats'
+import { useGoals } from '@/composables/useGoals'
 import { useUserPreferences } from '@/composables/useUserPreferences'
 import { useAuthStore } from '@/stores/auth'
 import {
@@ -123,6 +131,7 @@ const {
   load: loadRecent,
 } = useRecentRuns(100)
 const { months, loading: monthlyLoading, error: monthlyError, load: loadMonthly } = useMonthlyStats(12)
+const { goals, error: goalsError, load: loadGoals } = useGoals()
 const { unit } = useUserPreferences()
 
 const initialLoading = computed(
@@ -131,13 +140,15 @@ const initialLoading = computed(
     !stats.value &&
     recentRuns.value.length === 0,
 )
-const loadError = computed(() => statsError.value || recentError.value || monthlyError.value)
+const loadError = computed(
+  () => statsError.value || recentError.value || monthlyError.value || goalsError.value,
+)
 const isNewUser = computed(() => stats.value !== null && stats.value.total_runs === 0)
 
 const heatmapGrid = computed(() => buildHeatmapGrid(recentRuns.value, 12))
 
 const reload = async () => {
-  await Promise.all([loadStats(), loadRecent(), loadMonthly()])
+  await Promise.all([loadStats(), loadRecent(), loadMonthly(), loadGoals()])
 }
 
 onMounted(reload)


### PR DESCRIPTION
## Summary

Second half of #76 — frontend wiring for the goals dashboard work. Backend endpoint already shipped in #77.

\`\`\`
┌──────────────────┬──────────────────┐
│   StreakHero     │   GoalsCard      │   ← lg:grid-cols-2
│   (compact)      │   (new)          │
└──────────────────┴──────────────────┘
\`\`\`

- New \`GoalsCard.vue\` — visual lifted from \`qualityplaybook.dev\`'s \`RunningStreak.vue\` (the GOALS section only). Yearly + monthly distance progress, pace-aware progress bars, goal text in italic, completion celebration. Empty state when no goals stored. Recomputes \`percent\` locally from \`progress_mi / goal_mi\` so the bar always matches the totals shown directly above it.
- \`StreakHero.vue\` — compact redesign for half-width: \`text-5xl/6xl\` current streak (was \`text-7xl/8xl\`), \"current\" above \"longest\" stacked vertically, \`p-6\` padding (was \`p-8/10\`). Same gradient identity + \`useCountUp\` animation. Only used in DashboardView so redesigned in place rather than adding a \`compact\` prop.
- New \`useGoals\` composable mirroring \`useStats\` — single \`GET /stats/goals\` call, ref/loading/error pattern.
- \`DashboardView.vue\` — wraps StreakHero + GoalsCard in a 2-col grid (stacks on mobile), wires the new composable into \`reload()\`, surfaces \`goalsError\` in the unified \`loadError\`.
- \`GoalsData\` / \`GoalProgress\` types added to \`types/runs.ts\`.

## Tests

- 9 GoalsCard cases (empty / one-null variants / both populated / progress formatting / completion celebration / behind-pace footer / current month name / current year). Uses \`vi.useFakeTimers + setSystemTime\` to anchor pace math at 2026-05-09 for deterministic assertions.
- Frontend suite: **61/61 green** (52 prior + 9 new)
- \`npm run type-check\` clean

## Test plan

- [x] Frontend suite green
- [x] Type-check clean
- [ ] After deploy: load /dashboard → see compact streak card on the left + populated goals card on the right at lg breakpoint
- [ ] Mobile view: both stack vertically, streak first
- [ ] Visual: matches the qualityplaybook tile's GOALS section appearance (same colors, same pace-delta language)
- [ ] Reload after sync: goals refresh in place without a full page reload

## Known unrelated issue

\`npm run lint\` errors with \"Parsing error: 'import' is reserved\" on every .ts file in the repo (including files I didn't touch). ESLint parser config issue, pre-existing, out of scope here. Worth a follow-up.

Closes #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)