### PR TITLE
fix: goals-card progress from synced runs (not stale SmashRun field)

### DIFF
--- a/backend/goals.py
+++ b/backend/goals.py
@@ -12,7 +12,7 @@ from datetime import date
 from typing import Any
 from uuid import UUID
 
-from src.shared.supabase_ops import GoalsRepository
+from src.shared.supabase_ops import GoalsRepository, RunsRepository
 
 KM_TO_MILES = 0.621371
 
@@ -21,8 +21,16 @@ def km_to_miles(km: float) -> float:
     return km * KM_TO_MILES
 
 
-def render_goal(row: dict[str, Any] | None) -> dict[str, Any] | None:
+def render_goal(
+    row: dict[str, Any] | None, progress_km_override: float | None = None
+) -> dict[str, Any] | None:
     """Convert a goals-table row into the GoalProgress payload (miles).
+
+    The goal's *target* and *text* come from SmashRun (the mirror row). Progress
+    is taken from ``progress_km_override`` when provided — computed from our own
+    synced runs — instead of the mirror's ``progress_km`` field, which lags
+    SmashRun's run total and goes stale between goal refreshes. Falls back to the
+    stored field only when no override is given.
 
     Returns None when the row is absent or its goal_km is null (the
     "no goal set on SmashRun" placeholder mark_absent writes).
@@ -30,7 +38,11 @@ def render_goal(row: dict[str, Any] | None) -> dict[str, Any] | None:
     if not row or row.get("goal_km") is None:
         return None
     goal_km = float(row["goal_km"])
-    progress_km = float(row.get("progress_km") or 0.0)
+    progress_km = (
+        float(progress_km_override)
+        if progress_km_override is not None
+        else float(row.get("progress_km") or 0.0)
+    )
     percent = (progress_km / goal_km * 100) if goal_km > 0 else None
     return {
         "goal_mi": round(km_to_miles(goal_km), 1),
@@ -46,13 +58,31 @@ def build_goals_block(
     source_id: UUID | None,
     goals_repo: GoalsRepository,
     today: date,
+    runs_repo: RunsRepository | None = None,
 ) -> dict[str, Any]:
     """Yearly + monthly goal progress, in miles. Each is None when the user
     has no goal stored for the period (or no SmashRun source at all).
