### PR TITLE
feat: planning API, persistence + stk commands (SB-164)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3,7 +3,7 @@
 import logging
 
 from backend.config import get_settings
-from backend.routes import auth_routes, metrics, runs, stats, sync
+from backend.routes import auth_routes, metrics, plan, runs, stats, sync
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -44,6 +44,7 @@ def create_app() -> FastAPI:
     app.include_router(sync.router)
     app.include_router(auth_routes.router)
     app.include_router(metrics.router)
+    app.include_router(plan.router)
 
     return app
 

--- a/backend/jobs/recompute_plans.py
+++ b/backend/jobs/recompute_plans.py
@@ -1,0 +1,74 @@
+"""K8s CronJob entry point: nightly recompute of every active user's plan.
+
+Re-aggregates each user's actuals and re-runs the planning engine for the
+current month (and the next month once it's within reach), persisting fresh
+``plan_days`` so the morning plan reflects yesterday's runs and any drift. The
+plan is a derived cache; this job just advances ``today`` and rebuilds.
+
+Mirrors the publish_status job's shape. Single-user today (one active SmashRun
+source); the loop is ready for more.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from datetime import datetime
+from uuid import UUID
+from zoneinfo import ZoneInfo
+
+from backend.planning import build_and_store_plan, period_for
+from src.shared.supabase_client import get_supabase_client
+from src.shared.supabase_ops import UsersRepository
+
+USER_TIMEZONE = ZoneInfo("America/New_York")
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_user_ids(users_repo: UsersRepository) -> list[UUID]:
+    """Active users whose plans to recompute. One SmashRun source today."""
+    sources = users_repo.get_all_active_sources(source_type="smashrun")
+    seen: dict[str, UUID] = {}
+    for src in sources:
+        seen.setdefault(src["user_id"], UUID(src["user_id"]))
+    return list(seen.values())
+
+
+def main() -> int:
+    log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+    logging.basicConfig(level=log_level)
+
+    supabase = get_supabase_client()
+    users_repo = UsersRepository(supabase)
+
+    today = datetime.now(USER_TIMEZONE).date()
+    period = period_for(today)
+
+    try:
+        user_ids = resolve_user_ids(users_repo)
+        if not user_ids:
+            logger.warning("No active users found; nothing to recompute")
+            return 0
+
+        failures = 0
+        for user_id in user_ids:
+            try:
+                result = build_and_store_plan(supabase, user_id, period, today)
+                logger.info(
+                    f"Recomputed plan for user {user_id} {period}: "
+                    f"{len(result.days)} prescriptions, status={result.status.value}"
+                )
+            except Exception as exc:  # noqa: BLE001 — one user must not sink the batch
+                failures += 1
+                logger.error(f"Recompute failed for user {user_id}: {exc}", exc_info=True)
+
+        return 1 if failures else 0
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"recompute_plans failed: {exc}", exc_info=True)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/planning.py
+++ b/backend/planning.py
@@ -1,0 +1,170 @@
+"""Plan assembly service (SB-164).
+
+Glue between Supabase and the pure planning engine (``src/shared/planning/``):
+gather a user's goals + actuals + constraints + readiness for a month, map them
+into engine inputs, run the engine, and persist the resulting prescriptions.
+
+The engine owns all the math; this module only does I/O + mapping. The plan is a
+derived cache — ``build_plan`` recomputes it from scratch every call.
+"""
+
+from __future__ import annotations
+
+import calendar
+import re
+from datetime import date, timedelta
+from typing import Any
+from uuid import UUID
+
+from src.shared.models.metric import GoalKind
+from src.shared.models.planning import (
+    ActualEntry,
+    PlanConstraint,
+    PlanningGoal,
+    PlanResult,
+    Readiness,
+    ReadinessStatus,
+)
+from src.shared.planning import generate_plan
+from src.shared.supabase_ops import (
+    MetricEntriesRepository,
+    MetricGoalsRepository,
+    PlanConstraintsRepository,
+    PlanDaysRepository,
+    ReadinessRepository,
+)
+from supabase import Client
+
+# Trailing history the ramp ceiling needs, beyond the period itself.
+_TRAILING_DAYS = 28
+_PERIOD_RE = re.compile(r"^(\d{4})-(\d{2})$")
+
+
+def period_bounds(period: str) -> tuple[date, date]:
+    """Parse a ``YYYY-MM`` period into inclusive (first_day, last_day)."""
+    m = _PERIOD_RE.match(period)
+    if not m:
+        raise ValueError(f"period must be 'YYYY-MM', got '{period}'")
+    year, month = int(m.group(1)), int(m.group(2))
+    if not 1 <= month <= 12:
+        raise ValueError(f"month out of range in period '{period}'")
+    last = calendar.monthrange(year, month)[1]
+    return date(year, month, 1), date(year, month, last)
+
+
+def period_for(day: date) -> str:
+    """The ``YYYY-MM`` period a date falls in."""
+    return f"{day.year:04d}-{day.month:02d}"
+
+
+def to_planning_goal(row: dict[str, Any], period_start: date, period_end: date) -> PlanningGoal:
+    """Map a stored ``metric_goals`` row onto the engine's monthly target."""
+    return PlanningGoal(
+        metric_key=row["metric_key"],
+        kind=GoalKind(row["kind"]),
+        target=float(row["target"]),
+        period_start=period_start,
+        period_end=period_end,
+        qualifier_threshold=(
+            float(row["qualifier_threshold"])
+            if row.get("qualifier_threshold") is not None
+            else None
+        ),
+        per_event_min=(
+            float(row["per_event_min"]) if row.get("per_event_min") is not None else None
+        ),
+        rest_budget=int(row.get("rest_budget") or 0),
+    )
+
+
+def _is_plan_goal(row: dict[str, Any]) -> bool:
+    """Monthly-planning goals only — yearly goals (e.g. the SmashRun mirror's
+    cadence) are not a month's daily plan."""
+    return row.get("period") != "year"
+
+
+def build_plan(
+    supabase: Client,
+    user_id: UUID,
+    period: str,
+    today: date,
+) -> PlanResult:
+    """Recompute a user's plan for ``period`` from current reality (no persistence)."""
+    period_start, period_end = period_bounds(period)
+    # Where the plan starts prescribing: today, clamped into the period. A future
+    # month plans from its first day; a current month plans from today.
+    plan_today = min(max(today, period_start), period_end)
+
+    goal_rows = MetricGoalsRepository(supabase).list(user_id, status="active")
+    goals = [to_planning_goal(r, period_start, period_end) for r in goal_rows if _is_plan_goal(r)]
+
+    history_from = period_start - timedelta(days=_TRAILING_DAYS)
+    entry_rows = MetricEntriesRepository(supabase).list(
+        user_id, date_from=history_from, date_to=period_end, limit=2000
+    )
+    entries = [
+        ActualEntry(
+            metric_key=r["metric_key"],
+            occurred_on=date.fromisoformat(r["occurred_on"]),
+            value=float(r["value"]),
+        )
+        for r in entry_rows
+    ]
+
+    constraint_rows = PlanConstraintsRepository(supabase).list(
+        user_id, date_from=period_start, date_to=period_end
+    )
+    constraints = [
+        PlanConstraint(
+            metric_key=r["metric_key"],
+            start_on=date.fromisoformat(r["start_on"]),
+            end_on=date.fromisoformat(r["end_on"]),
+            cap=float(r["cap"]) if r.get("cap") is not None else None,
+            floor=float(r["floor"]) if r.get("floor") is not None else None,
+            reason=r.get("reason"),
+        )
+        for r in constraint_rows
+    ]
+
+    readiness_rows = ReadinessRepository(supabase).list(
+        user_id, date_from=period_start, date_to=period_end
+    )
+    readiness = [
+        Readiness(
+            log_on=date.fromisoformat(r["log_on"]),
+            status=ReadinessStatus(r["status"]),
+            note=r.get("note"),
+        )
+        for r in readiness_rows
+    ]
+
+    return generate_plan(
+        period_start=period_start,
+        period_end=period_end,
+        today=plan_today,
+        goals=goals,
+        entries=entries,
+        constraints=constraints,
+        readiness=readiness,
+    )
+
+
+def build_and_store_plan(
+    supabase: Client,
+    user_id: UUID,
+    period: str,
+    today: date,
+) -> PlanResult:
+    """Recompute and persist the plan: delete-future + reinsert ``plan_days``."""
+    result = build_plan(supabase, user_id, period, today)
+    rows = [
+        {
+            "metric_key": d.metric_key,
+            "plan_on": d.plan_on.isoformat(),
+            "prescribed_value": d.prescribed_value,
+            "kind": d.kind.value,
+        }
+        for d in result.days
+    ]
+    PlanDaysRepository(supabase).replace_from(user_id, result.generated_for, rows)
+    return result

