### PR TITLE
feat: goal-creation UI (New goal form)

### DIFF
--- a/frontend/src/components/NewGoalForm.vue
+++ b/frontend/src/components/NewGoalForm.vue
@@ -1,0 +1,195 @@
+<template>
+  <div
+    v-if="show"
+    class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+    @click="$emit('cancel')"
+  >
+    <div
+      class="bg-white rounded-xl shadow-xl max-w-md w-[90%] max-h-[90vh] overflow-y-auto"
+      @click.stop
+    >
+      <form class="p-6 space-y-4" @submit.prevent="submit">
+        <h3 class="text-lg font-semibold text-gray-900">New goal</h3>
+
+        <!-- Metric -->
+        <label class="block">
+          <span class="text-xs font-medium text-gray-700">Metric</span>
+          <select v-model="metricKey" class="mt-1 w-full px-3 py-2 rounded-lg border border-gray-200 text-sm">
+            <option v-for="t in types" :key="t.key" :value="t.key">{{ t.display_name }}</option>
+          </select>
+        </label>
+
+        <!-- Kind -->
+        <label class="block">
+          <span class="text-xs font-medium text-gray-700">Type</span>
+          <select v-model="kind" class="mt-1 w-full px-3 py-2 rounded-lg border border-gray-200 text-sm">
+            <option value="volume">Volume — accumulate toward a total</option>
+            <option value="frequency">Frequency — do it N times</option>
+            <option value="streak">Streak — a daily chain</option>
+          </select>
+        </label>
+
+        <!-- Period -->
+        <label class="block">
+          <span class="text-xs font-medium text-gray-700">Period</span>
+          <select v-model="period" class="mt-1 w-full px-3 py-2 rounded-lg border border-gray-200 text-sm">
+            <option value="week">This week</option>
+            <option value="month">This month</option>
+            <option value="year">This year</option>
+            <option value="custom">Custom range</option>
+          </select>
+        </label>
+
+        <div v-if="period === 'custom'" class="grid grid-cols-2 gap-3">
+          <label class="block">
+            <span class="text-xs font-medium text-gray-700">Start</span>
+            <input v-model="periodStart" type="date" class="mt-1 w-full px-3 py-2 rounded-lg border border-gray-200 text-sm" />
+          </label>
+          <label class="block">
+            <span class="text-xs font-medium text-gray-700">End</span>
+            <input v-model="periodEnd" type="date" class="mt-1 w-full px-3 py-2 rounded-lg border border-gray-200 text-sm" />
+          </label>
+        </div>
+
+        <!-- Target -->
+        <label class="block">
+          <span class="text-xs font-medium text-gray-700">{{ targetLabel }}</span>
+          <input
+            v-model.number="target"
+            type="number"
+            min="0"
+            step="any"
+            class="mt-1 w-full px-3 py-2 rounded-lg border border-gray-200 text-sm"
+          />
+        </label>
+
+        <!-- Comparator (volume only) -->
+        <label v-if="kind === 'volume'" class="block">
+          <span class="text-xs font-medium text-gray-700">Goal direction</span>
+          <select v-model="comparator" class="mt-1 w-full px-3 py-2 rounded-lg border border-gray-200 text-sm">
+            <option value="gte">Reach at least the target</option>
+            <option value="lte">Stay at or under the target</option>
+          </select>
+        </label>
+
+        <!-- Rest budget (frequency / streak) -->
+        <label v-if="kind !== 'volume'" class="block">
+          <span class="text-xs font-medium text-gray-700">Rest days allowed (per window)</span>
+          <input
+            v-model.number="restBudget"
+            type="number"
+            min="0"
+            class="mt-1 w-full px-3 py-2 rounded-lg border border-gray-200 text-sm"
+          />
+        </label>
+
+        <p v-if="error" class="text-xs text-red-600">{{ error }}</p>
+
+        <div class="flex justify-end gap-3 pt-2">
+          <button type="button" class="btn-secondary text-sm" @click="$emit('cancel')">Cancel</button>
+          <button
+            type="submit"
+            class="px-4 py-2 text-sm font-semibold text-white rounded-lg bg-brand-600 hover:bg-brand-700 disabled:opacity-50"
+            :disabled="submitting || !valid"
+          >
+            {{ submitting ? 'Saving…' : 'Create goal' }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useMetrics, type NewGoalPayload } from '@/composables/useMetrics'
+import type { MetricType } from '@/types/metrics'
+import { displayUnit, toStored } from '@/utils/metrics'
+
+const props = defineProps<{ show: boolean; types: MetricType[] }>()
+const emit = defineEmits<{ created: []; cancel: [] }>()
+
+const { createGoal } = useMetrics()
+
+const metricKey = ref('')
+const kind = ref('volume')
+const period = ref('month')
+const target = ref<number | null>(null)
+const comparator = ref('gte')
+const restBudget = ref(0)
+const periodStart = ref('')
+const periodEnd = ref('')
+const submitting = ref(false)
+const error = ref('')
+
+const selectedType = computed(() => props.types.find((t) => t.key === metricKey.value))
+
+// Default the metric once types arrive, and auto-pick a sensible direction.
+watch(
+  () => props.types,
+  (t) => {
+    if (!metricKey.value && t.length) metricKey.value = t[0].key
+  },
+  { immediate: true },
+)
+watch(metricKey, () => {
+  comparator.value = selectedType.value && !selectedType.value.higher_is_better ? 'lte' : 'gte'
+})
+
+const targetLabel = computed(() => {
+  if (kind.value === 'frequency') return 'How many times'
+  if (kind.value === 'streak') return 'Target streak (days)'
+  const u = selectedType.value ? displayUnit(selectedType.value.unit) : ''
+  return `Target${u ? ` (${u})` : ''}`
+})
+
+const valid = computed(() => {
+  if (!metricKey.value || target.value === null || target.value <= 0) return false
+  if (period.value === 'custom' && (!periodStart.value || !periodEnd.value)) return false
+  return true
+})
+
+async function submit(): Promise<void> {
+  if (!valid.value || target.value === null) return
+  submitting.value = true
+  error.value = ''
+  try {
+    // Volume targets are in the metric's unit → convert display→stored.
+    // Frequency/streak targets are plain counts.
+    const storedTarget =
+      kind.value === 'volume' && selectedType.value
+        ? toStored(selectedType.value.unit, target.value)
+        : target.value
+
+    const payload: NewGoalPayload = {
+      metric_key: metricKey.value,
+      kind: kind.value,
+      period: period.value,
+      target: storedTarget,
+      comparator: comparator.value,
+    }
+    if (kind.value !== 'volume') payload.rest_budget = restBudget.value
+    if (period.value === 'custom') {
+      payload.period_start = periodStart.value
+      payload.period_end = periodEnd.value
+    }
+
+    await createGoal(payload)
+    reset()
+    emit('created')
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to create goal'
+  } finally {
+    submitting.value = false
+  }
+}
+
+function reset(): void {
+  kind.value = 'volume'
+  period.value = 'month'
+  target.value = null
+  restBudget.value = 0
+  periodStart.value = ''
+  periodEnd.value = ''
+}
+</script>

