### PR TITLE
feat: one-tap metric logging + Today card (SB-94)

### DIFF
--- a/frontend/src/components/QuickLog.vue
+++ b/frontend/src/components/QuickLog.vue
@@ -1,0 +1,125 @@
+<template>
+  <div class="bg-white rounded-2xl shadow-md p-6 border border-gray-100">
+    <div class="flex items-center gap-2 mb-4">
+      <span class="text-lg">⚡</span>
+      <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-700">
+        Quick log
+      </h3>
+    </div>
+
+    <!-- Push-ups: one-tap presets + custom -->
+    <div class="mb-5">
+      <div class="flex items-center justify-between mb-2">
+        <span class="text-xs font-medium text-gray-700">💪 Push-ups</span>
+      </div>
+      <div class="flex flex-wrap items-center gap-2">
+        <button
+          v-for="n in presets"
+          :key="n"
+          type="button"
+          class="px-3 py-1.5 rounded-lg bg-brand-50 text-brand-700 text-sm font-medium hover:bg-brand-100 disabled:opacity-50"
+          :disabled="submitting"
+          @click="log('pushups', n)"
+        >
+          +{{ n }}
+        </button>
+        <div class="flex items-center gap-1">
+          <input
+            v-model.number="pushupCustom"
+            type="number"
+            min="1"
+            inputmode="numeric"
+            class="w-20 px-2 py-1.5 rounded-lg border border-gray-200 text-sm"
+            placeholder="reps"
+          />
+          <button
+            type="button"
+            class="px-3 py-1.5 rounded-lg bg-gray-100 text-gray-700 text-sm font-medium hover:bg-gray-200 disabled:opacity-50"
+            :disabled="submitting || !pushupCustom || pushupCustom < 1"
+            @click="pushupCustom && log('pushups', pushupCustom)"
+          >
+            Log
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Body weight: number entry (display unit lb) -->
+    <div>
+      <div class="flex items-center justify-between mb-2">
+        <span class="text-xs font-medium text-gray-700">⚖️ Weigh-in</span>
+      </div>
+      <div class="flex items-center gap-2">
+        <input
+          v-model.number="weight"
+          type="number"
+          min="1"
+          step="0.1"
+          inputmode="decimal"
+          class="w-28 px-2 py-1.5 rounded-lg border border-gray-200 text-sm"
+          :placeholder="weightUnit"
+        />
+        <span class="text-xs text-gray-400">{{ weightUnit }}</span>
+        <button
+          type="button"
+          class="px-3 py-1.5 rounded-lg bg-gray-100 text-gray-700 text-sm font-medium hover:bg-gray-200 disabled:opacity-50"
+          :disabled="submitting || !weight || weight <= 0"
+          @click="logWeight"
+        >
+          Log
+        </button>
+      </div>
+    </div>
+
+    <p v-if="confirmation" class="mt-3 text-xs text-green-600">{{ confirmation }}</p>
+    <p v-if="error" class="mt-3 text-xs text-red-600">{{ error }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useMetrics } from '@/composables/useMetrics'
+import type { MetricType } from '@/types/metrics'
+import { displayUnit, toStored } from '@/utils/metrics'
+
+const props = defineProps<{ types: MetricType[] }>()
+const emit = defineEmits<{ logged: [] }>()
+
+const { logEntry } = useMetrics()
+
+const presets = [10, 25, 50]
+const pushupCustom = ref<number | null>(null)
+const weight = ref<number | null>(null)
+const submitting = ref(false)
+const confirmation = ref('')
+const error = ref('')
+
+const weightStoredUnit = computed(
+  () => props.types.find((t) => t.key === 'body_weight')?.unit ?? 'kg',
+)
+const weightUnit = computed(() => displayUnit(weightStoredUnit.value))
+
+async function log(metricKey: string, value: number): Promise<void> {
+  if (submitting.value || !value || value <= 0) return
+  submitting.value = true
+  confirmation.value = ''
+  error.value = ''
+  try {
+    await logEntry(metricKey, value)
+    confirmation.value = 'Logged ✓'
+    pushupCustom.value = null
+    emit('logged')
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to log'
+  } finally {
+    submitting.value = false
+  }
+}
+
+async function logWeight(): Promise<void> {
+  if (!weight.value || weight.value <= 0) return
+  const stored = toStored(weightStoredUnit.value, weight.value)
+  await log('body_weight', stored)
+  weight.value = null
+}
+</script>

