### PR TITLE
feat: time-of-day goal qualifier — "start by 8am" goals

### DIFF
--- a/backend/metrics_progress.py
+++ b/backend/metrics_progress.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import calendar
 from datetime import date, timedelta
+from zoneinfo import ZoneInfo
 
 from src.shared.models.metric import (
     GoalComparator,
@@ -20,6 +21,27 @@ from src.shared.models.metric import (
     MetricGoal,
     MetricType,
 )
+
+# App-wide local anchor (matches /stats, /metrics, and the cron jobs).
+_LOCAL_TZ = ZoneInfo("America/New_York")
+
+
+def _qualifying_days(entries: list[MetricEntry], goal: MetricGoal) -> set[date]:
+    """Distinct days that count toward a frequency goal.
+
+    Honors ``before_time`` — a day counts only if its entry started at/before that
+    local clock time (e.g. "out the door by 8am"). An entry without a precise
+    ``occurred_at`` can't satisfy a time goal, so it's excluded when one is set.
+    """
+    if goal.before_time is None:
+        return {e.occurred_on for e in entries}
+    days: set[date] = set()
+    for e in entries:
+        if e.occurred_at is None:
+            continue
+        if e.occurred_at.astimezone(_LOCAL_TZ).timetz().replace(tzinfo=None) <= goal.before_time:
+            days.add(e.occurred_on)
+    return days
 
 
 def resolve_window(goal: MetricGoal, today: date) -> tuple[date, date]:
@@ -38,7 +60,9 @@ def resolve_window(goal: MetricGoal, today: date) -> tuple[date, date]:
     return goal.period_start, goal.period_end
 
 
-def _aggregate(values: list[float], agg: MetricAggregation, entries_in_window: list[MetricEntry]) -> float:
+def _aggregate(
+    values: list[float], agg: MetricAggregation, entries_in_window: list[MetricEntry]
+) -> float:
     if not values:
         return 0.0
     if agg == MetricAggregation.sum:
@@ -50,7 +74,10 @@ def _aggregate(values: list[float], agg: MetricAggregation, entries_in_window: l
     # latest: value of the most recent entry (by occurred_at, then occurred_on).
     latest = max(
         entries_in_window,
-        key=lambda e: (e.occurred_at.timestamp() if e.occurred_at else 0.0, e.occurred_on.toordinal()),
+        key=lambda e: (
+            e.occurred_at.timestamp() if e.occurred_at else 0.0,
+            e.occurred_on.toordinal(),
+        ),
     )
     return float(latest.value)
 
@@ -90,14 +117,16 @@ def compute_progress(
     if goal.kind == GoalKind.volume:
         progress = _aggregate([e.value for e in in_window], metric.aggregation, in_window)
     elif goal.kind == GoalKind.frequency:
-        # Count distinct days with any entry.
-        progress = float(len({e.occurred_on for e in in_window}))
+        # Count distinct qualifying days (honors before_time if set).
+        progress = float(len(_qualifying_days(in_window, goal)))
     else:  # streak
         progress = float(current_streak({e.occurred_on for e in entries}, today, goal.rest_budget))
 
     percent = (progress / goal.target * 100.0) if goal.target else None
-    met = progress >= goal.target if goal.comparator == GoalComparator.gte else (
-        0 < progress <= goal.target
+    met = (
+        progress >= goal.target
+        if goal.comparator == GoalComparator.gte
+        else (0 < progress <= goal.target)
     )
 
     result = GoalProgress(

--- a/backend/planning.py
+++ b/backend/planning.py
@@ -78,9 +78,19 @@ def to_planning_goal(row: dict[str, Any], period_start: date, period_end: date) 
 
 
 def _is_plan_goal(row: dict[str, Any]) -> bool:
-    """Monthly-planning goals only — yearly goals (e.g. the SmashRun mirror's
-    cadence) are not a month's daily plan."""
-    return row.get("period") != "year"
+    """Monthly-planning goals only.
+
+    Excludes:
+      - yearly goals (the SmashRun mirror's cadence, not a month's daily plan),
+      - weekly goals (the monthly planner doesn't schedule a weekly cadence),
+      - time-of-day goals (``before_time`` — a habit tracked + coached via the
+        goals/progress engine; it doesn't change what distance to run).
+    """
+    if row.get("period") in ("year", "week"):
+        return False
+    if row.get("before_time") is not None:
+        return False
+    return True
 
 
 def build_plan(

--- a/backend/tests/test_metrics_progress.py
+++ b/backend/tests/test_metrics_progress.py
@@ -45,11 +45,20 @@ def _goal(**kw) -> MetricGoal:
     return MetricGoal(**base)
 
 
-PUSHUPS = MetricType(key="pushups", display_name="Push-ups", unit="reps", aggregation=MetricAggregation.sum)
-WEIGHT = MetricType(key="body_weight", display_name="Body weight", unit="kg", aggregation=MetricAggregation.latest, higher_is_better=False)
+PUSHUPS = MetricType(
+    key="pushups", display_name="Push-ups", unit="reps", aggregation=MetricAggregation.sum
+)
+WEIGHT = MetricType(
+    key="body_weight",
+    display_name="Body weight",
+    unit="kg",
+    aggregation=MetricAggregation.latest,
+    higher_is_better=False,
+)
 
 
 # ---- resolve_window ----
+
 
 def test_window_year():
     s, e = resolve_window(_goal(period=GoalPeriod.year), date(2026, 6, 2))
@@ -73,6 +82,7 @@ def test_window_custom():
 
 
 # ---- volume ----
+
 
 def test_volume_sum_and_pace():
     today = date(2026, 6, 10)  # day 10 of a 30-day month
@@ -110,19 +120,25 @@ def test_volume_excludes_out_of_window_entries():
 
 def test_weight_latest_lte_comparator():
     today = date(2026, 6, 20)
-    g = _goal(metric_key="body_weight", kind=GoalKind.volume, period=GoalPeriod.month,
-              target=80.0, comparator=GoalComparator.lte)
+    g = _goal(
+        metric_key="body_weight",
+        kind=GoalKind.volume,
+        period=GoalPeriod.month,
+        target=80.0,
+        comparator=GoalComparator.lte,
+    )
     entries = [
         _entry("body_weight", date(2026, 6, 1), 82.0, at=datetime(2026, 6, 1, tzinfo=UTC)),
         _entry("body_weight", date(2026, 6, 18), 79.5, at=datetime(2026, 6, 18, tzinfo=UTC)),
     ]
     p = compute_progress(g, WEIGHT, entries, today)
-    assert p.progress == 79.5      # latest, not sum
-    assert p.met is True           # 79.5 <= 80
-    assert p.on_pace is None       # pace only for volume+gte
+    assert p.progress == 79.5  # latest, not sum
+    assert p.met is True  # 79.5 <= 80
+    assert p.on_pace is None  # pace only for volume+gte
 
 
 # ---- frequency ----
+
 
 def test_frequency_counts_distinct_days():
     today = date(2026, 6, 3)  # week Mon 06-01..Sun 06-07
@@ -139,6 +155,7 @@ def test_frequency_counts_distinct_days():
 
 # ---- streak ----
 
+
 def test_current_streak_basic_and_gap_breaks():
     today = date(2026, 6, 10)
     days = {date(2026, 6, 10), date(2026, 6, 9), date(2026, 6, 7)}  # gap on the 8th
@@ -153,9 +170,75 @@ def test_current_streak_rest_budget_tolerates_gap():
 
 def test_streak_goal_progress():
     today = date(2026, 6, 10)
-    g = _goal(metric_key="running_distance", kind=GoalKind.streak, period=GoalPeriod.year, target=30.0, rest_budget=0)
+    g = _goal(
+        metric_key="running_distance",
+        kind=GoalKind.streak,
+        period=GoalPeriod.year,
+        target=30.0,
+        rest_budget=0,
+    )
     entries = [_entry("running_distance", date(2026, 6, d), 5.0) for d in (10, 9, 8)]
-    rd = MetricType(key="running_distance", display_name="Running", unit="km", aggregation=MetricAggregation.sum)
+    rd = MetricType(
+        key="running_distance", display_name="Running", unit="km", aggregation=MetricAggregation.sum
+    )
     p = compute_progress(g, rd, entries, today)
     assert p.progress == 3.0
     assert p.met is False
+
+
+# ---- before_time (start-by clock time) frequency goals ----
+
+from datetime import time as _time  # noqa: E402
+from zoneinfo import ZoneInfo as _ZoneInfo  # noqa: E402
+
+_NY = _ZoneInfo("America/New_York")
+RUNNING = MetricType(
+    key="running_distance", display_name="Running", unit="km", aggregation=MetricAggregation.sum
+)
+
+
+def _early_week_entries() -> list[MetricEntry]:
+    # Mon/Tue/Wed of the same ISO week, with varying local start times.
+    return [
+        _entry("running_distance", date(2026, 6, 1), 5.0, datetime(2026, 6, 1, 7, 30, tzinfo=_NY)),
+        _entry("running_distance", date(2026, 6, 2), 5.0, datetime(2026, 6, 2, 9, 0, tzinfo=_NY)),
+        _entry("running_distance", date(2026, 6, 3), 5.0, datetime(2026, 6, 3, 8, 0, tzinfo=_NY)),
+    ]
+
+
+def test_before_time_counts_only_early_starts():
+    goal = _goal(
+        metric_key="running_distance",
+        kind=GoalKind.frequency,
+        period=GoalPeriod.week,
+        target=3.0,
+        before_time=_time(8, 0),
+    )
+    p = compute_progress(goal, RUNNING, _early_week_entries(), date(2026, 6, 3))
+    assert p.progress == 2.0  # 7:30 ✓ and 8:00 ✓ (<=); 9:00 ✗
+    assert p.met is False  # 2 of 3
+
+
+def test_no_before_time_counts_every_day():
+    goal = _goal(
+        metric_key="running_distance",
+        kind=GoalKind.frequency,
+        period=GoalPeriod.week,
+        target=3.0,
+    )
+    p = compute_progress(goal, RUNNING, _early_week_entries(), date(2026, 6, 3))
+    assert p.progress == 3.0
+    assert p.met is True
+
+
+def test_before_time_excludes_entries_without_timestamp():
+    goal = _goal(
+        metric_key="running_distance",
+        kind=GoalKind.frequency,
+        period=GoalPeriod.week,
+        target=1.0,
+        before_time=_time(8, 0),
+    )
+    entries = [_entry("running_distance", date(2026, 6, 1), 5.0, at=None)]
+    p = compute_progress(goal, RUNNING, entries, date(2026, 6, 1))
+    assert p.progress == 0.0  # no precise start time → can't satisfy a time goal

--- a/src/shared/models/metric.py
+++ b/src/shared/models/metric.py
@@ -7,7 +7,7 @@ See docs/GOALS_TRACKING.md.
 
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, time
 from enum import Enum
 from typing import Any
 from uuid import UUID
@@ -100,6 +100,9 @@ class MetricGoalCreate(BaseModel):
     period_end: date | None = None
     qualifier_threshold: float | None = Field(default=None, ge=0)
     per_event_min: float | None = Field(default=None, ge=0)
+    before_time: time | None = Field(
+        default=None, description='Start-by clock time, e.g. 08:00 — "out the door by 8am"'
+    )
 
     @model_validator(mode="after")
     def _custom_needs_bounds(self) -> MetricGoalCreate:
@@ -122,6 +125,7 @@ class MetricGoalUpdate(BaseModel):
     period_end: date | None = None
     qualifier_threshold: float | None = Field(default=None, ge=0)
     per_event_min: float | None = Field(default=None, ge=0)
+    before_time: time | None = None
 
 
 class MetricGoal(BaseModel):
@@ -140,6 +144,7 @@ class MetricGoal(BaseModel):
     status: GoalStatus = GoalStatus.active
     qualifier_threshold: float | None = None
     per_event_min: float | None = None
+    before_time: time | None = None
     created_at: datetime | None = None
 
 

--- a/supabase/migrations/20260617000000_add_goal_before_time.sql
+++ b/supabase/migrations/20260617000000_add_goal_before_time.sql
@@ -1,0 +1,17 @@
+-- =====================================================
+-- metric_goals.before_time — "start the activity by this clock time" qualifier
+-- =====================================================
+-- Additive, nullable. Powers time-of-day habit goals like "start a run by 8am,
+-- 3x per week" (frequency + period=week + before_time='08:00'). A day counts
+-- toward the goal only if that day's entry started at/before this local time.
+--
+-- Evaluated against metric_entries.occurred_at (the activity's local start time,
+-- projected from runs.start_date_time_local). Local tz = America/New_York, the
+-- app-wide anchor. Tracked + coached via the goals/progress engine; it does not
+-- change planning prescriptions. See docs/GOALS_TRACKING.md.
+-- =====================================================
+
+ALTER TABLE metric_goals
+    ADD COLUMN before_time TIME;
+
+COMMENT ON COLUMN metric_goals.before_time IS 'Time-of-day qualifier: a day counts only if its entry started at/before this local clock time (e.g. 08:00 = "out the door by 8am")';


### PR DESCRIPTION
## Summary
Adds a **`before_time`** qualifier to native goals so you can track time-of-day habits — the one you asked for: **"start a run by 8am, 3× per week"** (`frequency` + `period=week` + `target=3` + `before_time=08:00`). A mindset goal: prioritize the run, first thing.

- **Migration** — additive, nullable `metric_goals.before_time` (TIME).
- **Model** — `before_time` on `MetricGoalCreate` / `Update` / `MetricGoal`.
- **Progress** — frequency goals honor `before_time`: a day counts only if its entry's **local start time** (`occurred_at`, America/New_York) is at/before the target. An entry with no precise timestamp can't satisfy a time goal. Evaluated in the goals/progress engine — it tracks (and later coaches); it does **not** change what distance the planner prescribes.
- **Planner** — excludes weekly + `before_time` goals from the monthly plan builder (progress-tracked, not scheduled).

## Test plan
- [x] `uv run --project backend python -m pytest backend/tests/test_metrics_progress.py` — 15 pass (early-start `<=`, no-before_time counts all, no-timestamp excluded)
- [x] `uv run pytest tests/` — 46 pass; ruff + mypy clean on new code
- [ ] After merge + migrate + deploy: create the goal (`before_time=08:00`, weekly, target 3) and confirm progress shows "N/3 early this week"

## Follow-ups (not in this PR)
- Surface it to the user: a `stk goals` view and/or the `plan` skill mentioning early-run progress (no CLI goals command today).
- "Complete by 8am" (finish, not start) would need duration projected into `metric_entries` — deferred; start-time is the checkbox you chose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)