--- a/frontend/src/components/TodayCard.vue
+++ b/frontend/src/components/TodayCard.vue
@@ -1,10 +1,19 @@
 <template>
   <div class="bg-white rounded-2xl shadow-md p-6 h-full border border-gray-100">
-    <div class="flex items-center gap-2 mb-4">
-      <span class="text-lg">📈</span>
-      <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-700">
-        Today
-      </h3>
+    <div class="flex items-center justify-between mb-4">
+      <div class="flex items-center gap-2">
+        <span class="text-lg">📈</span>
+        <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-700">
+          Today
+        </h3>
+      </div>
+      <button
+        type="button"
+        class="text-xs font-medium text-brand-600 hover:text-brand-700"
+        @click="$emit('create')"
+      >
+        + New goal
+      </button>
     </div>
 
     <div v-if="goals.length === 0" class="text-sm text-gray-500">
@@ -45,6 +54,8 @@ const props = defineProps<{
   goals: GoalProgress[]
   types: MetricType[]
 }>()
+
+defineEmits<{ create: [] }>()
 
 interface Row {
   id: string

--- a/frontend/src/components/__tests__/NewGoalForm.test.ts
+++ b/frontend/src/components/__tests__/NewGoalForm.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+const apiCall = vi.fn()
+vi.mock('@/config/api', () => ({
+  apiCall: (...args: unknown[]) => apiCall(...args),
+}))
+
+import NewGoalForm from '../NewGoalForm.vue'
+import type { MetricType } from '@/types/metrics'
+
+const types: MetricType[] = [
+  { key: 'running_distance', display_name: 'Running distance', unit: 'km', aggregation: 'sum', higher_is_better: true },
+  { key: 'pushups', display_name: 'Push-ups', unit: 'reps', aggregation: 'sum', higher_is_better: true },
+]
+
+beforeEach(() => apiCall.mockReset())
+
+function lastBody(): Record<string, unknown> {
+  const [, opts] = apiCall.mock.calls[apiCall.mock.calls.length - 1]
+  return JSON.parse((opts as RequestInit).body as string)
+}
+
+describe('NewGoalForm', () => {
+  it('does not render when show is false', () => {
+    const w = mount(NewGoalForm, { props: { show: false, types } })
+    expect(w.find('form').exists()).toBe(false)
+  })
+
+  it('converts a volume target from display units (mi) to stored (km)', async () => {
+    apiCall.mockResolvedValueOnce({ id: 'g1' })
+    const w = mount(NewGoalForm, { props: { show: true, types } })
+
+    const selects = w.findAll('select')
+    await selects[0].setValue('running_distance') // metric
+    await selects[1].setValue('volume') // kind
+    await selects[2].setValue('month') // period
+    await w.find('input[type="number"]').setValue(100) // 100 mi
+
+    await w.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(apiCall).toHaveBeenCalledWith('/metrics/goals', expect.objectContaining({ method: 'POST' }))
+    const body = lastBody()
+    expect(body.metric_key).toBe('running_distance')
+    expect(body.kind).toBe('volume')
+    expect(body.comparator).toBe('gte')
+    expect(body.target as number).toBeCloseTo(160.93, 1) // 100 mi → km
+    expect(w.emitted('created')).toBeTruthy()
+  })
+
+  it('sends a plain count (no conversion) for a frequency goal with rest_budget', async () => {
+    apiCall.mockResolvedValueOnce({ id: 'g2' })
+    const w = mount(NewGoalForm, { props: { show: true, types } })
+
+    const selects = w.findAll('select')
+    await selects[0].setValue('pushups')
+    await selects[1].setValue('frequency')
+    await selects[2].setValue('week')
+    await w.find('input[type="number"]').setValue(5)
+
+    await w.find('form').trigger('submit')
+    await flushPromises()
+
+    const body = lastBody()
+    expect(body.metric_key).toBe('pushups')
+    expect(body.kind).toBe('frequency')
+    expect(body.target).toBe(5)
+    expect(body.rest_budget).toBe(0)
+  })
+
+  it('requires period bounds for a custom period before submitting', async () => {
+    const w = mount(NewGoalForm, { props: { show: true, types } })
+    const selects = w.findAll('select')
+    await selects[1].setValue('volume')
+    await selects[2].setValue('custom')
+    await w.find('input[type="number"]').setValue(50)
+
+    await w.find('form').trigger('submit')
+    await flushPromises()
+
+    // No dates → invalid → no API call.
+    expect(apiCall).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/composables/useMetrics.ts
+++ b/frontend/src/composables/useMetrics.ts
@@ -1,6 +1,17 @@
 import { ref } from 'vue'
 import { apiCall } from '@/config/api'
-import type { GoalProgress, MetricEntry, MetricType } from '@/types/metrics'
+import type { GoalProgress, MetricEntry, MetricGoal, MetricType } from '@/types/metrics'
+
+export interface NewGoalPayload {
+  metric_key: string
+  kind: string
+  period: string
+  target: number
+  comparator: string
+  rest_budget?: number
+  period_start?: string
+  period_end?: string
+}
 
 export function useMetrics() {
   const types = ref<MetricType[]>([])
@@ -35,5 +46,12 @@ export function useMetrics() {
     })
   }
 
-  return { types, goals, loading, error, loadTypes, loadGoals, logEntry }
+  const createGoal = async (payload: NewGoalPayload): Promise<MetricGoal> => {
+    return apiCall<MetricGoal>('/metrics/goals', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    })
+  }
+
+  return { types, goals, loading, error, loadTypes, loadGoals, logEntry, createGoal }
 }

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -36,9 +36,16 @@
       </div>
 
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
-        <TodayCard :goals="metricGoals" :types="metricTypes" />
+        <TodayCard :goals="metricGoals" :types="metricTypes" @create="showNewGoal = true" />
         <QuickLog :types="metricTypes" @logged="loadMetricGoals" />
       </div>
+
+      <NewGoalForm
+        :show="showNewGoal"
+        :types="metricTypes"
+        @created="onGoalCreated"
+        @cancel="showNewGoal = false"
+      />
 
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         <StatCard
@@ -101,7 +108,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { RouterLink } from 'vue-router'
 import StatCard from '@/components/StatCard.vue'
 import RunRow from '@/components/RunRow.vue'
@@ -113,6 +120,7 @@ import MonthlyDistanceChart from '@/components/MonthlyDistanceChart.vue'
 import GoalsCard from '@/components/GoalsCard.vue'
 import TodayCard from '@/components/TodayCard.vue'
 import QuickLog from '@/components/QuickLog.vue'
+import NewGoalForm from '@/components/NewGoalForm.vue'
 import { useStats } from '@/composables/useStats'
 import { useMetrics } from '@/composables/useMetrics'
 import { useRecentRuns } from '@/composables/useRecentRuns'
@@ -147,6 +155,12 @@ const {
   loadGoals: loadMetricGoals,
 } = useMetrics()
 const { unit } = useUserPreferences()
+
+const showNewGoal = ref(false)
+const onGoalCreated = async () => {
+  showNewGoal.value = false
+  await loadMetricGoals()
+}
 
 const initialLoading = computed(
   () =>


### PR DESCRIPTION
Implements **SB-109** — closes the Phase 0 loop. You can now **create goals from the UI**, so the Today card actually lights up.

## What's here
- **`useMetrics.createGoal`** + `NewGoalPayload` → `POST /metrics/goals`.
- **`NewGoalForm`** modal: metric · kind (volume/frequency/streak) · period (week/month/year/custom + date bounds) · target · comparator (auto **lte** for lower-is-better metrics like weight, else **gte**) · `rest_budget` for frequency/streak.
  - **Volume** targets convert display→stored (mi→km, lb→kg); **frequency/streak** targets are plain counts.
- **`+ New goal`** button on `TodayCard` opens the form; on create → goals refresh and the card updates.

## Tests / gates
- New `NewGoalForm.test.ts`: unit conversion (100 mi → ~160.9 km), frequency payload + rest_budget, custom-period validation guard.
- **78 frontend tests pass · type-check clean · build OK.**

## Where this leaves Phase 0
End-to-end usable for manual metrics: **create a goal → log via QuickLog → watch Today card progress + pace.** The remaining engine gap is running data — runs aren't projected into `metric_entries` yet (the recommended next build), so running goals won't populate until that lands.

Fixes SB-109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)