### PR TITLE
fix: bound plan "done" progress to the goal period (SB-168)

### DIFF
--- a/src/shared/planning/engine.py
+++ b/src/shared/planning/engine.py
@@ -119,10 +119,10 @@ def generate_plan(
     for metric_key, mgoals in by_metric.items():
         if metric_key == RUNNING_KEY:
             days, st = _plan_running(
-                metric_key, mgoals, entries, constraints, readiness, today, period_end
+                metric_key, mgoals, entries, constraints, readiness, period_start, today, period_end
             )
         else:
-            days, st = _plan_simple(metric_key, mgoals, entries, today, period_end)
+            days, st = _plan_simple(metric_key, mgoals, entries, period_start, today, period_end)
         plan_days.extend(days)
         statuses.extend(st)
 
@@ -159,6 +159,7 @@ def _plan_running(
     entries: Sequence[ActualEntry],
     constraints: Sequence[PlanConstraint],
     readiness: Sequence[Readiness],
+    period_start: date,
     today: date,
     period_end: date,
 ) -> tuple[list[PlanDay], list[GoalPlanStatus]]:
@@ -189,11 +190,16 @@ def _plan_running(
             rested.add(day)  # rest day: only the streak floor, no long/extra
         free.append(day)
 
-    # ---- progress so far (entries strictly before today) ----
-    done_volume = sum(v for d, v in totals.items() if d < today)
+    # ---- progress so far: entries within the period, strictly before today ----
+    # Bounded to [period_start, today) — trailing history (used only for the ramp
+    # ceiling below) must NOT count as goal progress, or last month's runs inflate
+    # this month's "done".
+    done_volume = sum(v for d, v in totals.items() if period_start <= d < today)
     long_threshold: float = (long_goal.qualifier_threshold or 0.0) if long_goal else 0.0
     qualifying_done = (
-        sum(1 for d, v in totals.items() if d < today and v >= long_threshold - _EPS)
+        sum(
+            1 for d, v in totals.items() if period_start <= d < today and v >= long_threshold - _EPS
+        )
         if long_goal
         else 0
     )
@@ -276,7 +282,13 @@ def _plan_running(
                 metric_key=metric_key,
                 kind=GoalKind.streak,
                 target=streak.target,
-                done=float(sum(1 for d in totals if d < today and totals[d] >= floor_km - _EPS)),
+                done=float(
+                    sum(
+                        1
+                        for d in totals
+                        if period_start <= d < today and totals[d] >= floor_km - _EPS
+                    )
+                ),
                 remaining=float(len(horizon)),
                 status=FeasibilityStatus.on_track if not below else FeasibilityStatus.at_risk,
                 detail=None
@@ -357,6 +369,7 @@ def _plan_simple(
     metric_key: str,
     goals: Sequence[PlanningGoal],
     entries: Sequence[ActualEntry],
+    period_start: date,
     today: date,
     period_end: date,
 ) -> tuple[list[PlanDay], list[GoalPlanStatus]]:
@@ -370,7 +383,9 @@ def _plan_simple(
             # P0 only needs frequency for the non-running metrics (sessions, weigh-ins).
             continue
         threshold = goal.per_event_min if goal.per_event_min else _EPS
-        done_count = sum(1 for d, v in totals.items() if d < today and v >= threshold - _EPS)
+        done_count = sum(
+            1 for d, v in totals.items() if period_start <= d < today and v >= threshold - _EPS
+        )
         needed = max(0, math.ceil(goal.target) - done_count)
         chosen = _spread(horizon, needed)
         value = goal.per_event_min if goal.per_event_min else 1.0

--- a/tests/test_planning_engine.py
+++ b/tests/test_planning_engine.py
@@ -241,6 +241,33 @@ def test_on_track_when_ahead_of_pace():
 
 
 # --------------------------------------------------------------------------- #
+# Regression: prior-month runs (pulled only for the ramp ceiling) must NOT
+# count as this month's progress. Caught in live e2e — June runs were inflating
+# July's "done" and shrinking the plan. today=Jul 1 with a full June of entries.
+# --------------------------------------------------------------------------- #
+def test_prior_month_entries_do_not_count_as_done():
+    june_runs = [
+        ActualEntry(metric_key=RUNNING_KEY, occurred_on=date(2026, 6, d), value=miles_to_km(6.0))
+        for d in range(1, 31)  # 30 June days, 6 mi each, several over the 5-mi long-run bar
+    ]
+    result = generate_plan(
+        period_start=JUL_START,
+        period_end=JUL_END,
+        today=JUL_START,  # plan all of July; nothing done IN July yet
+        goals=_july_goals(),
+        entries=june_runs,
+        constraints=[_chicago()],
+    )
+    vol = next(g for g in result.goals if g.kind is GoalKind.volume)
+    assert vol.done == pytest.approx(0.0, abs=1e-6)  # June must not leak in
+    # The full target is still planned across July, not just a remainder.
+    planned = sum(d.prescribed_value for d in result.days_for(RUNNING_KEY))
+    assert planned == pytest.approx(TOTAL_MI, abs=0.5)
+    # And all 4 long runs are placed (no June run miscounted as a done long run).
+    assert sum(1 for d in result.days_for(RUNNING_KEY) if d.kind is PlanDayKind.long) == 4
+
+
+# --------------------------------------------------------------------------- #
 # Readiness: a sick day becomes rest but keeps the streak floor
 # --------------------------------------------------------------------------- #
 def test_sick_day_is_rest_but_keeps_streak_floor():


### PR DESCRIPTION
## Summary
**Bug found in live e2e testing** (SB-168). The planning engine counted trailing-history entries — pulled *only* to compute the weekly-ramp ceiling — as goal progress. With real prior-month runs in the DB, last month's mileage inflated this month's `done`:

- Volume `done` showed **96 km already done** on a future month (it was June's runs).
- Plan under-prescribed: **120 km planned** for a 135 mi (217 km) target.
- Only **3 of 4** long runs placed (a prior long run counted as already done).

Root cause: every `done` aggregate was bounded `(-∞, today)` instead of `[period_start, today)`.

## Fix
Bound all `done` aggregates (volume, streak count, qualifying long-run count, simple-distributor session count) to `[period_start, today)`. The trailing-28-day ramp window is unchanged — it legitimately uses pre-period history.

## Why unit tests missed it
Fixtures never had entries *before* `period_start` with `today == period_start`. Added a regression test: a full June of runs, `today = Jul 1` → asserts `done == 0`, full target planned, all 4 long runs placed.

## Verification
- [x] `uv run pytest tests/` — 46 pass (new regression included)
- [x] ruff + mypy clean on the engine
- [x] **Verified against live production data** (fetched real entries, ran the fixed engine): `done` 0, **217 km planned**, **4 long runs**, on_track
- [ ] After merge + backend redeploy: re-run `stk plan show --period 2026-07` live and confirm the corrected numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes SB-168