### PR TITLE
feat: metric tracking repos + endpoints + progress engine

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3,7 +3,7 @@
 import logging
 
 from backend.config import get_settings
-from backend.routes import auth_routes, runs, stats, sync
+from backend.routes import auth_routes, metrics, runs, stats, sync
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -30,7 +30,7 @@ def create_app() -> FastAPI:
         CORSMiddleware,
         allow_origins=origins,
         allow_credentials=False,
-        allow_methods=["GET", "POST", "OPTIONS"],
+        allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
         allow_headers=["Authorization", "Content-Type", "X-Api-Key"],
         max_age=300,
     )
@@ -43,6 +43,7 @@ def create_app() -> FastAPI:
     app.include_router(runs.router)
     app.include_router(sync.router)
     app.include_router(auth_routes.router)
+    app.include_router(metrics.router)
 
     return app
 

--- a/backend/metrics_progress.py
+++ b/backend/metrics_progress.py
@@ -1,0 +1,127 @@
+"""Goal-progress computation — pure functions over entries + dates.
+
+No DB or I/O here so it's trivially unit-testable. Given a goal, its metric's
+aggregation rule, and the user's entries, compute progress for the goal's
+current window. See docs/GOALS_TRACKING.md for the volume/frequency/streak model.
+"""
+
+from __future__ import annotations
+
+import calendar
+from datetime import date, timedelta
+
+from src.shared.models.metric import (
+    GoalComparator,
+    GoalKind,
+    GoalPeriod,
+    GoalProgress,
+    MetricAggregation,
+    MetricEntry,
+    MetricGoal,
+    MetricType,
+)
+
+
+def resolve_window(goal: MetricGoal, today: date) -> tuple[date, date]:
+    """The [start, end] dates the goal is measured over, for a given 'today'."""
+    if goal.period == GoalPeriod.year:
+        return date(today.year, 1, 1), date(today.year, 12, 31)
+    if goal.period == GoalPeriod.month:
+        last = calendar.monthrange(today.year, today.month)[1]
+        return date(today.year, today.month, 1), date(today.year, today.month, last)
+    if goal.period == GoalPeriod.week:
+        # ISO week: Monday start.
+        start = today - timedelta(days=today.weekday())
+        return start, start + timedelta(days=6)
+    # custom — bounds are required by the model validator.
+    assert goal.period_start is not None and goal.period_end is not None
+    return goal.period_start, goal.period_end
+
+
+def _aggregate(values: list[float], agg: MetricAggregation, entries_in_window: list[MetricEntry]) -> float:
+    if not values:
+        return 0.0
+    if agg == MetricAggregation.sum:
+        return sum(values)
+    if agg == MetricAggregation.max:
+        return max(values)
+    if agg == MetricAggregation.count:
+        return float(len(values))
+    # latest: value of the most recent entry (by occurred_at, then occurred_on).
+    latest = max(
+        entries_in_window,
+        key=lambda e: (e.occurred_at.timestamp() if e.occurred_at else 0.0, e.occurred_on.toordinal()),
+    )
+    return float(latest.value)
+
+
+def current_streak(entry_days: set[date], today: date, rest_budget: int) -> int:
+    """Trailing run of days-with-an-entry ending at/near today.
+
+    Tolerates up to ``rest_budget`` *consecutive* missed days before the chain
+    is considered broken; a logged day resets the miss counter.
+    """
+    count = 0
+    misses = 0
+    day = today
+    # Bound the walk so a corrupt date set can't loop forever.
+    for _ in range(800):
+        if day in entry_days:
+            count += 1
+            misses = 0
+        else:
+            misses += 1
+            if misses > rest_budget:
+                break
+        day -= timedelta(days=1)
+    return count
+
+
+def compute_progress(
+    goal: MetricGoal,
+    metric: MetricType,
+    entries: list[MetricEntry],
+    today: date,
+) -> GoalProgress:
+    """Progress for ``goal`` given the user's ``entries`` for that metric."""
+    window_start, window_end = resolve_window(goal, today)
+    in_window = [e for e in entries if window_start <= e.occurred_on <= window_end]
+
+    if goal.kind == GoalKind.volume:
+        progress = _aggregate([e.value for e in in_window], metric.aggregation, in_window)
+    elif goal.kind == GoalKind.frequency:
+        # Count distinct days with any entry.
+        progress = float(len({e.occurred_on for e in in_window}))
+    else:  # streak
+        progress = float(current_streak({e.occurred_on for e in entries}, today, goal.rest_budget))
+
+    percent = (progress / goal.target * 100.0) if goal.target else None
+    met = progress >= goal.target if goal.comparator == GoalComparator.gte else (
+        0 < progress <= goal.target
+    )
+
+    result = GoalProgress(
+        goal=goal,
+        window_start=window_start,
+        window_end=window_end,
+        progress=round(progress, 3),
+        target=goal.target,
+        percent=round(percent, 1) if percent is not None else None,
+        met=met,
+    )
+
+    # Pace line — volume + reach-target only.
+    if goal.kind == GoalKind.volume and goal.comparator == GoalComparator.gte:
+        total_days = (window_end - window_start).days + 1
+        elapsed = (min(today, window_end) - window_start).days + 1
+        if 0 < elapsed <= total_days:
+            expected = goal.target * (elapsed / total_days)
+            result.on_pace = progress >= expected
+            result.projected = round(progress / elapsed * total_days, 1)
+            remaining_days = total_days - elapsed
+            if remaining_days > 0:
+                result.per_day_needed = round(max(0.0, goal.target - progress) / remaining_days, 3)
+            else:
+                result.per_day_needed = 0.0
+
+    return result