--- a/backend/routes/plan.py
+++ b/backend/routes/plan.py
@@ -1,0 +1,130 @@
+"""/plan/* — adaptive monthly planning: constraints, readiness, the plan itself.
+
+All endpoints are JWT-gated. The backend uses the service-role Supabase key, so
+the repositories scope every query by ``user_id`` themselves.
+
+The plan is a derived cache: ``GET /plan/{period}`` recomputes from current
+reality every call; ``POST .../recompute`` and ``POST /plan/readiness`` also
+persist the prescriptions. See backend/planning.py + src/shared/planning/.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from uuid import UUID
+from zoneinfo import ZoneInfo
+
+from backend.auth import authenticate_request
+from backend.cache import invalidate_user
+from backend.planning import build_and_store_plan, build_plan, period_for
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from src.shared.models.planning import (
+    PlanConstraint,
+    PlanConstraintRecord,
+    PlanResult,
+    Readiness,
+)
+from src.shared.supabase_client import get_supabase_client
+from src.shared.supabase_ops import (
+    MetricTypesRepository,
+    PlanConstraintsRepository,
+    ReadinessRepository,
+)
+
+router = APIRouter(prefix="/plan", tags=["plan"])
+
+
+def _today_local() -> date:
+    """America/New_York anchor, consistent with /metrics and /stats."""
+    return datetime.now(ZoneInfo("America/New_York")).date()
+
+
+# ---------------------------------------------------------------- constraints
+
+
+@router.post(
+    "/constraints",
+    response_model=PlanConstraintRecord,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_constraint(
+    body: PlanConstraint,
+    user_id: UUID = Depends(authenticate_request),
+) -> PlanConstraintRecord:
+    supabase = get_supabase_client()
+    if MetricTypesRepository(supabase).get(body.metric_key) is None:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, f"Unknown metric_key '{body.metric_key}'")
+
+    payload = body.model_dump(exclude_none=True, mode="json")
+    row = PlanConstraintsRepository(supabase).create(user_id, payload)
+    await invalidate_user(user_id)
+    return PlanConstraintRecord(**row)
+
+
+@router.get("/constraints", response_model=list[PlanConstraintRecord])
+def list_constraints(
+    user_id: UUID = Depends(authenticate_request),
+    date_from: date | None = Query(default=None),
+    date_to: date | None = Query(default=None),
+) -> list[PlanConstraintRecord]:
+    rows = PlanConstraintsRepository(get_supabase_client()).list(
+        user_id, date_from=date_from, date_to=date_to
+    )
+    return [PlanConstraintRecord(**r) for r in rows]
+
+
+@router.delete("/constraints/{constraint_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_constraint(
+    constraint_id: UUID,
+    user_id: UUID = Depends(authenticate_request),
+) -> None:
+    deleted = PlanConstraintsRepository(get_supabase_client()).delete(user_id, constraint_id)
+    if not deleted:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Constraint not found")
+    await invalidate_user(user_id)
+
+
+# ---------------------------------------------------------------- readiness
+
+
+@router.post("/readiness", response_model=PlanResult)
+async def set_readiness(
+    body: Readiness,
+    user_id: UUID = Depends(authenticate_request),
+) -> PlanResult:
+    """Record how the user feels and immediately recompute that day's month plan."""
+    supabase = get_supabase_client()
+    payload = body.model_dump(exclude_none=True, mode="json")
+    ReadinessRepository(supabase).upsert(user_id, payload)
+    await invalidate_user(user_id)
+    return build_and_store_plan(supabase, user_id, period_for(body.log_on), _today_local())
+
+
+# ---------------------------------------------------------------- the plan
+
+
+@router.get("/{period}", response_model=PlanResult)
+def get_plan(
+    period: str,
+    user_id: UUID = Depends(authenticate_request),
+) -> PlanResult:
+    """Recompute and return the plan for a ``YYYY-MM`` period (no persistence)."""
+    try:
+        return build_plan(get_supabase_client(), user_id, period, _today_local())
+    except ValueError as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, str(exc)) from exc
+
+
+@router.post("/{period}/recompute", response_model=PlanResult)
+async def recompute_plan(
+    period: str,
+    user_id: UUID = Depends(authenticate_request),
+) -> PlanResult:
+    """Recompute and persist the plan for a ``YYYY-MM`` period."""
+    supabase = get_supabase_client()
+    try:
+        result = build_and_store_plan(supabase, user_id, period, _today_local())
+    except ValueError as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, str(exc)) from exc
+    await invalidate_user(user_id)
+    return result

