### PR TITLE
feat: plan coaching skill + user guide (SB-165)

### DIFF
--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: plan
+description: >-
+  Show, explain, and adapt the user's adaptive monthly running plan via the `stk`
+  CLI — with motivating coaching. Use when the user wants to see their plan or
+  today's run ("what's my plan", "how's July going", "what should I run today"),
+  log how they feel ("I feel rough", "slept badly", "feeling great"), tell the
+  plan about a known disruption in plain language ("I'm in Chicago Thu–Mon, can
+  only get a mile in", "tweaked my knee, easy week"), or recompute after falling
+  behind. The planning engine owns every number; this skill only narrates and
+  motivates — it never computes or invents mileage.
+---
+
+# Plan — adaptive monthly coaching
+
+Drive the `stk` CLI to read and adapt the user's monthly plan, then turn the
+engine's output into a **motivating** message. The plan exists to keep the user
+going: on-track should feel good; falling behind needs an honest, encouraging
+push.
+
+## The one rule
+
+> **The engine owns every number. You only narrate them.**
+
+Never compute a prescription, a feasibility verdict, or a catch-up yourself.
+Read them from `stk ... --json` and quote them. If you're tempted to do
+arithmetic on mileage, stop and call `stk` instead. Inventing a number the
+engine didn't produce is the one unforgivable failure here.
+
+## Prerequisite
+
+`stk` must be on PATH and logged in. Verify with `stk --version`; if the user
+isn't authenticated the commands print "Not logged in" — tell them to run
+`stk auth login`. Always pass `--json` so you parse structured output, not the
+human table.
+
+## Units: store km, speak miles
+
+The API and engine are canonical **kilometers**. The runner thinks in **miles**.
+Always convert for display: `miles = km * 0.621371` (round to 1 decimal). When
+you pass distances *in* (constraints), use mile suffixes and let the CLI convert
+— e.g. `--cap 1mi`.
+
+## Reading the plan
+
+```bash
+stk plan show --period 2026-07 --json     # a specific month
+stk plan show --json                       # current month
+```
+
+Returns a `PlanResult`:
+
+```jsonc
+{
+  "period_start": "2026-07-01",
+  "period_end": "2026-07-31",
+  "generated_for": "2026-07-09",     // plan prescribes from this day forward
+  "status": "on_track",              // or "at_risk" — the month-level roll-up
+  "at_risk_reasons": [],             // human strings when at risk
+  "days": [                          // one row per metric per day
+    {"metric_key": "running_distance", "plan_on": "2026-07-09",
+     "prescribed_value": 7.24, "kind": "easy"}   // km! kind: long|easy|rest|fixed
+  ],
+  "goals": [                         // per-goal progress + verdict
+    {"metric_key": "running_distance", "kind": "volume", "target": 217.26,
+     "done": 96.5, "remaining": 120.76, "projected": 217.0,
+     "status": "on_track", "detail": null}
+  ]
+}
+```
+
+To answer **"what should I run today"**: find the `days` entry where `plan_on`
+== today and `metric_key` == `running_distance`, convert `prescribed_value` to
+miles, and report it with its `kind` ("an easy 4.5", "your long run — 6.2",
+"rest day, just your streak mile", "travel-capped at 1 mile").
+
+## Coaching — pick the voice from the engine's status
+
+The engine emits status + facts; you choose the tone. Quote real numbers.
+
+| Engine state | Voice |
+|---|---|
+| `status: on_track`, goal `projected` comfortably ≥ `target` | Celebrate, reinforce the streak. "You're ahead — 96 of 135 mi with the month's hardest days behind you." |
+| `on_track`, projected ≈ target (tight) | Steady. "Right on the line. Today's 4.5 keeps you there." |
+| `status: at_risk` | Empathize, then present the engine's own catch-up (the higher daily targets in `days`, the `at_risk_reasons`) as doable — or, if it truly can't be saved, say so honestly and surface the trade (drop a stretch goal, raise the cap). Never fake-cheerful. |
+| A `rest` day after `sick` readiness | Permission to rest + reassurance: "Took today off — the plan already absorbed it, you're still on track." |
+
+Lead with where they stand, give today's concrete action, end with the streak
+or the win. Keep it short — a runner reads this between waking up and lacing up.
+
+## Fuzzy intake — natural language → structured
+
+When the user describes a disruption or how they feel, translate it into the
+right `stk` call, run it, then re-read and narrate the adapted plan.
+
+**A known disruption → a constraint.** "I'm in Chicago Thursday through Monday,
+can only get a mile in":
+
+```bash
+stk constraint add --metric running_distance \
+  --from 2026-07-12 --to 2026-07-16 \
+  --cap 1mi --floor 1mi --reason "Chicago travel" --json
+```
+
+- `--cap` = the most they can do/day; `--floor` = the least they'll still do
+  (keeps the streak alive). Both equal = a pinned day.
+- Resolve relative dates ("Thursday through Monday") to ISO yourself from the
+  current date before calling.
+- An injury week is a `--cap` with no `--floor` ("take it easy, max 3mi").
+
+**How they feel → readiness.** "Feeling rough", "slept badly", "exhausted" →
+`tired`; "sick", "under the weather" → `sick`; "great", "fresh" → `good`.
+
+```bash
+stk readiness set --status tired --date today --json
+```
+
+This returns the **recomputed** `PlanResult` directly — narrate the adjusted
+plan from it (today down-shifts, the load moves forward, the gate re-checks).
+
+**Recompute on demand** (e.g. after they log runs, or to refresh):
+
+```bash
+stk plan recompute --period 2026-07 --json
+```
+
+## Conversational flow
+
+```
+user: "how's my July plan looking?"
+  → stk plan show --json
+  → narrate: status, where they stand (miles), today's prescription, the streak
+
+user: "ugh, slept terrible, not feeling it today"
+  → stk readiness set --status tired --date today --json
+  → narrate the returned plan: "Dialed today back to an easy 3.1 and pushed the
+     miles to the weekend. You're still on track for 135."
+
+user: "I'll be in Chicago next weekend, can barely run there"
+  → ask only what you can't infer (dates? cap?), then:
+     stk constraint add --metric running_distance --from ... --to ... --cap 1mi --floor 1mi --reason "Chicago"
+  → stk plan recompute --json → narrate how the other days absorbed it
+```
+
+Ask a clarifying question only when a required field is genuinely ambiguous
+(exact dates, the cap). Otherwise infer sensible values and proceed.
+
+## Distribution
+
+This skill is version-controlled with the project at `.claude/skills/plan/`. To
+use it outside this repo, copy or symlink it into `~/.claude/skills/plan/`
+(same as `linear-crud` / `todo`). It needs only the `stk` CLI — no extra deps.

--- a/docs/PLANNING_GUIDE.md
+++ b/docs/PLANNING_GUIDE.md
@@ -1,0 +1,130 @@
+# Your Month, Planned. Your Plan, Alive.
+
+**MyRunStreak Adaptive Planning** turns the goals in your head into a plan that
+tells you exactly what to do today — and quietly rewrites itself the moment life
+gets in the way.
+
+You set the goals. It builds the month. You run. It keeps you honest, keeps you
+moving, and tells you the truth about where you stand — with a little push when
+you need one.
+
+> *This is a user guide written as the feature ships (P2). The visual month-grid
+> walkthrough and screenshots land with the frontend (P3); for now this is the
+> CLI + coaching story.*
+
+---
+
+## The idea in one breath
+
+Most goal trackers show you a number and a percentage and leave the math to you.
+"You're at 47%." Okay — so what do I run *today*?
+
+Adaptive Planning answers that question every single morning. It takes your
+monthly goals, lays them across the calendar, works around the trips and the
+rough mornings you can't control, and hands you one thing: **today's plan.** When
+you fall behind, it doesn't shame you with a red bar — it reshuffles the rest of
+the month so the goal is still reachable, and shows you how.
+
+---
+
+## Set your goals
+
+Tell MyRunStreak what the month is about. A real July:
+
+- **Run every day** — the streak, never broken.
+- **135 miles** total.
+- **4 long runs** — over 5 miles each.
+- **Push-ups** — at least 60, ten times.
+- **Weigh in** — ten times.
+
+These aren't five separate apps and five separate nags. They're one month, and
+the planner holds all of them at once.
+
+## Get your plan
+
+```bash
+stk plan show --period 2026-07
+```
+
+Out comes a day-by-day plan: an easy 4-miler here, a long 6 on Saturday, a rest
+day with just your streak mile, push-up sessions and weigh-ins slotted in. Every
+day has a job. You never have to do the math again.
+
+Better yet, ask your assistant:
+
+> **"How's my July plan looking?"**
+
+and the `plan` skill reads your real plan and talks you through it — where you
+stand, what today asks of you, whether you're ahead. Real numbers, plain
+language, and a nudge in the right direction.
+
+---
+
+## Life happens. The plan adapts.
+
+This is the part that makes it feel alive.
+
+### You're traveling
+
+You're in **Chicago, July 12–16**. Hotel treadmill, packed schedule — you can
+keep the streak, but only a mile a day. Just say so:
+
+> **"I'm in Chicago Thursday through Monday, can only get a mile in."**
+
+The plan pins those five days at one mile, keeps your streak intact, and **moves
+the missing miles into the rest of the month** — spread out safely, never dumped
+on one brutal day. You left for a trip; you came back to a plan that already
+handled it.
+
+### You wake up rough
+
+The plan says 5 miles. You slept badly and your legs feel like sandbags. You
+don't have to white-knuckle it or blow up the month:
+
+> **"Slept terrible, not feeling it today."**
+
+Today softens to an easy effort, the load shifts forward, and you get told the
+truth: *still on track for 135.* Feeling genuinely sick? Take the rest day — the
+plan absorbs it, your streak survives on the floor mile, and nobody panics.
+
+### You fall behind
+
+It's the 28th and the miles didn't happen. Instead of finding out on July 31st
+that it was hopeless, the plan flags **at risk** early — and shows you the
+concrete catch-up, or tells you honestly when a goal needs to bend. No false
+cheer. Just a clear call and the path forward.
+
+---
+
+## Why it actually motivates
+
+- **One job a day.** The month stops being a vague 135 and becomes "today: an
+  easy 4.5." Doable. Done. Streak intact.
+- **The plan carries the worry, not you.** Travel, a bad night, a missed long
+  run — it re-plans so you don't lie awake doing mileage arithmetic.
+- **It tells the truth, kindly.** Ahead of pace? You'll hear it. At risk? You'll
+  hear that too — early, with a way out, never sugar-coated.
+- **Every number is real.** The coaching never makes up a mileage to sound
+  encouraging. What it tells you is exactly what the plan says.
+
+---
+
+## The commands behind it
+
+The coaching assistant drives these for you, but they're yours to run directly:
+
+```bash
+stk plan show --period 2026-07          # see the month
+stk plan recompute                      # rebuild from the latest reality
+stk constraint add --metric running_distance \
+  --from 2026-07-12 --to 2026-07-16 \
+  --cap 1mi --floor 1mi --reason "Chicago travel"
+stk readiness set --status tired        # tell it how you feel; it re-plans
+```
+
+And every night, while you sleep, the plan recomputes on its own — so the
+version waiting for you in the morning already knows about yesterday's run.
+
+---
+
+*Set the goals. Run the miles. Let the plan handle the rest.*


### PR DESCRIPTION
## Summary
Phase 2 of Adaptive Monthly Planning ([SB-162](https://linear.app/silverbeer/issue/SB-162)) — the **coaching layer**. A Claude skill that drives the deterministic `stk` CLI and turns the engine's output into motivating, plain-language coaching. This completes the **pre-July motivation loop**: goals → plan → adapt → coach.

- **`.claude/skills/plan/SKILL.md`** — reads `stk plan show --json`, narrates where the user stands + today's run, and tunes tone to the engine's status (ahead → celebrate, tight → steady, `at_risk` → honest catch-up, sick rest day → reassurance). Fuzzy intake maps natural language → structured calls: *"I'm in Chicago Thu–Mon, only a mile"* → `stk constraint add`; *"feel rough"* → `stk readiness set`. **The hard rule:** the engine owns every number, the skill only quotes them — never computes or invents mileage. km in, miles out.
- **`docs/PLANNING_GUIDE.md`** — the lasting, marketing-flavored user guide (committed, unlike the throwaway design scratch). Narrates the real July story end-to-end. Gets the month-grid visuals + screenshots in P3.

## Test plan
- [x] `uv run pytest tests/` — 45 pass (no code changed; confirms no regression)
- [x] Skill frontmatter valid; `plan` skill is discovered by the harness
- [x] Every `stk` command the skill calls exists in the P1 CLI (`plan show/recompute`, `constraint add`, `readiness set`) with matching flags
- [ ] Reviewer: with `stk` authed against a live env, run the skill ("how's my July plan?", "feel rough today", "Chicago next weekend") and confirm coaching quotes the engine numbers (no hallucinated mileage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes SB-165