--- a/backend/routes/metrics.py
+++ b/backend/routes/metrics.py
@@ -1,0 +1,170 @@
+"""/metrics/* — generic metric tracking: catalog, entries, native goals.
+
+All endpoints are JWT-gated. The backend uses the service-role Supabase key, so
+the repositories scope every query by ``user_id`` themselves.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from uuid import UUID
+from zoneinfo import ZoneInfo
+
+from backend.auth import authenticate_request
+from backend.cache import invalidate_user
+from backend.metrics_progress import compute_progress
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from src.shared.models.metric import (
+    GoalProgress,
+    MetricEntry,
+    MetricEntryCreate,
+    MetricGoal,
+    MetricGoalCreate,
+    MetricGoalUpdate,
+    MetricType,
+)
+from src.shared.supabase_client import get_supabase_client
+from src.shared.supabase_ops import (
+    MetricEntriesRepository,
+    MetricGoalsRepository,
+    MetricTypesRepository,
+)
+
+router = APIRouter(prefix="/metrics", tags=["metrics"])
+
+
+def _today_local() -> date:
+    """America/New_York anchor, consistent with /stats."""
+    return datetime.now(ZoneInfo("America/New_York")).date()
+
+
+# ---------------------------------------------------------------- types
+
+@router.get("/types", response_model=list[MetricType])
+def list_metric_types(
+    _user_id: UUID = Depends(authenticate_request),
+) -> list[MetricType]:
+    rows = MetricTypesRepository(get_supabase_client()).list_all()
+    return [MetricType(**r) for r in rows]
+
+
+# ---------------------------------------------------------------- entries
+
+@router.post("/entries", response_model=MetricEntry, status_code=status.HTTP_201_CREATED)
+async def create_entry(
+    body: MetricEntryCreate,
+    user_id: UUID = Depends(authenticate_request),
+) -> MetricEntry:
+    supabase = get_supabase_client()
+    if MetricTypesRepository(supabase).get(body.metric_key) is None:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, f"Unknown metric_key '{body.metric_key}'")
+
+    payload = body.model_dump(exclude_none=True)
+    payload["occurred_on"] = (body.occurred_on or _today_local()).isoformat()
+    if body.occurred_at is not None:
+        payload["occurred_at"] = body.occurred_at.isoformat()
+
+    row = MetricEntriesRepository(supabase).insert(user_id, payload)
+    await invalidate_user(user_id)
+    return MetricEntry(**row)
+
+
+@router.get("/entries", response_model=list[MetricEntry])
+def list_entries(
+    user_id: UUID = Depends(authenticate_request),
+    metric_key: str | None = Query(default=None),
+    date_from: date | None = Query(default=None),
+    date_to: date | None = Query(default=None),
+    limit: int = Query(default=200, ge=1, le=2000),
+) -> list[MetricEntry]:
+    rows = MetricEntriesRepository(get_supabase_client()).list(
+        user_id, metric_key=metric_key, date_from=date_from, date_to=date_to, limit=limit
+    )
+    return [MetricEntry(**r) for r in rows]
+
+
+@router.delete("/entries/{entry_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_entry(
+    entry_id: UUID,
+    user_id: UUID = Depends(authenticate_request),
+) -> None:
+    deleted = MetricEntriesRepository(get_supabase_client()).delete(user_id, entry_id)
+    if not deleted:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Entry not found")
+    await invalidate_user(user_id)
+
+
+# ---------------------------------------------------------------- goals
+
+def _progress_for(supabase, user_id: UUID, goal: MetricGoal) -> GoalProgress:
+    metric = MetricTypesRepository(supabase).get(goal.metric_key)
+    if metric is None:
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Goal references unknown metric")
+    # Pull the user's entries for this metric (recent history covers any window
+    # plus the trailing days a streak needs).
+    rows = MetricEntriesRepository(supabase).list(user_id, metric_key=goal.metric_key, limit=2000)
+    entries = [MetricEntry(**r) for r in rows]
+    return compute_progress(goal, MetricType(**metric), entries, _today_local())
+
+
+@router.post("/goals", response_model=MetricGoal, status_code=status.HTTP_201_CREATED)
+async def create_goal(
+    body: MetricGoalCreate,
+    user_id: UUID = Depends(authenticate_request),
+) -> MetricGoal:
+    supabase = get_supabase_client()
+    if MetricTypesRepository(supabase).get(body.metric_key) is None:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, f"Unknown metric_key '{body.metric_key}'")
+
+    payload = body.model_dump(exclude_none=True, mode="json")
+    row = MetricGoalsRepository(supabase).create(user_id, payload)
+    await invalidate_user(user_id)
+    return MetricGoal(**row)
+
+
+@router.get("/goals", response_model=list[GoalProgress])
+def list_goals(
+    user_id: UUID = Depends(authenticate_request),
+    status_filter: str | None = Query(default="active", alias="status"),
+) -> list[GoalProgress]:
+    supabase = get_supabase_client()
+    rows = MetricGoalsRepository(supabase).list(user_id, status=status_filter)
+    return [_progress_for(supabase, user_id, MetricGoal(**r)) for r in rows]
+
+
+@router.get("/goals/{goal_id}", response_model=GoalProgress)
+def get_goal(
+    goal_id: UUID,
+    user_id: UUID = Depends(authenticate_request),
+) -> GoalProgress:
+    supabase = get_supabase_client()
+    row = MetricGoalsRepository(supabase).get(user_id, goal_id)
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Goal not found")
+    return _progress_for(supabase, user_id, MetricGoal(**row))
+
+
+@router.patch("/goals/{goal_id}", response_model=MetricGoal)
+async def update_goal(
+    goal_id: UUID,
+    body: MetricGoalUpdate,
+    user_id: UUID = Depends(authenticate_request),
+) -> MetricGoal:
+    supabase = get_supabase_client()
+    payload = body.model_dump(exclude_none=True, mode="json")
+    row = MetricGoalsRepository(supabase).update(user_id, goal_id, payload)
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Goal not found")
+    await invalidate_user(user_id)
+    return MetricGoal(**row)
+
+
+@router.delete("/goals/{goal_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_goal(
+    goal_id: UUID,
+    user_id: UUID = Depends(authenticate_request),
+) -> None:
+    deleted = MetricGoalsRepository(get_supabase_client()).delete(user_id, goal_id)
+    if not deleted:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Goal not found")
+    await invalidate_user(user_id)

--- a/backend/tests/test_metrics_progress.py
+++ b/backend/tests/test_metrics_progress.py
@@ -1,0 +1,161 @@
+"""Unit tests for backend.metrics_progress — pure, no DB."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from uuid import uuid4
+
+from backend.metrics_progress import compute_progress, current_streak, resolve_window
+from src.shared.models.metric import (
+    GoalComparator,
+    GoalKind,
+    GoalPeriod,
+    MetricAggregation,
+    MetricEntry,
+    MetricGoal,
+    MetricType,
+)
+
+USER = uuid4()
+
+
+def _entry(metric_key: str, on: date, value: float, at: datetime | None = None) -> MetricEntry:
+    return MetricEntry(
+        id=uuid4(),
+        user_id=USER,
+        metric_key=metric_key,
+        occurred_on=on,
+        occurred_at=at,
+        value=value,
+    )
+
+
+def _goal(**kw) -> MetricGoal:
+    base = {
+        "id": uuid4(),
+        "user_id": USER,
+        "metric_key": "pushups",
+        "kind": GoalKind.volume,
+        "period": GoalPeriod.month,
+        "target": 100.0,
+        "comparator": GoalComparator.gte,
+        "rest_budget": 0,
+    }
+    base.update(kw)
+    return MetricGoal(**base)
+
+
+PUSHUPS = MetricType(key="pushups", display_name="Push-ups", unit="reps", aggregation=MetricAggregation.sum)
+WEIGHT = MetricType(key="body_weight", display_name="Body weight", unit="kg", aggregation=MetricAggregation.latest, higher_is_better=False)
+
+
+# ---- resolve_window ----
+
+def test_window_year():
+    s, e = resolve_window(_goal(period=GoalPeriod.year), date(2026, 6, 2))
+    assert s == date(2026, 1, 1) and e == date(2026, 12, 31)
+
+
+def test_window_month():
+    s, e = resolve_window(_goal(period=GoalPeriod.month), date(2026, 2, 15))
+    assert s == date(2026, 2, 1) and e == date(2026, 2, 28)  # 2026 not a leap year
+
+
+def test_window_week_monday_start():
+    # 2026-06-02 is a Tuesday → week is Mon 06-01 .. Sun 06-07.
+    s, e = resolve_window(_goal(period=GoalPeriod.week), date(2026, 6, 2))
+    assert s == date(2026, 6, 1) and e == date(2026, 6, 7)
+
+
+def test_window_custom():
+    g = _goal(period=GoalPeriod.custom, period_start=date(2026, 6, 1), period_end=date(2026, 6, 10))
+    assert resolve_window(g, date(2026, 6, 5)) == (date(2026, 6, 1), date(2026, 6, 10))
+
+
+# ---- volume ----
+
+def test_volume_sum_and_pace():
+    today = date(2026, 6, 10)  # day 10 of a 30-day month
+    g = _goal(kind=GoalKind.volume, period=GoalPeriod.month, target=300.0)
+    entries = [_entry("pushups", date(2026, 6, d), 10.0) for d in (1, 5, 10)]  # 30 total
+    p = compute_progress(g, PUSHUPS, entries, today)
+    assert p.progress == 30.0
+    assert p.percent == 10.0
+    assert p.met is False
+    # 10/30 days elapsed; expected = 300*10/30 = 100; 30 < 100 → behind.
+    assert p.on_pace is False
+    assert p.projected == 90.0  # 30/10*30
+    # remaining 20 days, need (300-30)/20 = 13.5/day
+    assert p.per_day_needed == 13.5
+
+
+def test_volume_met_when_target_reached():
+    today = date(2026, 6, 30)
+    g = _goal(kind=GoalKind.volume, period=GoalPeriod.month, target=100.0)
+    entries = [_entry("pushups", date(2026, 6, 15), 120.0)]
+    p = compute_progress(g, PUSHUPS, entries, today)
+    assert p.progress == 120.0 and p.met is True
+
+
+def test_volume_excludes_out_of_window_entries():
+    today = date(2026, 6, 10)
+    g = _goal(kind=GoalKind.volume, period=GoalPeriod.month, target=100.0)
+    entries = [
+        _entry("pushups", date(2026, 5, 31), 999.0),  # previous month — excluded
+        _entry("pushups", date(2026, 6, 3), 25.0),
+    ]
+    p = compute_progress(g, PUSHUPS, entries, today)
+    assert p.progress == 25.0
+
+
+def test_weight_latest_lte_comparator():
+    today = date(2026, 6, 20)
+    g = _goal(metric_key="body_weight", kind=GoalKind.volume, period=GoalPeriod.month,
+              target=80.0, comparator=GoalComparator.lte)
+    entries = [
+        _entry("body_weight", date(2026, 6, 1), 82.0, at=datetime(2026, 6, 1, tzinfo=UTC)),
+        _entry("body_weight", date(2026, 6, 18), 79.5, at=datetime(2026, 6, 18, tzinfo=UTC)),
+    ]
+    p = compute_progress(g, WEIGHT, entries, today)
+    assert p.progress == 79.5      # latest, not sum
+    assert p.met is True           # 79.5 <= 80
+    assert p.on_pace is None       # pace only for volume+gte
+
+
+# ---- frequency ----
+
+def test_frequency_counts_distinct_days():
+    today = date(2026, 6, 3)  # week Mon 06-01..Sun 06-07
+    g = _goal(metric_key="body_weight", kind=GoalKind.frequency, period=GoalPeriod.week, target=3.0)
+    entries = [
+        _entry("body_weight", date(2026, 6, 1), 80.0),
+        _entry("body_weight", date(2026, 6, 1), 80.0),  # same day → still 1
+        _entry("body_weight", date(2026, 6, 2), 80.0),
+    ]
+    p = compute_progress(g, WEIGHT, entries, today)
+    assert p.progress == 2.0
+    assert p.met is False
+
+
+# ---- streak ----
+
+def test_current_streak_basic_and_gap_breaks():
+    today = date(2026, 6, 10)
+    days = {date(2026, 6, 10), date(2026, 6, 9), date(2026, 6, 7)}  # gap on the 8th
+    assert current_streak(days, today, rest_budget=0) == 2
+
+
+def test_current_streak_rest_budget_tolerates_gap():
+    today = date(2026, 6, 10)
+    days = {date(2026, 6, 10), date(2026, 6, 8)}  # one missed day (the 9th)
+    assert current_streak(days, today, rest_budget=1) == 2
+
+
+def test_streak_goal_progress():
+    today = date(2026, 6, 10)
+    g = _goal(metric_key="running_distance", kind=GoalKind.streak, period=GoalPeriod.year, target=30.0, rest_budget=0)
+    entries = [_entry("running_distance", date(2026, 6, d), 5.0) for d in (10, 9, 8)]
+    rd = MetricType(key="running_distance", display_name="Running", unit="km", aggregation=MetricAggregation.sum)
+    p = compute_progress(g, rd, entries, today)
+    assert p.progress == 3.0
+    assert p.met is False