--- a/helm/myrunstreak/templates/cronjob-recompute-plans.yaml
+++ b/helm/myrunstreak/templates/cronjob-recompute-plans.yaml
@@ -1,0 +1,55 @@
+{{- if and .Values.backend.enabled .Values.backend.cronjobs.recomputePlans.enabled }}
+# Nightly recompute of every active user's adaptive monthly plan (SB-164).
+# Re-aggregates actuals and re-runs the planning engine, persisting fresh
+# plan_days so the morning plan reflects yesterday's runs and any drift.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "myrunstreak.fullname" . }}-recompute-plans
+  labels:
+    {{- include "myrunstreak.labels" . | nindent 4 }}
+    app.kubernetes.io/component: recompute-plans-cron
+spec:
+  schedule: {{ .Values.backend.cronjobs.recomputePlans.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 300
+      template:
+        metadata:
+          labels:
+            {{- include "myrunstreak.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: recompute-plans-cron
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: recompute-plans
+              image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
+              imagePullPolicy: {{ .Values.backend.image.pullPolicy | default "IfNotPresent" }}
+              command: ["python", "-m", "backend.jobs.recompute_plans"]
+              env:
+                - name: ENVIRONMENT
+                  value: {{ .Values.backend.env.environment | default "dev" | quote }}
+                - name: LOG_LEVEL
+                  value: {{ .Values.backend.env.logLevel | default "INFO" | quote }}
+                - name: SUPABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                      key: supabase-url
+                - name: SUPABASE_SERVICE_ROLE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                      key: supabase-service-key
+                - name: SUPABASE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.externalSecret.targetName | default "myrunstreak-secrets" }}
+                      key: supabase-service-key
+              resources:
+                {{- toYaml (.Values.backend.cronjobs.recomputePlans.resources | default dict) | nindent 16 }}
+{{- end }}

--- a/helm/myrunstreak/values.yaml
+++ b/helm/myrunstreak/values.yaml
@@ -112,6 +112,19 @@ backend:
         limits:
           cpu: 200m
           memory: 256Mi
+    recomputePlans:
+      enabled: true
+      # 08:00 UTC (~03:00-04:00 ET) — after the day rolls over and the morning
+      # SmashRun sync, so the day's plan reflects yesterday's runs. The plan is a
+      # derived cache; this rebuilds it (SB-164).
+      schedule: "0 8 * * *"
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi
 
 # ============================================================================
 # Redis (cache for backend stats endpoints) — disabled by default

--- a/src/cli/api.py
+++ b/src/cli/api.py
@@ -135,6 +135,32 @@ def request(endpoint: str, params: dict[str, Any] | None = None) -> dict[str, An
     return result
 
 
+def delete_request(endpoint: str, timeout: float | None = None) -> None:
+    """Authenticated DELETE. Same auto-refresh behavior; expects a 2xx/204."""
+    s = _ensure_fresh(_require_session())
+    url = f"{get_api_url()}/{endpoint.lstrip('/')}"
+    request_timeout = timeout if timeout else TIMEOUT
+    try:
+        response = httpx.delete(url, headers=_auth_headers(s), timeout=request_timeout)
+    except httpx.TimeoutException:
+        display_error(f"Request timed out after {request_timeout}s")
+        sys.exit(1)
+    except httpx.RequestError as e:
+        display_error(f"Request failed: {e}")
+        sys.exit(1)
+
+    if response.status_code == 401:
+        refreshed = _refresh_session(s)
+        if refreshed is None:
+            display_error("Session expired")
+            display_info("Run 'stk auth login' to sign in again")
+            sys.exit(1)
+        response = httpx.delete(url, headers=_auth_headers(refreshed), timeout=request_timeout)
+
+    if response.status_code >= 400:
+        _exit_with_error(response)
+
+
 def post_request(
     endpoint: str,
     data: dict[str, Any] | None = None,

--- a/src/cli/commands/plan.py
+++ b/src/cli/commands/plan.py
@@ -1,0 +1,165 @@
+"""Planning commands for stk CLI — plan / constraint / readiness.
+
+Deterministic, machine-readable wrappers over the /plan API. These are what the
+`plan` Claude skill (P2) drives: it calls these with --json, reads the engine's
+result, and narrates the coaching. No LLM here.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+import typer
+
+from cli import api, display
+
+# Canonical storage is km (matches the API). The CLI speaks miles, the runner's
+# unit. Kept local to avoid the CLI<->shared import-root ambiguity.
+_MILES_TO_KM = 1.609344
+
+plan_app = typer.Typer(help="View and recompute your adaptive monthly plan.")
+constraint_app = typer.Typer(help="Manage known-in-advance plan constraints (travel, injury).")
+readiness_app = typer.Typer(help="Log how you feel so the plan can adapt.")
+
+
+def _today() -> date:
+    return datetime.now(ZoneInfo("America/New_York")).date()
+
+
+def _current_period() -> str:
+    t = _today()
+    return f"{t.year:04d}-{t.month:02d}"
+
+
+def _parse_distance_km(value: str) -> float:
+    """Parse '1mi' / '5km' / '5k' / '8' (bare == miles) into canonical km."""
+    s = value.strip().lower()
+    try:
+        if s.endswith("mi"):
+            return float(s[:-2]) * _MILES_TO_KM
+        if s.endswith("km"):
+            return float(s[:-2])
+        if s.endswith("k"):
+            return float(s[:-1])
+        return float(s) * _MILES_TO_KM  # bare number = miles
+    except ValueError as exc:
+        raise typer.BadParameter(f"can't parse distance '{value}' (try '1mi' or '5km')") from exc
+
+
+def _parse_day(value: str) -> date:
+    """Parse 'today' or an ISO YYYY-MM-DD date."""
+    if value.strip().lower() == "today":
+        return _today()
+    try:
+        return date.fromisoformat(value.strip())
+    except ValueError as exc:
+        raise typer.BadParameter(f"can't parse date '{value}' (use YYYY-MM-DD or 'today')") from exc
+
+
+def _emit(data: dict, json_output: bool, render) -> None:
+    if json_output:
+        print(json.dumps(data, indent=2, default=str))
+    else:
+        render(data)
+
+
+def _render_plan(data: dict) -> None:
+    """A compact human summary; the rich month-grid is P3 (frontend)."""
+    status = data.get("status", "?")
+    icon = "✅" if status == "on_track" else "⚠️"
+    display.console.print(
+        f"[bold]Plan {data.get('period_start')} → {data.get('period_end')}[/bold]  {icon} {status}"
+    )
+    for g in data.get("goals", []):
+        gicon = "✅" if g.get("status") == "on_track" else "⚠️"
+        line = f"  {gicon} {g['metric_key']} ({g['kind']}): {g.get('done')}/{g.get('target')}"
+        if g.get("detail"):
+            line += f" — {g['detail']}"
+        display.console.print(line)
+    for reason in data.get("at_risk_reasons", []):
+        display.console.print(f"  [yellow]at risk:[/yellow] {reason}")
+
+
+# ----------------------------------------------------------------- plan show / recompute
+
+
+def plan_show(
+    period: str = typer.Option(None, "--period", "-p", help="YYYY-MM (default: this month)"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
+) -> None:
+    """Show your plan for a month (recomputed from current reality)."""
+    data = api.request(f"plan/{period or _current_period()}")
+    _emit(data, json_output, _render_plan)
+
+
+def plan_recompute(
+    period: str = typer.Option(None, "--period", "-p", help="YYYY-MM (default: this month)"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
+) -> None:
+    """Recompute and persist your plan for a month."""
+    data = api.post_request(f"plan/{period or _current_period()}/recompute")
+    _emit(data, json_output, _render_plan)
+
+
+# ----------------------------------------------------------------- constraint add
+
+
+def constraint_add(
+    metric: str = typer.Option("running_distance", "--metric", "-m", help="Metric key"),
+    date_from: str = typer.Option(..., "--from", help="Start date YYYY-MM-DD"),
+    date_to: str = typer.Option(..., "--to", help="End date YYYY-MM-DD"),
+    cap: str = typer.Option(None, "--cap", help="Max per day, e.g. '1mi' (distance metrics)"),
+    floor: str = typer.Option(None, "--floor", help="Min still required per day, e.g. '1mi'"),
+    reason: str = typer.Option(None, "--reason", help="Why, e.g. 'Chicago travel'"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
+) -> None:
+    """Add a known-in-advance limit (e.g. travel caps running to 1 mi/day)."""
+    body: dict = {
+        "metric_key": metric,
+        "start_on": _parse_day(date_from).isoformat(),
+        "end_on": _parse_day(date_to).isoformat(),
+    }
+    if cap is not None:
+        body["cap"] = _parse_distance_km(cap)
+    if floor is not None:
+        body["floor"] = _parse_distance_km(floor)
+    if reason is not None:
+        body["reason"] = reason
+
+    data = api.post_request("plan/constraints", body)
+    if json_output:
+        print(json.dumps(data, indent=2, default=str))
+    else:
+        display.console.print(
+            f"[green]Added constraint[/green] {data.get('id')}: {reason or metric}"
+        )
+
+
+# ----------------------------------------------------------------- readiness set
+
+
+def readiness_set(
+    status: str = typer.Option(..., "--status", "-s", help="good | tired | sick"),
+    day: str = typer.Option("today", "--date", "-d", help="YYYY-MM-DD or 'today'"),
+    note: str = typer.Option(None, "--note", "-n", help="Optional note"),
+    json_output: bool = typer.Option(
+        False, "--json", "-j", help="Output raw JSON (recomputed plan)"
+    ),
+) -> None:
+    """Log how you feel; the plan recomputes immediately and adapts."""
+    if status not in {"good", "tired", "sick"}:
+        raise typer.BadParameter("status must be good, tired, or sick")
+    body: dict = {"log_on": _parse_day(day).isoformat(), "status": status}
+    if note is not None:
+        body["note"] = note
+
+    data = api.post_request("plan/readiness", body)
+    _emit(data, json_output, _render_plan)
+
+
+plan_app.command(name="show")(plan_show)
+plan_app.command(name="recompute")(plan_recompute)
+constraint_app.command(name="add")(constraint_add)
+readiness_app.command(name="set")(readiness_set)

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -17,7 +17,7 @@ import typer
 from rich.console import Console
 
 from cli import __version__
-from cli.commands import auth, runs, stats, sync
+from cli.commands import auth, plan, runs, stats, sync
 
 # Create the main app
 app = typer.Typer(
@@ -29,6 +29,9 @@ app = typer.Typer(
 
 # Add command groups
 app.add_typer(auth.app, name="auth", help="Authentication commands")
+app.add_typer(plan.plan_app, name="plan", help="Adaptive monthly plan")
+app.add_typer(plan.constraint_app, name="constraint", help="Plan constraints (travel, injury)")
+app.add_typer(plan.readiness_app, name="readiness", help="Daily readiness check-in")
 
 # Console for output
 console = Console()

--- a/src/shared/models/__init__.py
+++ b/src/shared/models/__init__.py
@@ -30,6 +30,7 @@ from .planning import (
     FeasibilityStatus,
     GoalPlanStatus,
     PlanConstraint,
+    PlanConstraintRecord,
     PlanDay,
     PlanDayKind,
     PlanningGoal,
@@ -67,6 +68,7 @@ __all__ = [
     # Planning
     "ActualEntry",
     "PlanConstraint",
+    "PlanConstraintRecord",
     "PlanDay",
     "PlanDayKind",
     "PlanningGoal",

--- a/src/shared/models/metric.py
+++ b/src/shared/models/metric.py
@@ -98,6 +98,8 @@ class MetricGoalCreate(BaseModel):
     rest_budget: int = Field(default=0, ge=0)
     period_start: date | None = None
     period_end: date | None = None
+    qualifier_threshold: float | None = Field(default=None, ge=0)
+    per_event_min: float | None = Field(default=None, ge=0)
 
     @model_validator(mode="after")
     def _custom_needs_bounds(self) -> MetricGoalCreate:
@@ -118,6 +120,8 @@ class MetricGoalUpdate(BaseModel):
     status: GoalStatus | None = None
     period_start: date | None = None
     period_end: date | None = None
+    qualifier_threshold: float | None = Field(default=None, ge=0)
+    per_event_min: float | None = Field(default=None, ge=0)
 
 
 class MetricGoal(BaseModel):
@@ -134,6 +138,8 @@ class MetricGoal(BaseModel):
     comparator: GoalComparator = GoalComparator.gte
     rest_budget: int = 0
     status: GoalStatus = GoalStatus.active
+    qualifier_threshold: float | None = None
+    per_event_min: float | None = None
     created_at: datetime | None = None
 
 

--- a/src/shared/models/planning.py
+++ b/src/shared/models/planning.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from datetime import date
 from enum import StrEnum
+from uuid import UUID
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -84,6 +85,12 @@ class PlanConstraint(BaseModel):
     def pinned_value(self) -> float | None:
         """The value a covered day is locked to: cap if set, else floor."""
         return self.cap if self.cap is not None else self.floor
+
+
+class PlanConstraintRecord(PlanConstraint):
+    """A stored constraint, with its row id — the API read shape."""
+
+    id: UUID
 
 
 class Readiness(BaseModel):

--- a/src/shared/supabase_ops/__init__.py
+++ b/src/shared/supabase_ops/__init__.py
@@ -7,6 +7,11 @@ from .metrics_repository import (
     MetricGoalsRepository,
     MetricTypesRepository,
 )
+from .planning_repository import (
+    PlanConstraintsRepository,
+    PlanDaysRepository,
+    ReadinessRepository,
+)
 from .runs_repository import RunsRepository
 from .token_repository import TokenRepository
 from .users_repository import UsersRepository
@@ -16,6 +21,9 @@ __all__ = [
     "MetricEntriesRepository",
     "MetricGoalsRepository",
     "MetricTypesRepository",
+    "PlanConstraintsRepository",
+    "PlanDaysRepository",
+    "ReadinessRepository",
     "RunsRepository",
     "TokenRepository",
     "UsersRepository",

--- a/src/shared/supabase_ops/planning_repository.py
+++ b/src/shared/supabase_ops/planning_repository.py
@@ -1,0 +1,122 @@
+"""Repositories for the adaptive planning tables (SB-164).
+
+plan_constraints / plan_days / readiness_log. Like the metric repos, the backend
+connects with the service-role key (bypasses RLS), so every query scopes by
+``user_id`` itself — the DB policies are a second line of defence.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import date
+from typing import Any, cast
+from uuid import UUID
+
+from supabase import Client
+
+
+class PlanConstraintsRepository:
+    """Per-user known-in-advance limits (travel cap, injury window)."""
+
+    def __init__(self, supabase: Client):
+        self.supabase = supabase
+
+    def create(self, user_id: UUID, payload: dict[str, Any]) -> dict[str, Any]:
+        row = {**payload, "user_id": str(user_id)}
+        result = self.supabase.table("plan_constraints").insert(row).execute()
+        return cast(list[dict[str, Any]], result.data)[0]
+
+    def list(
+        self,
+        user_id: UUID,
+        date_from: date | None = None,
+        date_to: date | None = None,
+    ) -> list[dict[str, Any]]:
+        query = self.supabase.table("plan_constraints").select("*").eq("user_id", str(user_id))
+        # Overlap with [date_from, date_to]: starts on/before the window end and
+        # ends on/after the window start.
+        if date_to is not None:
+            query = query.lte("start_on", date_to.isoformat())
+        if date_from is not None:
+            query = query.gte("end_on", date_from.isoformat())
+        result = query.order("start_on").execute()
+        return cast(list[dict[str, Any]], result.data)
+
+    def delete(self, user_id: UUID, constraint_id: UUID) -> bool:
+        result = (
+            self.supabase.table("plan_constraints")
+            .delete()
+            .eq("id", str(constraint_id))
+            .eq("user_id", str(user_id))
+            .execute()
+        )
+        return bool(cast(list[dict[str, Any]], result.data))
+
+
+class ReadinessRepository:
+    """Per-user daily how-I-feel signal (one row per day; upserted)."""
+
+    def __init__(self, supabase: Client):
+        self.supabase = supabase
+
+    def upsert(self, user_id: UUID, payload: dict[str, Any]) -> dict[str, Any]:
+        row = {**payload, "user_id": str(user_id)}
+        result = (
+            self.supabase.table("readiness_log").upsert(row, on_conflict="user_id,log_on").execute()
+        )
+        return cast(list[dict[str, Any]], result.data)[0]
+
+    def list(
+        self,
+        user_id: UUID,
+        date_from: date | None = None,
+        date_to: date | None = None,
+    ) -> list[dict[str, Any]]:
+        query = self.supabase.table("readiness_log").select("*").eq("user_id", str(user_id))
+        if date_from is not None:
+            query = query.gte("log_on", date_from.isoformat())
+        if date_to is not None:
+            query = query.lte("log_on", date_to.isoformat())
+        result = query.order("log_on").execute()
+        return cast(list[dict[str, Any]], result.data)
+
+
+class PlanDaysRepository:
+    """Per-user generated prescriptions (the derived cache)."""
+
+    def __init__(self, supabase: Client):
+        self.supabase = supabase
+
+    # Defined before ``list`` so its ``list[...]`` annotations resolve to the
+    # builtin, not this class's ``list`` method (Python binds the method name
+    # only once its ``def`` executes).
+    def replace_from(
+        self, user_id: UUID, from_date: date, rows: Sequence[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Delete this user's prescriptions on/after ``from_date`` and insert ``rows``.
+
+        Past rows (before ``from_date``) are preserved as the record of what was
+        asked. ``rows`` already carry their own ``plan_on`` (all >= ``from_date``).
+        """
+        self.supabase.table("plan_days").delete().eq("user_id", str(user_id)).gte(
+            "plan_on", from_date.isoformat()
+        ).execute()
+        if not rows:
+            return []
+        payload = [{**r, "user_id": str(user_id)} for r in rows]
+        result = self.supabase.table("plan_days").insert(payload).execute()
+        return cast(list[dict[str, Any]], result.data)
+
+    def list(
+        self,
+        user_id: UUID,
+        date_from: date | None = None,
+        date_to: date | None = None,
+    ) -> list[dict[str, Any]]:
+        query = self.supabase.table("plan_days").select("*").eq("user_id", str(user_id))
+        if date_from is not None:
+            query = query.gte("plan_on", date_from.isoformat())
+        if date_to is not None:
+            query = query.lte("plan_on", date_to.isoformat())
+        result = query.order("plan_on").execute()
+        return cast(list[dict[str, Any]], result.data)

--- a/supabase/migrations/20260615130000_add_goal_qualifiers.sql
+++ b/supabase/migrations/20260615130000_add_goal_qualifiers.sql
@@ -1,0 +1,24 @@
+-- =====================================================
+-- metric_goals qualifiers — per-day threshold + per-event minimum (SB-164)
+-- =====================================================
+-- Additive columns the planning engine needs to map a stored goal to a
+-- PlanningGoal (see src/shared/planning/). Both nullable — existing goals keep
+-- today's behavior (any entry counts).
+--
+--   qualifier_threshold  a day must reach this aggregate to "count":
+--                          streak    → daily floor (run >= 1 mi/day)
+--                          frequency → per-day threshold (a run >= 5 mi is one
+--                                      of the "4 long runs")
+--   per_event_min        minimum value each qualifying event needs
+--                          (push-ups >= 60 per session)
+--
+-- This is the additive "qualified goals" step from docs/GOALS_TRACKING.md, scoped
+-- to exactly what planning requires. Canonical units (km for distance, reps, ...).
+-- =====================================================
+
+ALTER TABLE metric_goals
+    ADD COLUMN qualifier_threshold NUMERIC(12, 3) CHECK (qualifier_threshold IS NULL OR qualifier_threshold >= 0),
+    ADD COLUMN per_event_min NUMERIC(12, 3) CHECK (per_event_min IS NULL OR per_event_min >= 0);
+
+COMMENT ON COLUMN metric_goals.qualifier_threshold IS 'Per-day aggregate a day must reach to count (streak floor / frequency threshold); canonical units';
+COMMENT ON COLUMN metric_goals.per_event_min IS 'Minimum value each qualifying event needs (e.g. push-ups >= 60 per session)';

--- a/tests/test_planning_service.py
+++ b/tests/test_planning_service.py
@@ -1,0 +1,242 @@
+"""Tests for the backend plan-assembly service (SB-164).
+
+Covers the Supabase<->engine glue: period parsing, goal mapping, and a full
+build/persist round-trip driven through a fake Supabase client (no live DB).
+The engine's own behavior is covered in test_planning_engine.py.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from backend.planning import (
+    build_and_store_plan,
+    build_plan,
+    period_bounds,
+    period_for,
+    to_planning_goal,
+)
+from src.shared.models.metric import GoalKind
+from src.shared.models.planning import FeasibilityStatus, PlanDayKind
+
+MILE = 1.609344
+FIVE_MI = 5 * MILE
+TOTAL = 135 * MILE
+
+
+# --------------------------------------------------------------------------- #
+# Fake Supabase — chainable query builder returning canned rows per table
+# --------------------------------------------------------------------------- #
+class _FakeQuery:
+    def __init__(self, table: str, store: dict, captured: dict):
+        self.table = table
+        self.store = store
+        self.captured = captured
+        self._mode = "select"
+        self._payload: Any = None
+
+    def select(self, *a: Any, **k: Any) -> _FakeQuery:
+        return self
+
+    def eq(self, *a: Any, **k: Any) -> _FakeQuery:
+        return self
+
+    def gte(self, *a: Any, **k: Any) -> _FakeQuery:
+        return self
+
+    def lte(self, *a: Any, **k: Any) -> _FakeQuery:
+        return self
+
+    def order(self, *a: Any, **k: Any) -> _FakeQuery:
+        return self
+
+    def limit(self, *a: Any, **k: Any) -> _FakeQuery:
+        return self
+
+    def insert(self, payload: Any) -> _FakeQuery:
+        self._mode, self._payload = "insert", payload
+        return self
+
+    def upsert(self, payload: Any, **k: Any) -> _FakeQuery:
+        self._mode, self._payload = "upsert", payload
+        return self
+
+    def delete(self) -> _FakeQuery:
+        self._mode = "delete"
+        return self
+
+    def execute(self) -> SimpleNamespace:
+        if self._mode in ("insert", "upsert"):
+            rows = self._payload if isinstance(self._payload, list) else [self._payload]
+            self.captured.setdefault(self.table, []).extend(rows)
+            return SimpleNamespace(data=rows)
+        if self._mode == "delete":
+            self.captured.setdefault(f"{self.table}:deleted", []).append(True)
+            return SimpleNamespace(data=[])
+        return SimpleNamespace(data=list(self.store.get(self.table, [])))
+
+
+class _FakeSupabase:
+    def __init__(self, store: dict):
+        self.store = store
+        self.captured: dict = {}
+
+    def table(self, name: str) -> _FakeQuery:
+        return _FakeQuery(name, self.store, self.captured)
+
+
+def _july_store() -> dict:
+    return {
+        "metric_goals": [
+            {
+                "metric_key": "running_distance",
+                "kind": "streak",
+                "target": 31,
+                "period": "month",
+                "qualifier_threshold": MILE,
+                "per_event_min": None,
+                "rest_budget": 0,
+            },
+            {
+                "metric_key": "running_distance",
+                "kind": "volume",
+                "target": TOTAL,
+                "period": "month",
+                "qualifier_threshold": None,
+                "per_event_min": None,
+                "rest_budget": 0,
+            },
+            {
+                "metric_key": "running_distance",
+                "kind": "frequency",
+                "target": 4,
+                "period": "month",
+                "qualifier_threshold": FIVE_MI,
+                "per_event_min": None,
+                "rest_budget": 0,
+            },
+            {
+                "metric_key": "pushups",
+                "kind": "frequency",
+                "target": 10,
+                "period": "month",
+                "qualifier_threshold": None,
+                "per_event_min": 60,
+                "rest_budget": 0,
+            },
+            {
+                "metric_key": "body_weight",
+                "kind": "frequency",
+                "target": 10,
+                "period": "month",
+                "qualifier_threshold": None,
+                "per_event_min": None,
+                "rest_budget": 0,
+            },
+        ],
+        "metric_entries": [],
+        "plan_constraints": [
+            {
+                "metric_key": "running_distance",
+                "start_on": "2026-07-12",
+                "end_on": "2026-07-16",
+                "cap": MILE,
+                "floor": MILE,
+                "reason": "Chicago travel",
+            },
+        ],
+        "readiness_log": [],
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Pure mapping
+# --------------------------------------------------------------------------- #
+def test_period_bounds_and_for():
+    assert period_bounds("2026-07") == (date(2026, 7, 1), date(2026, 7, 31))
+    assert period_bounds("2026-02") == (date(2026, 2, 1), date(2026, 2, 28))
+    assert period_for(date(2026, 7, 9)) == "2026-07"
+
+
+def test_period_bounds_rejects_garbage():
+    with pytest.raises(ValueError):
+        period_bounds("2026/07")
+    with pytest.raises(ValueError):
+        period_bounds("2026-13")
+
+
+def test_to_planning_goal_maps_qualifiers():
+    row = {
+        "metric_key": "running_distance",
+        "kind": "frequency",
+        "target": 4,
+        "qualifier_threshold": FIVE_MI,
+        "per_event_min": None,
+        "rest_budget": 0,
+    }
+    g = to_planning_goal(row, date(2026, 7, 1), date(2026, 7, 31))
+    assert g.kind is GoalKind.frequency
+    assert g.target == 4
+    assert g.qualifier_threshold == pytest.approx(FIVE_MI)
+    assert g.period_end == date(2026, 7, 31)
+
+
+# --------------------------------------------------------------------------- #
+# Full build through the fake client (future month plans from day 1)
+# --------------------------------------------------------------------------- #
+def test_build_plan_july_end_to_end():
+    supa = _FakeSupabase(_july_store())
+    result = build_plan(supa, uuid4(), "2026-07", today=date(2026, 6, 15))
+
+    assert result.generated_for == date(2026, 7, 1)
+    run_days = result.days_for("running_distance")
+    assert len(run_days) == 31
+
+    chicago = {date(2026, 7, d) for d in range(12, 17)}
+    for d in run_days:
+        if d.plan_on in chicago:
+            assert d.kind is PlanDayKind.fixed
+            assert d.prescribed_value == pytest.approx(MILE, abs=1e-3)
+    assert sum(d.prescribed_value for d in run_days) == pytest.approx(TOTAL, abs=0.5)
+
+    assert len(result.days_for("pushups")) == 10
+    assert len(result.days_for("body_weight")) == 10
+    assert result.status is FeasibilityStatus.on_track
+
+
+def test_build_and_store_persists_all_days():
+    supa = _FakeSupabase(_july_store())
+    user_id = uuid4()
+    result = build_and_store_plan(supa, user_id, "2026-07", today=date(2026, 6, 15))
+
+    inserted = supa.captured.get("plan_days", [])
+    assert len(inserted) == len(result.days)
+    # delete-future ran before reinsert
+    assert supa.captured.get("plan_days:deleted")
+    # rows carry the user_id and a serializable plan_on
+    assert all(r["user_id"] == str(user_id) for r in inserted)
+    assert all(isinstance(r["plan_on"], str) for r in inserted)
+
+
+def test_year_goals_excluded_from_month_plan():
+    store = _july_store()
+    store["metric_goals"].append(
+        {
+            "metric_key": "running_distance",
+            "kind": "volume",
+            "target": 9999,
+            "period": "year",
+            "qualifier_threshold": None,
+            "per_event_min": None,
+            "rest_budget": 0,
+        }
+    )
+    supa = _FakeSupabase(store)
+    result = build_plan(supa, uuid4(), "2026-07", today=date(2026, 6, 15))
+    # The 9999 yearly target would blow the gate if included; plan stays on track.
+    assert result.status is FeasibilityStatus.on_track


### PR DESCRIPTION
## Summary
Phase 1 of Adaptive Monthly Planning ([SB-162](https://linear.app/silverbeer/issue/SB-162)) — wires the P0 engine to Supabase and exposes deterministic, machine-readable surfaces. **No LLM**; backend + cron stay LLM-free, and the P2 `plan` skill will narrate this output.

**Persistence**
- `planning_repository.py` — `PlanConstraints` / `Readiness` / `PlanDays` repos (CRUD + delete-future-and-reinsert). Service-role key, so every query scopes by `user_id` itself.
- Migration — additive `qualifier_threshold` + `per_event_min` on `metric_goals` so a stored goal maps to a `PlanningGoal` ("4 runs > 5 mi", "push-ups ≥ 60" need the threshold). Nullable; existing goals unchanged.

**Service + API** (`backend/planning.py`, `backend/routes/plan.py`)
- Gather goals + actuals + constraints + readiness for a `YYYY-MM` period → map → engine → persist. The plan is a **derived cache**: `build_plan` recomputes from scratch every call. Yearly goals excluded from a month's daily plan.
- `POST/GET/DELETE /plan/constraints`, `POST /plan/readiness` (immediate recompute), `GET /plan/{period}`, `POST /plan/{period}/recompute`. JWT-gated like `/metrics`.

**Nightly cron** — `backend/jobs/recompute_plans.py` + a Helm `CronJob` (08:00 UTC, after the morning sync) so each day's plan reflects yesterday's runs and any drift.

**stk CLI** (deterministic JSON) — `stk plan show/recompute`, `stk constraint add` (parses `1mi`/`5km` → km), `stk readiness set`. `api.delete_request` helper.

## Test plan
- [x] `uv run pytest tests/` — 45 pass (engine + new service tests via a fake Supabase client: period parsing, goal mapping, full July build, persistence round-trip, yearly-goal exclusion)
- [x] `ruff check` clean; `mypy` clean on new code; `helm template` renders the new CronJob
- [ ] **Live e2e (needs a Supabase env — not runnable in CI here):** apply both migrations; `stk constraint add --metric running_distance --from 2026-07-12 --to 2026-07-16 --cap 1mi --floor 1mi --reason "Chicago travel"`; `stk plan show --period 2026-07 --json` returns a correct July plan; `stk readiness set --status sick` recomputes
- [ ] Reviewer: confirm the two migrations apply cleanly in order (qualifiers depend on the metric_goals table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes SB-164