--- a/frontend/src/components/TodayCard.vue
+++ b/frontend/src/components/TodayCard.vue
@@ -1,0 +1,128 @@
+<template>
+  <div class="bg-white rounded-2xl shadow-md p-6 h-full border border-gray-100">
+    <div class="flex items-center gap-2 mb-4">
+      <span class="text-lg">📈</span>
+      <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-700">
+        Today
+      </h3>
+    </div>
+
+    <div v-if="goals.length === 0" class="text-sm text-gray-500">
+      No active goals yet — set one to start tracking.
+    </div>
+
+    <div v-for="row in rows" :key="row.id" class="mb-4 last:mb-0">
+      <div class="flex items-start justify-between gap-2 mb-1">
+        <span class="text-xs font-medium text-gray-700">
+          {{ row.label }}
+          <span v-if="row.met" class="ml-1">🎉</span>
+        </span>
+        <span class="text-xs font-semibold text-gray-900 whitespace-nowrap">
+          {{ row.progressText }}
+        </span>
+      </div>
+      <div class="w-full bg-gray-200 rounded-full h-2 overflow-hidden">
+        <div
+          class="h-2 rounded-full transition-all duration-500"
+          :class="row.barClass"
+          :style="{ width: Math.min(row.percent, 100) + '%' }"
+        ></div>
+      </div>
+      <div class="flex justify-between items-center mt-1 text-xs">
+        <span class="text-gray-500">{{ row.percent.toFixed(0) }}%</span>
+        <span :class="row.paceClass">{{ row.paceText }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { GoalProgress, MetricType } from '@/types/metrics'
+import { displayDecimals, displayUnit, toDisplay } from '@/utils/metrics'
+
+const props = defineProps<{
+  goals: GoalProgress[]
+  types: MetricType[]
+}>()
+
+interface Row {
+  id: string
+  label: string
+  progressText: string
+  percent: number
+  met: boolean
+  barClass: string
+  paceText: string
+  paceClass: string
+}
+
+function metricFor(key: string): MetricType | undefined {
+  return props.types.find((t) => t.key === key)
+}
+
+function fmt(unit: string, value: number): string {
+  return toDisplay(unit, value).toFixed(displayDecimals(unit))
+}
+
+const rows = computed<Row[]>(() =>
+  props.goals.map((g): Row => {
+    const metric = metricFor(g.goal.metric_key)
+    const unit = metric?.unit ?? ''
+    const label = metric?.display_name ?? g.goal.metric_key
+    const percent = g.percent ?? (g.target > 0 ? (g.progress / g.target) * 100 : 0)
+
+    let progressText: string
+    let paceText: string
+    if (g.goal.kind === 'frequency') {
+      progressText = `${g.progress} / ${g.target}`
+      paceText = `${g.progress} of ${g.target} days`
+    } else if (g.goal.kind === 'streak') {
+      progressText = `${g.progress} day${g.progress === 1 ? '' : 's'}`
+      paceText = `target ${g.target}-day streak`
+    } else {
+      const u = displayUnit(unit)
+      progressText = `${fmt(unit, g.progress)} / ${fmt(unit, g.target)} ${u}`
+      paceText = paceForVolume(g, unit)
+    }
+
+    return {
+      id: g.goal.id,
+      label,
+      progressText,
+      percent,
+      met: g.met,
+      barClass: barClass(g, percent),
+      paceText: g.met ? 'Achieved 🎉' : paceText,
+      paceClass: paceClass(g),
+    }
+  }),
+)
+
+function paceForVolume(g: GoalProgress, unit: string): string {
+  if (g.met) return 'Achieved 🎉'
+  if (g.projected !== null) {
+    const u = displayUnit(unit)
+    const proj = `on pace for ${fmt(unit, g.projected)} ${u}`
+    if (g.per_day_needed && g.per_day_needed > 0) {
+      return `${fmt(unit, g.per_day_needed)} ${u}/day to finish · ${proj}`
+    }
+    return proj
+  }
+  return ''
+}
+
+function barClass(g: GoalProgress, percent: number): string {
+  if (g.met || percent >= 100) return 'bg-green-500'
+  if (g.on_pace === true) return 'bg-green-500'
+  if (g.on_pace === false) return 'bg-amber-500'
+  return 'bg-blue-500'
+}
+
+function paceClass(g: GoalProgress): string {
+  if (g.met) return 'text-green-600 font-medium'
+  if (g.on_pace === true) return 'text-green-600 font-medium'
+  if (g.on_pace === false) return 'text-amber-600 font-medium'
+  return 'text-gray-500'
+}
+</script>

--- a/frontend/src/components/__tests__/TodayCard.test.ts
+++ b/frontend/src/components/__tests__/TodayCard.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import TodayCard from '../TodayCard.vue'
+import type { GoalProgress, MetricGoal, MetricType } from '@/types/metrics'
+
+const types: MetricType[] = [
+  { key: 'pushups', display_name: 'Push-ups', unit: 'reps', aggregation: 'sum', higher_is_better: true },
+  { key: 'body_weight', display_name: 'Body weight', unit: 'kg', aggregation: 'latest', higher_is_better: false },
+]
+
+function makeGoal(over: Partial<MetricGoal>): MetricGoal {
+  return {
+    id: 'g1',
+    user_id: 'u1',
+    metric_key: 'pushups',
+    kind: 'volume',
+    period: 'month',
+    period_start: null,
+    period_end: null,
+    target: 100,
+    comparator: 'gte',
+    rest_budget: 0,
+    status: 'active',
+    ...over,
+  }
+}
+
+function progress(over: Partial<GoalProgress> & { goal: MetricGoal }): GoalProgress {
+  return {
+    window_start: '2026-06-01',
+    window_end: '2026-06-30',
+    progress: 0,
+    target: over.goal.target,
+    percent: null,
+    met: false,
+    projected: null,
+    on_pace: null,
+    per_day_needed: null,
+    ...over,
+  }
+}
+
+describe('TodayCard', () => {
+  it('shows empty state with no goals', () => {
+    const w = mount(TodayCard, { props: { goals: [], types } })
+    expect(w.text()).toContain('No active goals')
+  })
+
+  it('renders a volume goal with display unit and pace', () => {
+    const g = progress({
+      goal: makeGoal({ metric_key: 'pushups', kind: 'volume', target: 100 }),
+      progress: 30,
+      percent: 30,
+      on_pace: false,
+      projected: 90,
+      per_day_needed: 13.5,
+    })
+    const w = mount(TodayCard, { props: { goals: [g], types } })
+    expect(w.text()).toContain('Push-ups')
+    expect(w.text()).toContain('30 / 100 reps')
+    expect(w.text()).toContain('30%')
+    expect(w.text()).toContain('on pace for 90 reps')
+  })
+
+  it('renders a frequency goal as days', () => {
+    const g = progress({
+      goal: makeGoal({ metric_key: 'body_weight', kind: 'frequency', period: 'week', target: 3 }),
+      progress: 2,
+      percent: 66.6,
+    })
+    const w = mount(TodayCard, { props: { goals: [g], types } })
+    expect(w.text()).toContain('Body weight')
+    expect(w.text()).toContain('2 of 3 days')
+  })
+
+  it('flags a met goal as achieved', () => {
+    const g = progress({
+      goal: makeGoal({ target: 100 }),
+      progress: 120,
+      percent: 120,
+      met: true,
+    })
+    const w = mount(TodayCard, { props: { goals: [g], types } })
+    expect(w.text()).toContain('Achieved')
+  })
+})

--- a/frontend/src/composables/__tests__/useMetrics.test.ts
+++ b/frontend/src/composables/__tests__/useMetrics.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const apiCall = vi.fn()
+vi.mock('@/config/api', () => ({
+  apiCall: (...args: unknown[]) => apiCall(...args),
+}))
+
+import { useMetrics } from '@/composables/useMetrics'
+
+beforeEach(() => {
+  apiCall.mockReset()
+})
+
+describe('useMetrics', () => {
+  it('loadGoals fetches /metrics/goals and stores the result', async () => {
+    apiCall.mockResolvedValueOnce([{ goal: { id: 'g1' }, progress: 5 }])
+    const { goals, loadGoals } = useMetrics()
+    await loadGoals()
+    expect(apiCall).toHaveBeenCalledWith('/metrics/goals')
+    expect(goals.value).toHaveLength(1)
+  })
+
+  it('loadTypes fetches /metrics/types', async () => {
+    apiCall.mockResolvedValueOnce([{ key: 'pushups' }])
+    const { types, loadTypes } = useMetrics()
+    await loadTypes()
+    expect(apiCall).toHaveBeenCalledWith('/metrics/types')
+    expect(types.value).toHaveLength(1)
+  })
+
+  it('logEntry POSTs the metric_key and value', async () => {
+    apiCall.mockResolvedValueOnce({ id: 'e1' })
+    const { logEntry } = useMetrics()
+    await logEntry('pushups', 25)
+    expect(apiCall).toHaveBeenCalledWith('/metrics/entries', {
+      method: 'POST',
+      body: JSON.stringify({ metric_key: 'pushups', value: 25 }),
+    })
+  })
+
+  it('loadGoals surfaces an error message on failure', async () => {
+    apiCall.mockRejectedValueOnce(new Error('boom'))
+    const { error, loadGoals } = useMetrics()
+    await loadGoals()
+    expect(error.value).toBe('boom')
+  })
+})

--- a/frontend/src/composables/useMetrics.ts
+++ b/frontend/src/composables/useMetrics.ts
@@ -1,0 +1,39 @@
+import { ref } from 'vue'
+import { apiCall } from '@/config/api'
+import type { GoalProgress, MetricEntry, MetricType } from '@/types/metrics'
+
+export function useMetrics() {
+  const types = ref<MetricType[]>([])
+  const goals = ref<GoalProgress[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const loadTypes = async (): Promise<void> => {
+    try {
+      types.value = await apiCall<MetricType[]>('/metrics/types')
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load metric types'
+    }
+  }
+
+  const loadGoals = async (): Promise<void> => {
+    loading.value = true
+    error.value = null
+    try {
+      goals.value = await apiCall<GoalProgress[]>('/metrics/goals')
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load goals'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  const logEntry = async (metricKey: string, value: number): Promise<MetricEntry> => {
+    return apiCall<MetricEntry>('/metrics/entries', {
+      method: 'POST',
+      body: JSON.stringify({ metric_key: metricKey, value }),
+    })
+  }
+
+  return { types, goals, loading, error, loadTypes, loadGoals, logEntry }
+}

--- a/frontend/src/types/metrics.ts
+++ b/frontend/src/types/metrics.ts
@@ -1,0 +1,56 @@
+// Shapes returned by the backend /metrics/* endpoints (see backend/routes/metrics.py).
+
+export type MetricAggregation = 'sum' | 'count' | 'latest' | 'max'
+export type GoalKind = 'volume' | 'frequency' | 'streak'
+export type GoalPeriod = 'year' | 'month' | 'week' | 'custom'
+export type GoalComparator = 'gte' | 'lte'
+export type GoalStatus = 'active' | 'achieved' | 'archived'
+
+export interface MetricType {
+  key: string
+  display_name: string
+  unit: string
+  aggregation: MetricAggregation
+  higher_is_better: boolean
+}
+
+export interface MetricGoal {
+  id: string
+  user_id: string
+  metric_key: string
+  kind: GoalKind
+  period: GoalPeriod
+  period_start: string | null
+  period_end: string | null
+  target: number
+  comparator: GoalComparator
+  rest_budget: number
+  status: GoalStatus
+  created_at?: string | null
+}
+
+export interface GoalProgress {
+  goal: MetricGoal
+  window_start: string
+  window_end: string
+  progress: number
+  target: number
+  percent: number | null
+  met: boolean
+  projected: number | null
+  on_pace: boolean | null
+  per_day_needed: number | null
+}
+
+export interface MetricEntry {
+  id: string
+  user_id: string
+  metric_key: string
+  occurred_on: string
+  occurred_at: string | null
+  value: number
+  note: string | null
+  source: string
+  external_id: string | null
+  created_at?: string | null
+}

--- a/frontend/src/utils/metrics.ts
+++ b/frontend/src/utils/metrics.ts
@@ -1,0 +1,32 @@
+// Display conversion at the presentation edge: the backend stores canonical units
+// (km, kg, reps), the UI shows miles / pounds / reps. See docs/UNITS.md.
+
+const KM_TO_MI = 0.621371
+const KG_TO_LB = 2.20462
+
+/** Unit label shown to the user for a stored unit. */
+export function displayUnit(storedUnit: string): string {
+  if (storedUnit === 'km') return 'mi'
+  if (storedUnit === 'kg') return 'lb'
+  return storedUnit
+}
+
+/** Convert a stored value into its display unit. */
+export function toDisplay(storedUnit: string, value: number): number {
+  if (storedUnit === 'km') return value * KM_TO_MI
+  if (storedUnit === 'kg') return value * KG_TO_LB
+  return value
+}
+
+/** Convert a user-entered display value back to the stored (canonical) unit. */
+export function toStored(storedUnit: string, displayValue: number): number {
+  if (storedUnit === 'km') return displayValue / KM_TO_MI
+  if (storedUnit === 'kg') return displayValue / KG_TO_LB
+  return displayValue
+}
+
+/** Sensible decimal places for a display value by unit. */
+export function displayDecimals(storedUnit: string): number {
+  if (storedUnit === 'reps' || storedUnit === 'session') return 0
+  return 1
+}

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -35,6 +35,11 @@
         />
       </div>
 
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+        <TodayCard :goals="metricGoals" :types="metricTypes" />
+        <QuickLog :types="metricTypes" @logged="loadMetricGoals" />
+      </div>
+
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         <StatCard
           label="Total runs"
@@ -106,7 +111,10 @@ import StreakHero from '@/components/StreakHero.vue'
 import StreakHeatmap from '@/components/StreakHeatmap.vue'
 import MonthlyDistanceChart from '@/components/MonthlyDistanceChart.vue'
 import GoalsCard from '@/components/GoalsCard.vue'
+import TodayCard from '@/components/TodayCard.vue'
+import QuickLog from '@/components/QuickLog.vue'
 import { useStats } from '@/composables/useStats'
+import { useMetrics } from '@/composables/useMetrics'
 import { useRecentRuns } from '@/composables/useRecentRuns'
 import { useMonthlyStats } from '@/composables/useMonthlyStats'
 import { useGoals } from '@/composables/useGoals'
@@ -132,6 +140,12 @@ const {
 } = useRecentRuns(100)
 const { months, loading: monthlyLoading, error: monthlyError, load: loadMonthly } = useMonthlyStats(12)
 const { goals, error: goalsError, load: loadGoals } = useGoals()
+const {
+  types: metricTypes,
+  goals: metricGoals,
+  loadTypes: loadMetricTypes,
+  loadGoals: loadMetricGoals,
+} = useMetrics()
 const { unit } = useUserPreferences()
 
 const initialLoading = computed(
@@ -148,8 +162,10 @@ const isNewUser = computed(() => stats.value !== null && stats.value.total_runs 
 const heatmapGrid = computed(() => buildHeatmapGrid(recentRuns.value, 12))
 
 const reload = async () => {
-  await Promise.all([loadStats(), loadRecent(), loadMonthly(), loadGoals()])
+  await Promise.all([loadStats(), loadRecent(), loadMonthly(), loadGoals(), loadMetricGoals()])
 }
 
-onMounted(reload)
+onMounted(async () => {
+  await Promise.all([reload(), loadMetricTypes()])
+})
 </script>


### PR DESCRIPTION
Implements **SB-94** — the frontend for the metric engine (SB-92 schema + SB-93 API). Closes the Phase 0 loop: you can log weight/push-ups and see goal progress.

## What's here
- **`useMetrics`** composable — `loadTypes`, `loadGoals` (returns goals **with computed progress**), `logEntry` (POST `/metrics/entries`).
- **`QuickLog`** — the one-tap logging surface:
  - Push-ups: preset buttons **+10 / +25 / +50** (one tap = logged) + a custom field.
  - Weigh-in: number field in **lb**, converted to kg before storing.
  - Logging from the dashboard, no form-nav-submit.
- **`TodayCard`** — active goals as progress bars with **pace**:
  - volume → `X/day to finish · on pace for Y`
  - frequency → `N of M days`
  - streak → chain length
  - values shown in display units (mi / lb / reps); `utils/metrics.ts` converts at the edge per `docs/UNITS.md`.
- Wired both into `DashboardView`; a log refreshes goals.

## Tests / gates
- New: `useMetrics.test.ts` (mocked apiCall) + `TodayCard.test.ts` (render).
- **74 frontend tests pass · `vue-tsc` type-check clean · production build succeeds.**

## Notes
- Depends on SB-92 + SB-93 (both merged to `main`).
- Goal **creation** UI isn't in this PR — goals can be created via the `POST /metrics/goals` API; a create-goal form is a natural fast-follow. QuickLog + TodayCard make logging and progress visible now.

Fixes SB-94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)