### PR TITLE
feat: adaptive planning engine + schema (SB-163)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ tmp/
 
 # Local terraform plan artifacts
 terraform/environments/*/tfplan
+
+# Ephemeral design/planning scratch — superseded by Linear tickets + the shipped
+# user guide. Not committed; deleted once the feature lands.
+docs/PLANNING.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,14 @@ stk = "cli.main:cli"
 requires = ["uv_build>=0.9.5,<0.10.0"]
 build-backend = "uv_build"
 
+[tool.uv]
+# The root project is a virtual workspace: code is imported via the `src.*` path
+# (see tests + tooling), not installed as a `myrunstreak` wheel. Building it as a
+# package fails on newer uv (no `src/myrunstreak/` module) and is unnecessary for
+# tests. Matches backend/pyproject.toml. Packaging the `stk` script is a separate
+# concern handled at build/deploy time.
+package = false
+
 [tool.ruff]
 line-length = 100
 target-version = "py312"

--- a/src/shared/models/__init__.py
+++ b/src/shared/models/__init__.py
@@ -25,6 +25,18 @@ from .metric import (
     MetricType,
 )
 from .nested import HeartRateRecovery, Lap, Song
+from .planning import (
+    ActualEntry,
+    FeasibilityStatus,
+    GoalPlanStatus,
+    PlanConstraint,
+    PlanDay,
+    PlanDayKind,
+    PlanningGoal,
+    PlanResult,
+    Readiness,
+    ReadinessStatus,
+)
 from .split import Split
 from .units import (
     UnitSystem,
@@ -52,6 +64,17 @@ __all__ = [
     "GoalPeriod",
     "GoalComparator",
     "GoalStatus",
+    # Planning
+    "ActualEntry",
+    "PlanConstraint",
+    "PlanDay",
+    "PlanDayKind",
+    "PlanningGoal",
+    "PlanResult",
+    "Readiness",
+    "ReadinessStatus",
+    "GoalPlanStatus",
+    "FeasibilityStatus",
     # Nested models
     "Lap",
     "Song",

--- a/src/shared/models/planning.py
+++ b/src/shared/models/planning.py
@@ -1,0 +1,162 @@
+"""Adaptive monthly planning — domain models (SB-163).
+
+Pure-data models the planner consumes and produces. **No I/O.** The engine in
+``src/shared/planning/`` is a pure function over these; the repository/backend
+layer (P1, SB-164) maps Supabase rows to/from them.
+
+All distances are canonical **kilometers** (like ``runs.distance_km`` and
+``metric_entries.value``); convert to miles at the presentation edge.
+
+Design: planning reuses ``metric_goals`` as the target model — a stored goal maps
+to a :class:`PlanningGoal`. The qualifier fields (``qualifier_threshold``,
+``per_event_min``) are an additive Phase-1 concern on ``metric_goals``; the engine
+just needs them as input and stays decoupled from schema evolution.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from enum import StrEnum
+
+from pydantic import BaseModel, Field, model_validator
+
+from .metric import GoalKind
+
+
+class ReadinessStatus(StrEnum):
+    """How the user feels on a given day. Absence of a row == ``good``."""
+
+    good = "good"
+    tired = "tired"  # down-shift today to an easy day
+    sick = "sick"  # today becomes rest (streak floor still honored)
+
+
+class PlanDayKind(StrEnum):
+    """Training role of a prescribed day."""
+
+    long = "long"  # a qualifying long run
+    easy = "easy"  # ordinary distributed day
+    rest = "rest"  # recovery (streak floor still prescribed if a streak goal exists)
+    fixed = "fixed"  # constraint-locked (e.g. travel cap)
+
+
+class FeasibilityStatus(StrEnum):
+    """The planner's verdict on whether a goal is still reachable."""
+
+    on_track = "on_track"
+    at_risk = "at_risk"
+
+
+class ActualEntry(BaseModel):
+    """A logged metric event the planner reads (the subset of ``MetricEntry`` it needs)."""
+
+    metric_key: str
+    occurred_on: date
+    value: float = Field(ge=0, description="Canonical unit (km/reps) or 1 for a check-in")
+
+
+class PlanConstraint(BaseModel):
+    """A known-in-advance limit on a metric over a date range.
+
+    ``cap`` = max prescribable/day, ``floor`` = min still required/day. Both set =
+    a pinned value (Chicago: cap=floor=1 mi). Distances in canonical km.
+    """
+
+    metric_key: str
+    start_on: date
+    end_on: date
+    cap: float | None = Field(default=None, ge=0)
+    floor: float | None = Field(default=None, ge=0)
+    reason: str | None = None
+
+    @model_validator(mode="after")
+    def _check_bounds(self) -> PlanConstraint:
+        if self.end_on < self.start_on:
+            raise ValueError("end_on must be on or after start_on")
+        if self.cap is not None and self.floor is not None and self.floor > self.cap:
+            raise ValueError("floor must be <= cap")
+        return self
+
+    def covers(self, day: date) -> bool:
+        return self.start_on <= day <= self.end_on
+
+    @property
+    def pinned_value(self) -> float | None:
+        """The value a covered day is locked to: cap if set, else floor."""
+        return self.cap if self.cap is not None else self.floor
+
+
+class Readiness(BaseModel):
+    """A daily "how I feel" signal."""
+
+    log_on: date
+    status: ReadinessStatus = ReadinessStatus.good
+    note: str | None = None
+
+
+class PlanningGoal(BaseModel):
+    """Engine input: one monthly target. Maps from a stored ``metric_goals`` row.
+
+    ``qualifier_threshold`` does double duty:
+      - ``streak`` goal → the daily floor (run >= 1 mi/day).
+      - ``frequency`` goal → the per-day threshold a day must clear to count
+        (a run >= 5 mi qualifies as one of the "4 long runs").
+
+    ``per_event_min`` is the minimum value each qualifying event needs (push-ups
+    >= 60 per session).
+    """
+
+    metric_key: str
+    kind: GoalKind
+    target: float = Field(gt=0)
+    period_start: date
+    period_end: date
+    qualifier_threshold: float | None = Field(default=None, ge=0)
+    per_event_min: float | None = Field(default=None, ge=0)
+    rest_budget: int = Field(default=0, ge=0)
+
+
+class PlanDay(BaseModel):
+    """A generated prescription for one metric on one day (the cache row)."""
+
+    metric_key: str
+    plan_on: date
+    prescribed_value: float = Field(ge=0)
+    kind: PlanDayKind
+
+
+class GoalPlanStatus(BaseModel):
+    """Per-goal progress + verdict for a recompute."""
+
+    metric_key: str
+    kind: GoalKind
+    target: float
+    done: float
+    remaining: float
+    projected: float | None = None
+    status: FeasibilityStatus
+    detail: str | None = None  # catch-up note, or why it is at risk
+
+
+class PlanResult(BaseModel):
+    """The full output of a recompute — the planner's complete answer.
+
+    ``days`` holds every prescription for ``[generated_for .. period_end]``;
+    ``goals`` holds per-goal status; ``status`` is the month-level roll-up
+    (at_risk if any goal is at risk).
+    """
+
+    period_start: date
+    period_end: date
+    generated_for: date  # the "today" the recompute was run for
+    days: list[PlanDay]
+    goals: list[GoalPlanStatus]
+    status: FeasibilityStatus
+    at_risk_reasons: list[str] = Field(default_factory=list)
+
+    def days_for(self, metric_key: str) -> list[PlanDay]:
+        """Prescriptions for one metric, in date order."""
+        return sorted(
+            (d for d in self.days if d.metric_key == metric_key),
+            key=lambda d: d.plan_on,
+        )

--- a/src/shared/planning/__init__.py
+++ b/src/shared/planning/__init__.py
@@ -1,0 +1,16 @@
+"""Adaptive monthly planning engine (SB-163).
+
+Pure functions that turn monthly goals + actuals + constraints + readiness into a
+day-by-day plan. **No I/O, no LLM** — every number originates here so the result
+is reproducible and testable. The LLM coaching layer (P2) only narrates this
+output; it never computes.
+"""
+
+from .engine import RUNNING_KEY, check_feasibility, generate_plan, recompute
+
+__all__ = [
+    "generate_plan",
+    "recompute",
+    "check_feasibility",
+    "RUNNING_KEY",
+]

--- a/src/shared/planning/engine.py
+++ b/src/shared/planning/engine.py
@@ -1,0 +1,401 @@
+"""The deterministic planning engine (SB-163).
+
+``generate_plan`` is the entry point: given a goal set, the actuals logged so far,
+known constraints, and today's readiness, it returns a :class:`PlanResult` — a
+prescription per metric per day plus a feasibility verdict per goal.
+
+Design notes:
+  - **Per-metric prescriptions.** One run satisfies every running goal at once
+    (the daily streak floor, the 4 long runs, the 135-mi total). So the engine
+    collapses all goals on a metric into a *single* prescription per day via a
+    precedence: constraint ``fixed`` > streak ``floor`` > long-run threshold >
+    volume fill. ``PlanDay`` is keyed by (metric, day), not by goal.
+  - **Training-aware for running** (long-run placement + weekly-ramp ceiling);
+    **simple distributor** for everything else (push-ups, weigh-ins) — they have
+    no injury-ramp concern.
+  - **Done vs. prescribed.** Entries strictly before ``today`` are "done"; the
+    plan prescribes ``[today .. period_end]``. A nightly recompute simply advances
+    ``today``.
+
+All distances are canonical km. Locked defaults (revisit per SB-167):
+ramp +10%/wk, long runs on weekends, precedence as above, readiness affects the
+flagged day only.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from collections.abc import Sequence
+from datetime import date, timedelta
+
+from src.shared.models.metric import GoalKind
+from src.shared.models.planning import (
+    ActualEntry,
+    FeasibilityStatus,
+    GoalPlanStatus,
+    PlanConstraint,
+    PlanDay,
+    PlanDayKind,
+    PlanningGoal,
+    PlanResult,
+    Readiness,
+    ReadinessStatus,
+)
+
+# The one training-aware metric. Everything else uses the simple distributor.
+RUNNING_KEY = "running_distance"
+
+# Locked defaults (SB-167 revisits these with real usage data).
+RAMP_PCT = 0.10  # max +10%/wk vs trailing average
+DEFAULT_CEILING_KM = 16.09344  # ~10 mi — generous per-day cap when no history
+TRAILING_DAYS = 28  # window for the recent-average ramp basis
+MIN_LONG_SPACING_DAYS = 2  # qualifying long runs spaced >= this many days
+_EPS = 1e-6
+
+
+# --------------------------------------------------------------------------- #
+# Small date / aggregation helpers
+# --------------------------------------------------------------------------- #
+def _daterange(start: date, end: date) -> list[date]:
+    """Inclusive list of dates from ``start`` to ``end``."""
+    if end < start:
+        return []
+    return [start + timedelta(days=i) for i in range((end - start).days + 1)]
+
+
+def _is_weekend(day: date) -> bool:
+    return day.weekday() >= 5  # Sat=5, Sun=6
+
+
+def _daily_totals(entries: Sequence[ActualEntry], metric_key: str) -> dict[date, float]:
+    """Sum entry values per day for one metric."""
+    totals: dict[date, float] = defaultdict(float)
+    for e in entries:
+        if e.metric_key == metric_key:
+            totals[e.occurred_on] += e.value
+    return dict(totals)
+
+
+def _spread(days: list[date], n: int) -> list[date]:
+    """Pick ``n`` roughly evenly-spaced days from ``days`` (order preserved)."""
+    if n <= 0 or not days:
+        return []
+    if n >= len(days):
+        return list(days)
+    step = len(days) / n
+    return [days[min(len(days) - 1, int(i * step))] for i in range(n)]
+
+
+def check_feasibility(remaining: float, capacity: float) -> FeasibilityStatus:
+    """Core gate: is the remaining work reachable within the available capacity?"""
+    if remaining > capacity + _EPS:
+        return FeasibilityStatus.at_risk
+    return FeasibilityStatus.on_track
+
+
+# --------------------------------------------------------------------------- #
+# Public entry point
+# --------------------------------------------------------------------------- #
+def generate_plan(
+    *,
+    period_start: date,
+    period_end: date,
+    today: date,
+    goals: Sequence[PlanningGoal],
+    entries: Sequence[ActualEntry],
+    constraints: Sequence[PlanConstraint] = (),
+    readiness: Sequence[Readiness] = (),
+) -> PlanResult:
+    """Build the full plan for ``[today .. period_end]`` from current reality."""
+    plan_days: list[PlanDay] = []
+    statuses: list[GoalPlanStatus] = []
+    reasons: list[str] = []
+
+    by_metric: dict[str, list[PlanningGoal]] = defaultdict(list)
+    for g in goals:
+        by_metric[g.metric_key].append(g)
+
+    for metric_key, mgoals in by_metric.items():
+        if metric_key == RUNNING_KEY:
+            days, st = _plan_running(
+                metric_key, mgoals, entries, constraints, readiness, today, period_end
+            )
+        else:
+            days, st = _plan_simple(metric_key, mgoals, entries, today, period_end)
+        plan_days.extend(days)
+        statuses.extend(st)
+
+    reasons = [s.detail for s in statuses if s.status is FeasibilityStatus.at_risk and s.detail]
+    overall = (
+        FeasibilityStatus.at_risk
+        if any(s.status is FeasibilityStatus.at_risk for s in statuses)
+        else FeasibilityStatus.on_track
+    )
+
+    return PlanResult(
+        period_start=period_start,
+        period_end=period_end,
+        generated_for=today,
+        days=sorted(plan_days, key=lambda d: (d.plan_on, d.metric_key)),
+        goals=statuses,
+        status=overall,
+        at_risk_reasons=reasons,
+    )
+
+
+# ``recompute`` is the nightly/triggered path. For a pure engine it is identical
+# to ``generate_plan`` with an advanced ``today`` — kept as a named alias so the
+# API/cron layer (P1) reads intentionally.
+recompute = generate_plan
+
+
+# --------------------------------------------------------------------------- #
+# Running: training-aware planner
+# --------------------------------------------------------------------------- #
+def _plan_running(
+    metric_key: str,
+    goals: Sequence[PlanningGoal],
+    entries: Sequence[ActualEntry],
+    constraints: Sequence[PlanConstraint],
+    readiness: Sequence[Readiness],
+    today: date,
+    period_end: date,
+) -> tuple[list[PlanDay], list[GoalPlanStatus]]:
+    totals = _daily_totals(entries, metric_key)
+    run_constraints = [c for c in constraints if c.metric_key == metric_key]
+    readiness_by_day = {r.log_on: r.status for r in readiness}
+
+    streak = next((g for g in goals if g.kind is GoalKind.streak), None)
+    volume = next((g for g in goals if g.kind is GoalKind.volume), None)
+    long_goal = next(
+        (g for g in goals if g.kind is GoalKind.frequency and g.qualifier_threshold), None
+    )
+
+    floor_km: float = (streak.qualifier_threshold or 0.0) if streak else 0.0
+    horizon = _daterange(today, period_end)
+
+    # ---- classify each day: locked (constraint) vs free, apply readiness ----
+    locked: dict[date, float] = {}
+    free: list[date] = []
+    rested: set[date] = set()
+    for day in horizon:
+        covering = next((c for c in run_constraints if c.covers(day)), None)
+        if covering is not None and covering.pinned_value is not None:
+            locked[day] = max(covering.pinned_value, 0.0)
+            continue
+        day_status = readiness_by_day.get(day, ReadinessStatus.good)
+        if day_status is ReadinessStatus.sick:
+            rested.add(day)  # rest day: only the streak floor, no long/extra
+        free.append(day)
+
+    # ---- progress so far (entries strictly before today) ----
+    done_volume = sum(v for d, v in totals.items() if d < today)
+    long_threshold: float = (long_goal.qualifier_threshold or 0.0) if long_goal else 0.0
+    qualifying_done = (
+        sum(1 for d, v in totals.items() if d < today and v >= long_threshold - _EPS)
+        if long_goal
+        else 0
+    )
+
+    # ---- weekly-ramp ceiling from recent history ----
+    trailing_start = today - timedelta(days=TRAILING_DAYS)
+    trailing = [v for d, v in totals.items() if trailing_start <= d < today]
+    recent_avg = (sum(trailing) / TRAILING_DAYS) if trailing else 0.0
+    recent_max = max(trailing, default=0.0)
+    ceiling = max(DEFAULT_CEILING_KM, (1 + RAMP_PCT) * recent_avg, (1 + RAMP_PCT) * recent_max)
+
+    # ---- place qualifying long runs on free, non-rest days ----
+    needed_long = max(0, math.ceil(long_goal.target) - qualifying_done) if long_goal else 0
+    eligible = [d for d in free if d not in rested]
+    long_days = _place_long_runs(eligible, needed_long)
+
+    # ---- base prescription per free day, then distribute remaining volume ----
+    base: dict[date, float] = {}
+    for day in free:
+        if day in long_days:
+            base[day] = max(floor_km, long_threshold)
+        else:
+            base[day] = floor_km
+
+    planned_locked = sum(locked.values())
+    prescribed: dict[date, float] = dict(base)
+    volume_at_risk = False
+
+    if volume is not None:
+        remaining_volume = volume.target - done_volume - planned_locked
+        base_total = sum(base.values())
+        extra = remaining_volume - base_total
+        if extra > _EPS:
+            # Rest days (sick readiness) hold only the floor — no fill room, so
+            # their displaced mileage flows to the other free days.
+            room = {d: (0.0 if d in rested else max(0.0, ceiling - base[d])) for d in free}
+            total_room = sum(room.values())
+            capacity = base_total + total_room
+            if remaining_volume > capacity + _EPS:
+                volume_at_risk = True  # cannot fit even at the ceiling
+            if total_room > _EPS:
+                fillable = min(extra, total_room)
+                for d in free:
+                    prescribed[d] = base[d] + fillable * (room[d] / total_room)
+
+    # ---- assemble PlanDay rows ----
+    days_out: list[PlanDay] = []
+    for day, val in locked.items():
+        days_out.append(
+            PlanDay(
+                metric_key=metric_key, plan_on=day, prescribed_value=val, kind=PlanDayKind.fixed
+            )
+        )
+    for day in free:
+        if day in long_days:
+            kind = PlanDayKind.long
+        elif day in rested:
+            kind = PlanDayKind.rest
+        else:
+            kind = PlanDayKind.easy
+        days_out.append(
+            PlanDay(
+                metric_key=metric_key,
+                plan_on=day,
+                prescribed_value=round(prescribed[day], 3),
+                kind=kind,
+            )
+        )
+
+    # ---- per-goal status ----
+    statuses: list[GoalPlanStatus] = []
+    projected_total = done_volume + planned_locked + sum(prescribed.values())
+
+    if streak is not None:
+        # Every prescribed day clears the floor by construction (locked Chicago = 1 mi
+        # = floor; free days default to floor; rest days keep the floor).
+        below = [d for d in horizon if (prescribed.get(d, locked.get(d, 0.0)) + _EPS) < floor_km]
+        statuses.append(
+            GoalPlanStatus(
+                metric_key=metric_key,
+                kind=GoalKind.streak,
+                target=streak.target,
+                done=float(sum(1 for d in totals if d < today and totals[d] >= floor_km - _EPS)),
+                remaining=float(len(horizon)),
+                status=FeasibilityStatus.on_track if not below else FeasibilityStatus.at_risk,
+                detail=None
+                if not below
+                else f"{len(below)} day(s) fall below the {floor_km:.2f}km floor",
+            )
+        )
+
+    if long_goal is not None:
+        projected_long = qualifying_done + len(long_days)
+        ok = projected_long >= long_goal.target and long_threshold <= ceiling + _EPS
+        statuses.append(
+            GoalPlanStatus(
+                metric_key=metric_key,
+                kind=GoalKind.frequency,
+                target=long_goal.target,
+                done=float(qualifying_done),
+                remaining=float(needed_long),
+                projected=float(projected_long),
+                status=FeasibilityStatus.on_track if ok else FeasibilityStatus.at_risk,
+                detail=None
+                if ok
+                else f"can place only {len(long_days)} of {needed_long} long runs",
+            )
+        )
+
+    if volume is not None:
+        # Capacity = what locked days contribute + the most the free days can hold
+        # at the ramp ceiling. ``check_feasibility`` is the gate; ``volume_at_risk``
+        # is the same verdict captured during distribution.
+        capacity = planned_locked + ceiling * len(free)
+        vol_status = check_feasibility(volume.target - done_volume, capacity)
+        if volume_at_risk:
+            vol_status = FeasibilityStatus.at_risk
+        statuses.append(
+            GoalPlanStatus(
+                metric_key=metric_key,
+                kind=GoalKind.volume,
+                target=volume.target,
+                done=round(done_volume, 3),
+                remaining=round(volume.target - done_volume, 3),
+                projected=round(projected_total, 3),
+                status=vol_status,
+                detail=None
+                if vol_status is FeasibilityStatus.on_track
+                else f"projected {projected_total:.1f}km of {volume.target:.1f}km target",
+            )
+        )
+
+    return days_out, statuses
+
+
+def _place_long_runs(eligible: list[date], needed: int) -> set[date]:
+    """Greedily place ``needed`` long runs: weekends first, spaced >= MIN_LONG_SPACING_DAYS."""
+    if needed <= 0 or not eligible:
+        return set()
+    ordered = sorted(eligible, key=lambda d: (not _is_weekend(d), d))
+    chosen: list[date] = []
+    for day in ordered:
+        if all(abs((day - c).days) >= MIN_LONG_SPACING_DAYS for c in chosen):
+            chosen.append(day)
+        if len(chosen) >= needed:
+            break
+    # If spacing was too tight to place enough, relax and fill from remaining days.
+    if len(chosen) < needed:
+        for day in sorted(eligible):
+            if day not in chosen:
+                chosen.append(day)
+            if len(chosen) >= needed:
+                break
+    return set(chosen[:needed])
+
+
+# --------------------------------------------------------------------------- #
+# Non-running: simple distributor (no ramp, no long/rest cadence)
+# --------------------------------------------------------------------------- #
+def _plan_simple(
+    metric_key: str,
+    goals: Sequence[PlanningGoal],
+    entries: Sequence[ActualEntry],
+    today: date,
+    period_end: date,
+) -> tuple[list[PlanDay], list[GoalPlanStatus]]:
+    totals = _daily_totals(entries, metric_key)
+    horizon = _daterange(today, period_end)
+    days_out: list[PlanDay] = []
+    statuses: list[GoalPlanStatus] = []
+
+    for goal in goals:
+        if goal.kind is not GoalKind.frequency:
+            # P0 only needs frequency for the non-running metrics (sessions, weigh-ins).
+            continue
+        threshold = goal.per_event_min if goal.per_event_min else _EPS
+        done_count = sum(1 for d, v in totals.items() if d < today and v >= threshold - _EPS)
+        needed = max(0, math.ceil(goal.target) - done_count)
+        chosen = _spread(horizon, needed)
+        value = goal.per_event_min if goal.per_event_min else 1.0
+        for day in chosen:
+            days_out.append(
+                PlanDay(
+                    metric_key=metric_key,
+                    plan_on=day,
+                    prescribed_value=value,
+                    kind=PlanDayKind.easy,
+                )
+            )
+        projected = done_count + len(chosen)
+        ok = projected >= goal.target
+        statuses.append(
+            GoalPlanStatus(
+                metric_key=metric_key,
+                kind=GoalKind.frequency,
+                target=goal.target,
+                done=float(done_count),
+                remaining=float(needed),
+                projected=float(projected),
+                status=FeasibilityStatus.on_track if ok else FeasibilityStatus.at_risk,
+                detail=None if ok else f"only {len(horizon)} days left for {needed} more sessions",
+            )
+        )
+
+    return days_out, statuses

--- a/supabase/migrations/20260615120000_create_planning.sql
+++ b/supabase/migrations/20260615120000_create_planning.sql
@@ -1,0 +1,150 @@
+-- =====================================================
+-- Adaptive Monthly Planning — constraints + prescriptions + readiness (SB-163)
+-- =====================================================
+-- Turns monthly metric_goals into a day-by-day plan that adapts to reality.
+-- Three additive tables; metric_types / metric_entries / metric_goals are
+-- untouched. The plan is a DERIVED CACHE — always recomputable from
+-- metric_goals + metric_entries + plan_constraints + readiness_log. See the
+-- engine in src/shared/planning/.
+--
+--   plan_constraints  known-in-advance limits (travel cap, injury window)
+--   plan_days         generated prescriptions, keyed by (metric, day)
+--   readiness_log     daily "how I feel" signal
+--
+-- A prescription is per (metric_key, plan_on), NOT per goal: one run satisfies
+-- every running goal at once (streak floor + long runs + volume), so the engine
+-- collapses them into a single daily prescription via precedence.
+--
+-- RLS: all three are STRICT (user_id = auth.uid()), NO anon escape — planning
+-- data is personal (matches metric_entries / metric_goals).
+-- =====================================================
+
+-- ===== Enums =====
+CREATE TYPE plan_day_kind AS ENUM ('long', 'easy', 'rest', 'fixed');
+CREATE TYPE readiness_status AS ENUM ('good', 'tired', 'sick');
+
+-- =====================================================
+-- plan_constraints — known-in-advance limits on a metric over a date range
+-- =====================================================
+CREATE TABLE plan_constraints (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    user_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    metric_key TEXT NOT NULL REFERENCES metric_types(key),
+
+    start_on DATE NOT NULL,
+    end_on DATE NOT NULL,
+    cap NUMERIC(12, 3),                          -- max prescribable value/day (canonical units)
+    floor NUMERIC(12, 3),                        -- min still required/day
+    reason TEXT CHECK (reason IS NULL OR LENGTH(reason) <= 200),
+
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+
+    CONSTRAINT plan_constraints_range CHECK (end_on >= start_on),
+    CONSTRAINT plan_constraints_floor_le_cap
+        CHECK (cap IS NULL OR floor IS NULL OR floor <= cap)
+);
+
+CREATE INDEX idx_plan_constraints_user_metric_range
+    ON plan_constraints (user_id, metric_key, start_on, end_on);
+
+COMMENT ON TABLE plan_constraints IS 'Known-in-advance limits (travel cap, injury window) the planner pins; canonical units (km for distance)';
+COMMENT ON COLUMN plan_constraints.cap IS 'Max prescribable value/day; with floor=cap the day is pinned (e.g. Chicago = 1 mi)';
+
+-- =====================================================
+-- plan_days — generated prescriptions (the derived cache)
+-- =====================================================
+-- One row per (user, metric, day). Rebuilt every recompute (delete-future +
+-- reinsert); past rows are preserved as the record of what was asked.
+CREATE TABLE plan_days (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    user_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    metric_key TEXT NOT NULL REFERENCES metric_types(key),
+
+    plan_on DATE NOT NULL,
+    prescribed_value NUMERIC(12, 3) NOT NULL CHECK (prescribed_value >= 0),
+    kind plan_day_kind NOT NULL,
+    generated_at TIMESTAMPTZ DEFAULT NOW(),      -- which recompute produced this row
+
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+
+    -- One prescription per metric per day; a recompute upserts on this key.
+    CONSTRAINT plan_days_unique UNIQUE (user_id, metric_key, plan_on)
+);
+
+CREATE INDEX idx_plan_days_user_metric_date
+    ON plan_days (user_id, metric_key, plan_on);
+
+COMMENT ON TABLE plan_days IS 'Generated daily prescriptions; a derived cache, recomputed nightly from goals + entries + constraints + readiness';
+COMMENT ON COLUMN plan_days.kind IS 'long | easy | rest | fixed (constraint-locked)';
+
+-- =====================================================
+-- readiness_log — daily "how I feel" signal
+-- =====================================================
+CREATE TABLE readiness_log (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    user_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    log_on DATE NOT NULL,
+    status readiness_status NOT NULL DEFAULT 'good',
+    note TEXT CHECK (note IS NULL OR LENGTH(note) <= 400),
+
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+
+    -- One readiness signal per day; a new post updates it.
+    CONSTRAINT readiness_log_unique UNIQUE (user_id, log_on)
+);
+
+CREATE INDEX idx_readiness_log_user_date ON readiness_log (user_id, log_on DESC);
+
+COMMENT ON TABLE readiness_log IS 'Daily how-I-feel signal; tired down-shifts the day, sick rests it (streak floor preserved)';
+
+-- =====================================================
+-- Triggers — maintain updated_at (function from initial_schema)
+-- =====================================================
+CREATE TRIGGER update_plan_constraints_updated_at BEFORE UPDATE ON plan_constraints
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_plan_days_updated_at BEFORE UPDATE ON plan_days
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_readiness_log_updated_at BEFORE UPDATE ON readiness_log
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- =====================================================
+-- Row Level Security — STRICT per-user, no anon escape
+-- =====================================================
+ALTER TABLE plan_constraints ENABLE ROW LEVEL SECURITY;
+ALTER TABLE plan_days ENABLE ROW LEVEL SECURITY;
+ALTER TABLE readiness_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users select their own plan_constraints"
+    ON plan_constraints FOR SELECT USING (user_id = auth.uid());
+CREATE POLICY "Users insert their own plan_constraints"
+    ON plan_constraints FOR INSERT WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Users update their own plan_constraints"
+    ON plan_constraints FOR UPDATE USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Users delete their own plan_constraints"
+    ON plan_constraints FOR DELETE USING (user_id = auth.uid());
+
+CREATE POLICY "Users select their own plan_days"
+    ON plan_days FOR SELECT USING (user_id = auth.uid());
+CREATE POLICY "Users insert their own plan_days"
+    ON plan_days FOR INSERT WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Users update their own plan_days"
+    ON plan_days FOR UPDATE USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Users delete their own plan_days"
+    ON plan_days FOR DELETE USING (user_id = auth.uid());
+
+CREATE POLICY "Users select their own readiness_log"
+    ON readiness_log FOR SELECT USING (user_id = auth.uid());
+CREATE POLICY "Users insert their own readiness_log"
+    ON readiness_log FOR INSERT WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Users update their own readiness_log"
+    ON readiness_log FOR UPDATE USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Users delete their own readiness_log"
+    ON readiness_log FOR DELETE USING (user_id = auth.uid());

--- a/tests/test_planning_engine.py
+++ b/tests/test_planning_engine.py
@@ -1,0 +1,255 @@
+"""Golden tests for the adaptive planning engine (SB-163).
+
+The owner's real July scenario is the fixture:
+  - run every day (streak, >= 1 mi/day)
+  - 135 miles total (volume)
+  - 4 runs > 5 mi (frequency, qualifier 5 mi)
+  - push-ups >= 60, 10 times (frequency)
+  - weigh in 10 times (frequency)
+  - **Chicago Jul 12-16: run every day but capped at 1 mi**
+
+Distances are canonical km; the scenario is authored in miles and converted.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from src.shared.models.metric import GoalKind
+from src.shared.models.planning import (
+    ActualEntry,
+    FeasibilityStatus,
+    PlanConstraint,
+    PlanDayKind,
+    PlanningGoal,
+    Readiness,
+    ReadinessStatus,
+)
+from src.shared.models.units import miles_to_km
+from src.shared.planning import RUNNING_KEY, generate_plan
+
+JUL_START = date(2026, 7, 1)
+JUL_END = date(2026, 7, 31)
+PUSHUPS = "pushups"
+BODY_WEIGHT = "body_weight"  # stand-in metric for weigh-in frequency
+
+MILE = miles_to_km(1.0)
+FIVE_MI = miles_to_km(5.0)
+TOTAL_MI = miles_to_km(135.0)
+
+
+def _july_goals() -> list[PlanningGoal]:
+    return [
+        PlanningGoal(
+            metric_key=RUNNING_KEY,
+            kind=GoalKind.streak,
+            target=31,
+            period_start=JUL_START,
+            period_end=JUL_END,
+            qualifier_threshold=MILE,
+        ),
+        PlanningGoal(
+            metric_key=RUNNING_KEY,
+            kind=GoalKind.volume,
+            target=TOTAL_MI,
+            period_start=JUL_START,
+            period_end=JUL_END,
+        ),
+        PlanningGoal(
+            metric_key=RUNNING_KEY,
+            kind=GoalKind.frequency,
+            target=4,
+            period_start=JUL_START,
+            period_end=JUL_END,
+            qualifier_threshold=FIVE_MI,
+        ),
+        PlanningGoal(
+            metric_key=PUSHUPS,
+            kind=GoalKind.frequency,
+            target=10,
+            period_start=JUL_START,
+            period_end=JUL_END,
+            per_event_min=60,
+        ),
+        PlanningGoal(
+            metric_key=BODY_WEIGHT,
+            kind=GoalKind.frequency,
+            target=10,
+            period_start=JUL_START,
+            period_end=JUL_END,
+        ),
+    ]
+
+
+def _chicago() -> PlanConstraint:
+    return PlanConstraint(
+        metric_key=RUNNING_KEY,
+        start_on=date(2026, 7, 12),
+        end_on=date(2026, 7, 16),
+        cap=MILE,
+        floor=MILE,
+        reason="Chicago travel",
+    )
+
+
+def _plan_fresh(**kwargs):
+    """A start-of-month plan (today=Jul 1, no actuals yet)."""
+    defaults = {
+        "period_start": JUL_START,
+        "period_end": JUL_END,
+        "today": JUL_START,
+        "goals": _july_goals(),
+        "entries": [],
+        "constraints": [_chicago()],
+    }
+    defaults.update(kwargs)
+    return generate_plan(**defaults)
+
+
+# --------------------------------------------------------------------------- #
+# Constraints: Chicago days are pinned at 1 mi and locked
+# --------------------------------------------------------------------------- #
+def test_chicago_days_pinned_at_one_mile():
+    result = _plan_fresh()
+    run_days = {d.plan_on: d for d in result.days_for(RUNNING_KEY)}
+
+    for day in (
+        date(2026, 7, 12),
+        date(2026, 7, 13),
+        date(2026, 7, 14),
+        date(2026, 7, 15),
+        date(2026, 7, 16),
+    ):
+        d = run_days[day]
+        assert d.kind is PlanDayKind.fixed
+        assert d.prescribed_value == pytest.approx(MILE, abs=1e-3)
+
+
+def test_streak_floor_every_single_day():
+    result = _plan_fresh()
+    run_days = result.days_for(RUNNING_KEY)
+    # Every day of July has a running prescription >= the 1-mile floor.
+    assert len(run_days) == 31
+    assert all(d.prescribed_value >= MILE - 1e-3 for d in run_days)
+
+
+# --------------------------------------------------------------------------- #
+# Volume: the 5-mile Chicago shortfall is absorbed into the other 26 days
+# --------------------------------------------------------------------------- #
+def test_volume_target_met_and_shortfall_absorbed():
+    result = _plan_fresh()
+    run_days = result.days_for(RUNNING_KEY)
+    planned_total = sum(d.prescribed_value for d in run_days)
+
+    # The whole 135-mi target is planned across the month...
+    assert planned_total == pytest.approx(TOTAL_MI, abs=0.5)
+
+    # ...and the non-Chicago days carry the load: Chicago contributes only 5 mi,
+    # so the other 26 days must cover 130.
+    chicago = {date(2026, 7, d) for d in range(12, 17)}
+    free_total = sum(d.prescribed_value for d in run_days if d.plan_on not in chicago)
+    assert free_total == pytest.approx(TOTAL_MI - 5 * MILE, abs=0.5)
+
+    vol = next(g for g in result.goals if g.kind is GoalKind.volume)
+    assert vol.status is FeasibilityStatus.on_track
+
+
+# --------------------------------------------------------------------------- #
+# Long runs: 4 placed, none on a capped Chicago day, spaced apart
+# --------------------------------------------------------------------------- #
+def test_four_long_runs_placed_off_capped_days():
+    result = _plan_fresh()
+    long_days = [d for d in result.days_for(RUNNING_KEY) if d.kind is PlanDayKind.long]
+    assert len(long_days) == 4
+
+    chicago = {date(2026, 7, d) for d in range(12, 17)}
+    for d in long_days:
+        assert d.plan_on not in chicago
+        assert d.prescribed_value >= FIVE_MI - 1e-3
+
+    # Spaced >= 2 days apart.
+    dates = sorted(d.plan_on for d in long_days)
+    assert all((b - a).days >= 2 for a, b in zip(dates, dates[1:], strict=False))
+
+    freq = next(
+        g for g in result.goals if g.kind is GoalKind.frequency and g.metric_key == RUNNING_KEY
+    )
+    assert freq.status is FeasibilityStatus.on_track
+
+
+# --------------------------------------------------------------------------- #
+# Non-running metrics: simple distributor places the right number of sessions
+# --------------------------------------------------------------------------- #
+def test_pushups_and_weighins_scheduled():
+    result = _plan_fresh()
+
+    pushups = result.days_for(PUSHUPS)
+    assert len(pushups) == 10
+    assert all(d.prescribed_value == 60 for d in pushups)
+
+    weighins = result.days_for(BODY_WEIGHT)
+    assert len(weighins) == 10
+    assert all(d.prescribed_value == 1 for d in weighins)
+
+    assert result.status is FeasibilityStatus.on_track
+
+
+# --------------------------------------------------------------------------- #
+# Feasibility gate: flips AT_RISK when the goal can't be reached
+# --------------------------------------------------------------------------- #
+def test_gate_flags_at_risk_when_behind_and_infeasible():
+    # Jul 28: only 80 mi done, 55 mi left over 4 days — impossible under the ramp
+    # ceiling (~10 mi/day → ~40 mi capacity).
+    done = [
+        ActualEntry(
+            metric_key=RUNNING_KEY, occurred_on=date(2026, 7, d), value=miles_to_km(80 / 27)
+        )
+        for d in range(1, 28)
+    ]
+    result = generate_plan(
+        period_start=JUL_START,
+        period_end=JUL_END,
+        today=date(2026, 7, 28),
+        goals=_july_goals(),
+        entries=done,
+        constraints=[],
+    )
+    vol = next(g for g in result.goals if g.kind is GoalKind.volume)
+    assert vol.status is FeasibilityStatus.at_risk
+    assert result.status is FeasibilityStatus.at_risk
+    assert result.at_risk_reasons
+
+
+def test_on_track_when_ahead_of_pace():
+    # Halfway through with more than half the miles banked → never at risk.
+    done = [
+        ActualEntry(metric_key=RUNNING_KEY, occurred_on=date(2026, 7, d), value=miles_to_km(5.0))
+        for d in range(1, 16)
+    ]
+    result = generate_plan(
+        period_start=JUL_START,
+        period_end=JUL_END,
+        today=date(2026, 7, 16),
+        goals=[_july_goals()[1]],  # volume only
+        entries=done,
+        constraints=[],
+    )
+    vol = next(g for g in result.goals if g.kind is GoalKind.volume)
+    assert vol.status is FeasibilityStatus.on_track
+
+
+# --------------------------------------------------------------------------- #
+# Readiness: a sick day becomes rest but keeps the streak floor
+# --------------------------------------------------------------------------- #
+def test_sick_day_is_rest_but_keeps_streak_floor():
+    sick_day = date(2026, 7, 3)
+    result = _plan_fresh(readiness=[Readiness(log_on=sick_day, status=ReadinessStatus.sick)])
+    day = next(d for d in result.days_for(RUNNING_KEY) if d.plan_on == sick_day)
+    assert day.kind is PlanDayKind.rest
+    assert day.prescribed_value == pytest.approx(MILE, abs=1e-3)
+    # The streak survives, and the displaced mileage is still planned elsewhere.
+    assert result.status is FeasibilityStatus.on_track
+    planned_total = sum(d.prescribed_value for d in result.days_for(RUNNING_KEY))
+    assert planned_total == pytest.approx(TOTAL_MI, abs=0.5)

--- a/uv.lock
+++ b/uv.lock
@@ -1590,7 +1590,7 @@ wheels = [
 [[package]]
 name = "myrunstreak"
 version = "0.1.0"
-source = { editable = "." }
+source = { virtual = "." }
 dependencies = [
     { name = "authlib" },
     { name = "aws-lambda-powertools" },


### PR DESCRIPTION
## Summary
Phase 0 of Adaptive Monthly Planning ([SB-162](https://linear.app/silverbeer/issue/SB-162)) — the deterministic engine that turns monthly goals into a day-by-day plan and verifies feasibility. Pure functions, **no I/O, no LLM**; every number originates here so the result is reproducible and the LLM coaching layer (P2) only narrates it.

- **Engine** (`src/shared/planning/engine.py`) — `generate_plan` / `recompute` / `check_feasibility`. Training-aware two-pass planner for running (lock constraints → place long runs under a +10%/wk ramp ceiling → distribute volume) + a simple distributor for push-ups / weigh-ins.
- **Per-(metric, day) prescriptions** — one run satisfies every running goal, so the engine collapses them by precedence: constraint `fixed` > streak floor > long-run threshold > volume fill. `plan_days` keys on `(metric, day)`, not goal.
- **Models** (`src/shared/models/planning.py`) — planning reuses `metric_goals` as the target model; adds only constraints + prescriptions + readiness.
- **Migration** — `plan_constraints`, `plan_days`, `readiness_log` (additive, strict per-user RLS, km canonical). The plan is a **derived cache**, recomputable from goals + entries + constraints + readiness.
- **Build fix** — root project is now `package = false` (matches `backend/pyproject.toml`); `uv run pytest` works again after uv 0.11 broke the editable build. No CI impact — CI tests run the separate `backend` project.

## Test plan
- [x] `uv run pytest tests/test_planning_engine.py` — 8 golden-scenario cases pass
- [x] `uv run pytest tests/` — full root suite (39) passes, no regressions
- [x] `ruff check` + `mypy --strict` clean on new files
- [ ] Reviewer: confirm the July golden fixture matches the real goals (135 mi, run every day, 4 runs >5 mi, push-ups ≥60 ×10, weigh-in ×10, Chicago Jul 12–16 capped 1 mi)
- [ ] Reviewer: sanity-check the migration RLS (strict, no anon escape) before it reaches a Supabase env

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes SB-163