### PR TITLE
chore: manual backend tag bump for #79

### DIFF
--- a/helm/myrunstreak/values.yaml
+++ b/helm/myrunstreak/values.yaml
@@ -69,7 +69,7 @@ backend:
 
   image:
     repository: ghcr.io/silverbeer/myrunstreak-backend
-    tag: "e58c7d5" # backend-tag
+    tag: "cd9899d" # backend-tag
     pullPolicy: IfNotPresent
 
   env:


### PR DESCRIPTION
## Why

Recovers from a \`git-auto-commit-action\` race during the #79 deploy.

Both Backend Deploy + Frontend Deploy workflows fired at the merge of #79 (commit \`cd9899d\`). Frontend Deploy pushed its \`values.yaml\` tag bump first. Backend Deploy's push was rejected as non-fast-forward and exited 1 — even after a manual rerun, because the rerun starts from the original trigger SHA, not from the new HEAD after the frontend push.

The backend image at \`cd9899d\` **was** successfully built and pushed to ghcr.io during the original run. This commit just updates \`values.yaml\` so ArgoCD picks it up. Without this, the cluster keeps running the pre-#79 backend image and the new \`/auth/forgot-password\` + \`/auth/reset-password\` routes return 404 even though the code is merged.

## Impact

- One line: \`backend.image.tag: e58c7d5 → cd9899d\` in \`helm/myrunstreak/values.yaml\`
- After merge → ArgoCD reconciles → new backend pod rolls
- Then password reset flow from #79 actually becomes reachable

## Same race hit #70

Worth a follow-up issue: the deploy workflow should \`git pull --rebase\` before \`git push\`, or serialize the values.yaml writes via a workflow concurrency group / mutex. Will open separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)