--- a/backend/tests/test_metrics_routes.py
+++ b/backend/tests/test_metrics_routes.py
@@ -1,0 +1,147 @@
+"""Route-handler tests for /metrics/* with mocked repositories.
+
+Handlers are invoked directly (passing user_id), so no ASGI client or real
+Supabase is needed. CACHE_ENABLED=false (conftest) makes invalidate_user a
+no-op, so cache isn't patched.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from src.shared.models.metric import GoalKind, GoalPeriod, MetricEntryCreate, MetricGoalCreate
+
+
+def _patch(types=None, entries=None, goals=None):
+    """Patch get_supabase_client + the three repo classes in the route module."""
+    patches = [patch("backend.routes.metrics.get_supabase_client", return_value=MagicMock())]
+    if types is not None:
+        patches.append(patch("backend.routes.metrics.MetricTypesRepository", return_value=types))
+    if entries is not None:
+        patches.append(patch("backend.routes.metrics.MetricEntriesRepository", return_value=entries))
+    if goals is not None:
+        patches.append(patch("backend.routes.metrics.MetricGoalsRepository", return_value=goals))
+    return patches
+
+
+def _enter(patches):
+    for p in patches:
+        p.start()
+
+
+def _exit(patches):
+    for p in patches:
+        p.stop()
+
+
+@pytest.mark.asyncio
+async def test_create_entry_rejects_unknown_metric():
+    from backend.routes.metrics import create_entry
+
+    types = MagicMock()
+    types.get.return_value = None  # unknown metric
+    patches = _patch(types=types)
+    _enter(patches)
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await create_entry(MetricEntryCreate(metric_key="nope", value=10), user_id=uuid4())
+        assert exc.value.status_code == 400
+    finally:
+        _exit(patches)
+
+
+@pytest.mark.asyncio
+async def test_create_entry_defaults_occurred_on_and_inserts():
+    from backend.routes.metrics import create_entry
+
+    uid = uuid4()
+    types = MagicMock()
+    types.get.return_value = {"key": "pushups", "display_name": "Push-ups", "unit": "reps", "aggregation": "sum"}
+    entries = MagicMock()
+
+    def _insert(user_id, payload):
+        # echo back a stored row
+        return {"id": str(uuid4()), "user_id": str(user_id), **payload}
+
+    entries.insert.side_effect = _insert
+
+    patches = _patch(types=types, entries=entries)
+    _enter(patches)
+    try:
+        res = await create_entry(MetricEntryCreate(metric_key="pushups", value=25), user_id=uid)
+    finally:
+        _exit(patches)
+
+    # occurred_on defaulted to today (server) and an insert happened.
+    assert entries.insert.called
+    inserted_payload = entries.insert.call_args.args[1]
+    assert "occurred_on" in inserted_payload
+    assert res.value == 25.0
+    assert res.metric_key == "pushups"
+
+
+@pytest.mark.asyncio
+async def test_delete_entry_404_when_missing():
+    from backend.routes.metrics import delete_entry
+
+    entries = MagicMock()
+    entries.delete.return_value = False
+    patches = _patch(entries=entries)
+    _enter(patches)
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await delete_entry(uuid4(), user_id=uuid4())
+        assert exc.value.status_code == 404
+    finally:
+        _exit(patches)
+
+
+def test_list_goals_computes_progress():
+    from backend.routes.metrics import list_goals
+
+    uid = uuid4()
+    goal_row = {
+        "id": str(uuid4()),
+        "user_id": str(uid),
+        "metric_key": "pushups",
+        "kind": "volume",
+        "period": "month",
+        "target": 100.0,
+        "comparator": "gte",
+        "rest_budget": 0,
+        "status": "active",
+    }
+    goals = MagicMock()
+    goals.list.return_value = [goal_row]
+
+    types = MagicMock()
+    types.get.return_value = {"key": "pushups", "display_name": "Push-ups", "unit": "reps", "aggregation": "sum"}
+
+    entries = MagicMock()
+    today = date.today()
+    entries.list.return_value = [
+        {"id": str(uuid4()), "user_id": str(uid), "metric_key": "pushups",
+         "occurred_on": today.replace(day=1).isoformat(), "value": 40.0},
+    ]
+
+    patches = _patch(types=types, entries=entries, goals=goals)
+    _enter(patches)
+    try:
+        result = list_goals(user_id=uid, status_filter="active")
+    finally:
+        _exit(patches)
+
+    assert len(result) == 1
+    assert result[0].progress == 40.0
+    assert result[0].goal.metric_key == "pushups"
+    goals.list.assert_called_once_with(uid, status="active")
+
+
+def test_create_goal_custom_period_requires_bounds():
+    # Model-level validation: custom without bounds is rejected before any I/O.
+    with pytest.raises(ValueError):
+        MetricGoalCreate(metric_key="pushups", kind=GoalKind.volume, period=GoalPeriod.custom, target=100)

--- a/src/shared/models/__init__.py
+++ b/src/shared/models/__init__.py
@@ -10,6 +10,20 @@ from .enums import (
     WeatherType,
 )
 from .goal import Goal
+from .metric import (
+    GoalComparator,
+    GoalKind,
+    GoalPeriod,
+    GoalProgress,
+    GoalStatus,
+    MetricAggregation,
+    MetricEntry,
+    MetricEntryCreate,
+    MetricGoal,
+    MetricGoalCreate,
+    MetricGoalUpdate,
+    MetricType,
+)
 from .nested import HeartRateRecovery, Lap, Song
 from .split import Split
 from .units import (
@@ -25,6 +39,19 @@ __all__ = [
     "Activity",
     "Goal",
     "Split",
+    # Metric tracking
+    "MetricType",
+    "MetricEntry",
+    "MetricEntryCreate",
+    "MetricGoal",
+    "MetricGoalCreate",
+    "MetricGoalUpdate",
+    "GoalProgress",
+    "MetricAggregation",
+    "GoalKind",
+    "GoalPeriod",
+    "GoalComparator",
+    "GoalStatus",
     # Nested models
     "Lap",
     "Song",

--- a/src/shared/models/metric.py
+++ b/src/shared/models/metric.py
@@ -1,0 +1,157 @@
+"""Generic metric tracking models — types catalog, entries, native goals.
+
+Mirrors the schema in supabase/migrations/20260602120000_create_metric_tracking.sql.
+Running is "metric #1"; weight, push-ups, etc. are just more metric types.
+See docs/GOALS_TRACKING.md.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from enum import Enum
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class MetricAggregation(str, Enum):
+    """How a metric's entries roll up over a goal window."""
+
+    sum = "sum"
+    count = "count"
+    latest = "latest"
+    max = "max"
+
+
+class GoalKind(str, Enum):
+    volume = "volume"        # accumulate toward a target (sum to target)
+    frequency = "frequency"  # do it N times in a window (count of qualifying days)
+    streak = "streak"        # daily chain
+
+
+class GoalPeriod(str, Enum):
+    year = "year"
+    month = "month"
+    week = "week"
+    custom = "custom"
+
+
+class GoalComparator(str, Enum):
+    gte = "gte"  # reach target (most goals)
+    lte = "lte"  # stay under target (e.g. body weight)
+
+
+class GoalStatus(str, Enum):
+    active = "active"
+    achieved = "achieved"
+    archived = "archived"
+
+
+class MetricType(BaseModel):
+    """A row in the global metric catalog."""
+
+    key: str
+    display_name: str
+    unit: str
+    aggregation: MetricAggregation
+    higher_is_better: bool = True
+
+
+class MetricEntryCreate(BaseModel):
+    """Input for logging an entry. ``occurred_on`` defaults to today server-side."""
+
+    metric_key: str
+    value: float = Field(ge=0, description="Canonical unit (km/kg/reps) or 1 for a check-in")
+    occurred_on: date | None = None
+    occurred_at: datetime | None = None
+    note: str | None = Field(default=None, max_length=800)
+    source: str = "manual"
+    metadata: dict[str, Any] | None = None
+    external_id: str | None = None
+
+
+class MetricEntry(BaseModel):
+    """A stored metric entry."""
+
+    id: UUID
+    user_id: UUID
+    metric_key: str
+    occurred_on: date
+    occurred_at: datetime | None = None
+    value: float
+    note: str | None = None
+    source: str = "manual"
+    metadata: dict[str, Any] | None = None
+    external_id: str | None = None
+    created_at: datetime | None = None
+
+
+class MetricGoalCreate(BaseModel):
+    """Input for creating a native goal."""
+
+    metric_key: str
+    kind: GoalKind
+    period: GoalPeriod
+    target: float = Field(gt=0)
+    comparator: GoalComparator = GoalComparator.gte
+    rest_budget: int = Field(default=0, ge=0)
+    period_start: date | None = None
+    period_end: date | None = None
+
+    @model_validator(mode="after")
+    def _custom_needs_bounds(self) -> MetricGoalCreate:
+        if self.period == GoalPeriod.custom:
+            if self.period_start is None or self.period_end is None:
+                raise ValueError("custom period requires period_start and period_end")
+            if self.period_end < self.period_start:
+                raise ValueError("period_end must be on or after period_start")
+        return self
+
+
+class MetricGoalUpdate(BaseModel):
+    """Partial update — only provided fields change."""
+
+    target: float | None = Field(default=None, gt=0)
+    comparator: GoalComparator | None = None
+    rest_budget: int | None = Field(default=None, ge=0)
+    status: GoalStatus | None = None
+    period_start: date | None = None
+    period_end: date | None = None
+
+
+class MetricGoal(BaseModel):
+    """A stored native goal."""
+
+    id: UUID
+    user_id: UUID
+    metric_key: str
+    kind: GoalKind
+    period: GoalPeriod
+    period_start: date | None = None
+    period_end: date | None = None
+    target: float
+    comparator: GoalComparator = GoalComparator.gte
+    rest_budget: int = 0
+    status: GoalStatus = GoalStatus.active
+    created_at: datetime | None = None
+
+
+class GoalProgress(BaseModel):
+    """Computed progress for a goal over its current window.
+
+    ``progress`` is the aggregated value (volume), count of qualifying days
+    (frequency), or current chain length (streak). Pace fields are populated
+    for volume goals only.
+    """
+
+    goal: MetricGoal
+    window_start: date
+    window_end: date
+    progress: float
+    target: float
+    percent: float | None = None
+    met: bool = False
+    projected: float | None = None
+    on_pace: bool | None = None
+    per_day_needed: float | None = None