+
+    Progress is computed from the user's own synced runs (the same accurate
+    year/month-to-date aggregates the streak card uses) rather than SmashRun's
+    cached goal-progress field, which lags and goes stale.
     """
     if source_id is None:
         return {"yearly": None, "monthly": None}
 
     yearly_row = goals_repo.get_by_period(user_id, source_id, today.year, None)
     monthly_row = goals_repo.get_by_period(user_id, source_id, today.year, today.month)
-    return {"yearly": render_goal(yearly_row), "monthly": render_goal(monthly_row)}
+
+    year_progress_km: float | None = None
+    month_progress_km: float | None = None
+    if runs_repo is not None:
+        stats = runs_repo.get_user_running_stats(user_id) or {}
+        ytd = stats.get("year_to_date_distance_km")
+        mtd = stats.get("month_to_date_distance_km")
+        year_progress_km = float(ytd) if ytd is not None else None
+        month_progress_km = float(mtd) if mtd is not None else None
+
+    return {
+        "yearly": render_goal(yearly_row, year_progress_km),
+        "monthly": render_goal(monthly_row, month_progress_km),
+    }

--- a/backend/jobs/publish_status.py
+++ b/backend/jobs/publish_status.py
@@ -148,7 +148,7 @@ def build_status_data(
         "last_7_days": last_7_days,
         "month_total_mi": round(km_to_miles(month_total_km), 1),
         "year_total_mi": round(km_to_miles(year_total_km), 1),
-        "goals": build_goals_block(user_id, source_id, goals_repo, today),
+        "goals": build_goals_block(user_id, source_id, goals_repo, today, runs_repo),
     }
 
 

--- a/backend/routes/stats.py
+++ b/backend/routes/stats.py
@@ -187,9 +187,10 @@ async def _goals(user_id: UUID) -> dict[str, Any]:
     supabase = get_supabase_client()
     token_repo = TokenRepository(supabase)
     goals_repo = GoalsRepository(supabase)
+    runs_repo = RunsRepository(supabase)
 
     source_id = token_repo.get_source_id_for_user(user_id, "smashrun")
-    return build_goals_block(user_id, source_id, goals_repo, _today_local())
+    return build_goals_block(user_id, source_id, goals_repo, _today_local(), runs_repo)
 
 
 @router.get("/goals")

--- a/backend/tests/test_goals_module.py
+++ b/backend/tests/test_goals_module.py
@@ -89,3 +89,32 @@ def test_build_goals_block_handles_one_period_missing() -> None:
 
     assert result["yearly"] is None
     assert result["monthly"] is not None
+
+
+def test_render_goal_override_uses_runs_not_stale_mirror() -> None:
+    """progress_km_override (from synced runs) wins over the mirror's progress_km."""
+    row = {"goal_km": 209.2, "progress_km": 112.3, "goal_text": "month", "fetched_at": "Z"}
+    result = render_goal(row, progress_km_override=125.2)
+    assert result is not None
+    assert result["progress_mi"] == pytest.approx(km_to_miles(125.2), abs=0.1)  # not 112.3
+
+
+def test_build_goals_block_progress_from_run_stats() -> None:
+    """With a runs_repo, progress comes from the accurate year/month-to-date
+    aggregates — not SmashRun's stale cached goal-progress field."""
+    user_id, source_id = uuid4(), uuid4()
+    repo = MagicMock()
+    repo.get_by_period.side_effect = [
+        {"goal_km": 1931.2, "progress_km": 950.0, "goal_text": "year", "fetched_at": "Z"},
+        {"goal_km": 209.2, "progress_km": 112.3, "goal_text": "month", "fetched_at": "Z"},
+    ]
+    runs_repo = MagicMock()
+    runs_repo.get_user_running_stats.return_value = {
+        "year_to_date_distance_km": 1026.5,
+        "month_to_date_distance_km": 125.2,
+    }
+
+    result = build_goals_block(user_id, source_id, repo, date(2026, 6, 18), runs_repo)
+
+    assert result["yearly"]["progress_mi"] == pytest.approx(km_to_miles(1026.5), abs=0.1)
+    assert result["monthly"]["progress_mi"] == pytest.approx(km_to_miles(125.2), abs=0.1)


### PR DESCRIPTION
## Summary
The dashboard **GOALS card** showed mileage well behind reality:

| | GOALS card | Reality (synced runs = SmashRun) |
|---|---|---|
| June | 69.8 | **77.8 / 78** |
| 2026 | 590.7 | **637.7 / 638** |

**Root cause:** the card rendered SmashRun's cached goal-progress field from the `goals` mirror table, which (a) **goes stale** between refreshes — the yearly row hadn't refreshed in **11 days** (`fetched_at` June 7) — and (b) **lags SmashRun's own run total** even when freshly fetched (the monthly row refreshed *today* still returned 69.8, not 78).

Our own synced runs are accurate (637.7 yr / 77.8 mo, matching SmashRun's displayed totals). So the card should compute **progress** from those, not trust a lagging cache.

## Fix
Compute progress from the same `year/month_to_date_distance_km` aggregates the streak card uses (`user_running_stats`); keep the goal **target** + **text** from the SmashRun mirror. Matches the project principle that *progress is always computed, never stored stale* — while SmashRun stays the source of truth for the goal definition.

- `render_goal` takes an optional `progress_km` override; `build_goals_block` pulls ytd/mtd km from `runs_repo`.
- Callers (`/stats/goals`, `publish_status` job) pass `runs_repo`. `runs_repo` is optional → existing behavior preserved when absent.

## Test plan
- [x] `uv run --project backend python -m pytest backend/tests/` — **116 pass** (2 new: override beats stale mirror; progress reflects run stats)
- [x] ruff + mypy clean on changed files
- [ ] After deploy: GOALS card shows June ~77.8/130 and 2026 ~637.7/1200, matching SmashRun

🤖 Generated with [Claude Code](https://claude.com/claude-code)