--- a/src/shared/supabase_ops/__init__.py
+++ b/src/shared/supabase_ops/__init__.py
@@ -2,12 +2,20 @@
 
 from .goals_repository import GoalsRepository
 from .mappers import activity_to_run_dict, split_to_dict
+from .metrics_repository import (
+    MetricEntriesRepository,
+    MetricGoalsRepository,
+    MetricTypesRepository,
+)
 from .runs_repository import RunsRepository
 from .token_repository import TokenRepository
 from .users_repository import UsersRepository
 
 __all__ = [
     "GoalsRepository",
+    "MetricEntriesRepository",
+    "MetricGoalsRepository",
+    "MetricTypesRepository",
     "RunsRepository",
     "TokenRepository",
     "UsersRepository",

--- a/src/shared/supabase_ops/metrics_repository.py
+++ b/src/shared/supabase_ops/metrics_repository.py
@@ -1,0 +1,135 @@
+"""Repositories for the generic metric tracking tables.
+
+IMPORTANT: the backend connects with the Supabase **service-role key**, which
+**bypasses RLS**. So every query here MUST scope by ``user_id`` itself —
+the database policies are a second line of defence for direct anon-key access,
+not the primary guard on these server-side calls.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, cast
+from uuid import UUID
+
+from supabase import Client
+
+
+class MetricTypesRepository:
+    """Read-only access to the global metric catalog."""
+
+    def __init__(self, supabase: Client):
+        self.supabase = supabase
+
+    def list_all(self) -> list[dict[str, Any]]:
+        result = self.supabase.table("metric_types").select("*").order("key").execute()
+        return cast(list[dict[str, Any]], result.data)
+
+    def get(self, key: str) -> dict[str, Any] | None:
+        result = self.supabase.table("metric_types").select("*").eq("key", key).execute()
+        data = cast(list[dict[str, Any]], result.data)
+        return data[0] if data else None
+
+
+class MetricEntriesRepository:
+    """Per-user metric entry log."""
+
+    def __init__(self, supabase: Client):
+        self.supabase = supabase
+
+    def insert(self, user_id: UUID, payload: dict[str, Any]) -> dict[str, Any]:
+        row = {**payload, "user_id": str(user_id)}
+        result = self.supabase.table("metric_entries").insert(row).execute()
+        return cast(list[dict[str, Any]], result.data)[0]
+
+    def list(
+        self,
+        user_id: UUID,
+        metric_key: str | None = None,
+        date_from: date | None = None,
+        date_to: date | None = None,
+        limit: int = 1000,
+    ) -> list[dict[str, Any]]:
+        query = (
+            self.supabase.table("metric_entries")
+            .select("*")
+            .eq("user_id", str(user_id))
+        )
+        if metric_key is not None:
+            query = query.eq("metric_key", metric_key)
+        if date_from is not None:
+            query = query.gte("occurred_on", date_from.isoformat())
+        if date_to is not None:
+            query = query.lte("occurred_on", date_to.isoformat())
+        result = query.order("occurred_on", desc=True).limit(limit).execute()
+        return cast(list[dict[str, Any]], result.data)
+
+    def delete(self, user_id: UUID, entry_id: UUID) -> bool:
+        """Delete one entry, scoped to its owner. Returns True if a row went."""
+        result = (
+            self.supabase.table("metric_entries")
+            .delete()
+            .eq("id", str(entry_id))
+            .eq("user_id", str(user_id))
+            .execute()
+        )
+        return bool(cast(list[dict[str, Any]], result.data))
+
+
+class MetricGoalsRepository:
+    """Per-user native goals."""
+
+    def __init__(self, supabase: Client):
+        self.supabase = supabase
+
+    def create(self, user_id: UUID, payload: dict[str, Any]) -> dict[str, Any]:
+        row = {**payload, "user_id": str(user_id)}
+        result = self.supabase.table("metric_goals").insert(row).execute()
+        return cast(list[dict[str, Any]], result.data)[0]
+
+    def list(self, user_id: UUID, status: str | None = None) -> list[dict[str, Any]]:
+        query = (
+            self.supabase.table("metric_goals")
+            .select("*")
+            .eq("user_id", str(user_id))
+        )
+        if status is not None:
+            query = query.eq("status", status)
+        result = query.order("created_at", desc=True).execute()
+        return cast(list[dict[str, Any]], result.data)
+
+    def get(self, user_id: UUID, goal_id: UUID) -> dict[str, Any] | None:
+        result = (
+            self.supabase.table("metric_goals")
+            .select("*")
+            .eq("id", str(goal_id))
+            .eq("user_id", str(user_id))
+            .execute()
+        )
+        data = cast(list[dict[str, Any]], result.data)
+        return data[0] if data else None
+
+    def update(
+        self, user_id: UUID, goal_id: UUID, payload: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        if not payload:
+            return self.get(user_id, goal_id)
+        result = (
+            self.supabase.table("metric_goals")
+            .update(payload)
+            .eq("id", str(goal_id))
+            .eq("user_id", str(user_id))
+            .execute()
+        )
+        data = cast(list[dict[str, Any]], result.data)
+        return data[0] if data else None
+
+    def delete(self, user_id: UUID, goal_id: UUID) -> bool:
+        result = (
+            self.supabase.table("metric_goals")
+            .delete()
+            .eq("id", str(goal_id))
+            .eq("user_id", str(user_id))
+            .execute()
+        )
+        return bool(cast(list[dict[str, Any]], result.data))


### PR DESCRIPTION
Implements **SB-93** on top of the SB-92 schema — the backend for the generic metric engine.

## What's here
- **Models** (`src/shared/models/metric.py`) — `MetricType`/`MetricEntry`/`MetricGoal` + create/update DTOs + `GoalProgress`. Enums mirror the DB.
- **Repositories** (`src/shared/supabase_ops/metrics_repository.py`) — types (catalog read), entries (insert/list/delete), goals (CRUD). **Every query scopes by `user_id`** — the backend's service-role key bypasses RLS, so ownership is enforced in code (RLS is the second line for direct anon access).
- **Progress engine** (`backend/metrics_progress.py`) — pure, fully unit-tested:
  - **volume**: aggregate (sum/latest/max/count) vs target + **pace line** (on-pace, projected total, per-day-needed)
  - **frequency**: count of distinct qualifying days
  - **streak**: trailing day chain with `rest_budget` tolerance
  - window resolution for year/month/week/custom
- **Routes** (`backend/routes/metrics.py`), all JWT-gated:
  - `GET /metrics/types`
  - `POST/GET /metrics/entries`, `DELETE /metrics/entries/{id}`
  - `POST /metrics/goals`, `GET /metrics/goals` (list **with computed progress**), `GET /metrics/goals/{id}`, `PATCH /metrics/goals/{id}`, `DELETE /metrics/goals/{id}`
  - Writes call `invalidate_user`.
- **Wiring**: model/repo exports, router mounted, **CORS extended with PATCH/DELETE** (the goal endpoints need them).

## Tests
17 new (`test_metrics_progress.py` pure logic + `test_metrics_routes.py` handlers with mocked repos). **111 backend + 31 shared tests pass; `ruff check backend/` clean.**

## Notes
- Depends on SB-92 (merged) for the tables/enums.
- Next: **SB-94** — one-tap logging UI + Today card.

Fixes SB-93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)