### PR TITLE
feat: sync per-mile splits from SmashRun

### DIFF
--- a/backend/routes/sync.py
+++ b/backend/routes/sync.py
@@ -7,6 +7,7 @@ same underlying ``run_user_sync`` helper.
 from __future__ import annotations
 
 import logging
+import time
 from datetime import date, timedelta
 from typing import Any
 from uuid import UUID
@@ -23,11 +24,64 @@ from src.shared.supabase_ops import (
     RunsRepository,
     TokenRepository,
     activity_to_run_dict,
+    split_to_dict,
 )
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["sync"])
+
+# Forward-fill splits inline only for modest sync windows; a full/historical
+# sync would fire thousands of per-activity split calls, so those defer to the
+# dedicated batched backfill (/sync-splits).
+SPLITS_INLINE_MAX = 50
+SPLITS_UNIT = "mi"  # mile-boundary splits — "1st mile / 2nd mile" analysis
+
+
+def store_run_splits(
+    api: SmashRunAPIClient,
+    runs_repo: RunsRepository,
+    run_id: UUID,
+    activity_id: str,
+    unit: str = SPLITS_UNIT,
+) -> int:
+    """Fetch one activity's splits from SmashRun and store them; mark the run.
+
+    Returns the number of splits stored. Idempotent (upsert on
+    run_id,split_unit,split_number).
+    """
+    raw = api.get_activity_splits(activity_id, unit=unit)
+    splits = api.parse_splits(raw)
+    for i, split in enumerate(splits, start=1):
+        runs_repo.upsert_split(run_id, split_to_dict(split, run_id, split_number=i, unit=unit))
+    runs_repo.set_has_splits(run_id, True)
+    return len(splits)
+
+
+def _resolve_access_token(user_id: UUID, token_repo: TokenRepository) -> str:
+    """Current SmashRun access token for the user, refreshing if expired."""
+    tokens = token_repo.get_user_tokens(user_id, "smashrun")
+    if not tokens:
+        raise ValueError(f"No tokens found for user {user_id}. Please authenticate first.")
+
+    access_token = tokens["access_token"]
+    if token_repo.is_token_expired(user_id, "smashrun"):
+        creds = get_smashrun_oauth_credentials()
+        oauth = SmashRunOAuthClient(
+            client_id=creds.get("client_id", ""),
+            client_secret=creds.get("client_secret", ""),
+            redirect_uri="urn:ietf:wg:oauth:2.0:oob",
+        )
+        new_tokens = oauth.refresh_access_token(tokens["refresh_token"])
+        access_token = new_tokens["access_token"]
+        token_repo.save_user_tokens(
+            user_id=user_id,
+            access_token=access_token,
+            refresh_token=new_tokens.get("refresh_token", tokens["refresh_token"]),
+            expires_in=new_tokens.get("expires_in"),
+            source_type="smashrun",
+        )
+    return str(access_token)
 
 
 def run_user_sync(
@@ -56,34 +110,10 @@ def run_user_sync(
     if not source_id:
         raise ValueError(f"No SmashRun source found for user {user_id}")
 
-    tokens = token_repo.get_user_tokens(user_id, "smashrun")
-    if not tokens:
-        raise ValueError(
-            f"No tokens found for user {user_id}. Please authenticate first."
-        )
-
-    access_token = tokens["access_token"]
-    refresh_token = tokens["refresh_token"]
-
-    if token_repo.is_token_expired(user_id, "smashrun"):
-        creds = get_smashrun_oauth_credentials()
-        oauth = SmashRunOAuthClient(
-            client_id=creds.get("client_id", ""),
-            client_secret=creds.get("client_secret", ""),
-            redirect_uri="urn:ietf:wg:oauth:2.0:oob",
-        )
-        new_tokens = oauth.refresh_access_token(refresh_token)
-        access_token = new_tokens["access_token"]
-        new_refresh = new_tokens.get("refresh_token", refresh_token)
-        token_repo.save_user_tokens(
-            user_id=user_id,
-            access_token=access_token,
-            refresh_token=new_refresh,
-            expires_in=new_tokens.get("expires_in"),
-            source_type="smashrun",
-        )
+    access_token = _resolve_access_token(user_id, token_repo)
 
     runs_synced = 0
+    splits_synced = 0
     with SmashRunAPIClient(access_token=access_token) as api:
         activities = api.get_all_activities_since(since_date)
         activities = [
@@ -91,14 +121,25 @@ def run_user_sync(
             for a in activities
             if date.fromisoformat(a.get("startDateTimeLocal", "")[:10]) <= until_date
         ]
+        synced: list[tuple[str, str]] = []  # (run_id, source_activity_id)
         for activity_data in activities:
             try:
                 activity = api.parse_activity(activity_data)
                 run_dict = activity_to_run_dict(activity, user_id, source_id)
-                runs_repo.upsert_run(user_id, source_id, run_dict)
+                run = runs_repo.upsert_run(user_id, source_id, run_dict)
                 runs_synced += 1
+                synced.append((run["id"], activity.activity_id))
             except Exception:  # noqa: BLE001
                 continue
+
+        # Forward-fill splits for this batch (best-effort, never fail the sync).
+        # Skipped on full/large windows — those use the batched backfill instead.
+        if not full and len(synced) <= SPLITS_INLINE_MAX:
+            for run_id, activity_id in synced:
+                try:
+                    splits_synced += store_run_splits(api, runs_repo, UUID(run_id), activity_id)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(f"Split sync failed for activity {activity_id}: {exc}")
 
         # Refresh yearly + monthly goals for the current period if stale or
         # missing. Failure here must not fail the whole sync.
@@ -125,8 +166,53 @@ def run_user_sync(
     return {
         "message": "Sync completed",
         "runs_synced": runs_synced,
+        "splits_synced": splits_synced,
         "since": since_date.isoformat(),
         "until": until_date.isoformat(),
+    }
+
+
+def backfill_user_splits(
+    user_id: UUID,
+    since: date | None = None,
+    until: date | None = None,
+    limit: int = 50,
+    sleep_seconds: float = 0.4,
+) -> dict[str, Any]:
+    """Fetch + store splits for runs that don't have them yet (oldest gap first).
+
+    Batched + rate-limited so it can be called repeatedly until ``remaining`` is
+    0. Returns counts so a CLI can drive it in a loop.
+    """
+    supabase = get_supabase_client()
+    runs_repo = RunsRepository(supabase)
+    token_repo = TokenRepository(supabase)
+
+    pending = runs_repo.get_runs_missing_splits(user_id, since=since, until=until, limit=limit)
+    if not pending:
+        return {"runs_processed": 0, "splits_synced": 0, "remaining": 0}
+
+    access_token = _resolve_access_token(user_id, token_repo)
+    runs_processed = 0
+    splits_synced = 0
+    with SmashRunAPIClient(access_token=access_token) as api:
+        for row in pending:
+            activity_id = row.get("source_activity_id")
+            if not activity_id:
+                continue
+            try:
+                splits_synced += store_run_splits(api, runs_repo, UUID(row["id"]), activity_id)
+                runs_processed += 1
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(f"Backfill split failed for activity {activity_id}: {exc}")
+                runs_repo.set_has_splits(UUID(row["id"]), False)
+            time.sleep(sleep_seconds)  # be gentle with the SmashRun API
+
+    remaining = len(runs_repo.get_runs_missing_splits(user_id, since=since, until=until, limit=1))
+    return {
+        "runs_processed": runs_processed,
+        "splits_synced": splits_synced,
+        "remaining": remaining,  # >0 means call again to continue
     }
 
 
@@ -187,3 +273,19 @@ async def sync_user(
     result = run_user_sync(user_id, since=since, until=until, full=full)
     await invalidate_user(user_id)
     return result
+
+
+@router.post("/sync-splits")
+async def sync_splits(
+    user_id: UUID = Depends(authenticate_request),
+    body: dict[str, Any] = Body(default={}),
+) -> dict[str, Any]:
+    """Backfill per-mile splits for runs that don't have them, one batch per call.
+
+    Body: {since?, until?, limit?}. Returns {runs_processed, splits_synced,
+    remaining}; call repeatedly while ``remaining`` > 0.
+    """
+    since = date.fromisoformat(body["since"]) if body.get("since") else None
+    until = date.fromisoformat(body["until"]) if body.get("until") else None
+    limit = int(body.get("limit", 50))
+    return backfill_user_splits(user_id, since=since, until=until, limit=limit)

--- a/backend/tests/test_sync_splits.py
+++ b/backend/tests/test_sync_splits.py
@@ -1,0 +1,40 @@
+"""Tests for splits sync wiring — store_run_splits + backfill, with mocks."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from backend.routes.sync import store_run_splits
+from src.shared.models import Split
+
+RUN_ID = uuid4()
+
+
+def _splits() -> list[Split]:
+    return [
+        Split(distance=1.0, seconds=480.0, speed=12.0, heartRate=150),
+        Split(distance=2.0, seconds=970.0, speed=12.1, heartRate=155),
+        Split(distance=3.0, seconds=1455.0, speed=12.4, heartRate=158),
+    ]
+
+
+def test_store_run_splits_numbers_and_marks() -> None:
+    api = MagicMock()
+    api.get_activity_splits.return_value = [{"raw": "ignored by mocked parse"}]
+    api.parse_splits.return_value = _splits()
+    repo = MagicMock()
+
+    count = store_run_splits(api, repo, RUN_ID, "activity-123", unit="mi")
+
+    assert count == 3
+    api.get_activity_splits.assert_called_once_with("activity-123", unit="mi")
+    # one upsert per split, with 1-based split_number and unit applied
+    numbers = [c.args[1]["split_number"] for c in repo.upsert_split.call_args_list]
+    units = {c.args[1]["split_unit"] for c in repo.upsert_split.call_args_list}
+    assert numbers == [1, 2, 3]
+    assert units == {"mi"}
+    # mile distances converted to km in the stored rows
+    first = repo.upsert_split.call_args_list[0].args[1]
+    assert first["cumulative_distance_km"] > 1.6  # 1 mi ≈ 1.609 km
+    repo.set_has_splits.assert_called_once_with(RUN_ID, True)

--- a/src/cli/commands/splits.py
+++ b/src/cli/commands/splits.py
@@ -1,0 +1,49 @@
+"""Splits commands for stk CLI — per-mile splits backfill (analysis: PR2)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+from cli import display
+from cli.api import post_request
+
+splits_app = typer.Typer(help="Per-mile splits — backfill from SmashRun.")
+
+
+def backfill(
+    since: str = typer.Option(None, "--since", "-s", help="Only runs on/after YYYY-MM-DD"),
+    limit: int = typer.Option(50, "--limit", "-l", help="Runs per batch"),
+    max_batches: int = typer.Option(200, "--max-batches", help="Safety cap on batches"),
+) -> None:
+    """Fetch + store per-mile splits for runs that don't have them yet.
+
+    Runs in batches (the server rate-limits each one) until none remain.
+
+        stk splits backfill --since 2026-01-01
+    """
+    body: dict[str, Any] = {"limit": limit}
+    if since is not None:
+        body["since"] = since
+
+    total_runs = 0
+    total_splits = 0
+    display.display_sync_progress("Backfilling splits...")
+    for _ in range(max_batches):
+        result = post_request("sync-splits", data=body, timeout=180.0)
+        processed = result.get("runs_processed", 0)
+        synced = result.get("splits_synced", 0)
+        remaining = result.get("remaining", 0)
+        total_runs += processed
+        total_splits += synced
+        display.display_info(f"  {processed} runs, {synced} splits — {remaining} remaining")
+        if remaining == 0 or processed == 0:
+            break
+
+    display.display_sync_progress(
+        f"Backfilled {total_runs} runs ({total_splits} splits)", done=True
+    )
+
+
+splits_app.command(name="backfill")(backfill)

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -17,7 +17,7 @@ import typer
 from rich.console import Console
 
 from cli import __version__
-from cli.commands import auth, plan, runs, stats, sync
+from cli.commands import auth, plan, runs, splits, stats, sync
 
 # Create the main app
 app = typer.Typer(
@@ -32,6 +32,7 @@ app.add_typer(auth.app, name="auth", help="Authentication commands")
 app.add_typer(plan.plan_app, name="plan", help="Adaptive monthly plan")
 app.add_typer(plan.constraint_app, name="constraint", help="Plan constraints (travel, injury)")
 app.add_typer(plan.readiness_app, name="readiness", help="Daily readiness check-in")
+app.add_typer(splits.splits_app, name="splits", help="Per-mile splits")
 
 # Console for output
 console = Console()

--- a/src/shared/supabase_ops/mappers.py
+++ b/src/shared/supabase_ops/mappers.py
@@ -69,7 +69,9 @@ def activity_to_run_dict(activity: Activity, user_id: UUID, source_id: UUID) -> 
         "cadence_min": int(activity.cadence_min) if activity.cadence_min else None,
         "cadence_max": int(activity.cadence_max) if activity.cadence_max else None,
         # Heart rate (cast to int - database expects integer)
-        "heart_rate_average": int(activity.heart_rate_average) if activity.heart_rate_average else None,
+        "heart_rate_average": int(activity.heart_rate_average)
+        if activity.heart_rate_average
+        else None,
         "heart_rate_min": int(activity.heart_rate_min) if activity.heart_rate_min else None,
         "heart_rate_max": int(activity.heart_rate_max) if activity.heart_rate_max else None,
         # Health & subjective (filter "none" string values to NULL for enums)
@@ -86,7 +88,9 @@ def activity_to_run_dict(activity: Activity, user_id: UUID, source_id: UUID) -> 
             else None
         ),
         "temperature_celsius": (float(activity.temperature) if activity.temperature else None),
-        "weather_type": map_weather_type(activity.weather_type.value if activity.weather_type else None),
+        "weather_type": map_weather_type(
+            activity.weather_type.value if activity.weather_type else None
+        ),
         "humidity_percent": int(activity.humidity) if activity.humidity else None,
         "wind_speed_kph": activity.wind_speed,
         # User content
@@ -108,22 +112,42 @@ def activity_to_run_dict(activity: Activity, user_id: UUID, source_id: UUID) -> 
     }
 
 
-def split_to_dict(split: Split, run_id: UUID) -> dict[str, Any]:
+MILES_TO_KM = 1.609344
+
+
+def split_to_dict(
+    split: Split,
+    run_id: UUID,
+    split_number: int | None = None,
+    unit: str | None = None,
+) -> dict[str, Any]:
     """
     Convert Split model to Supabase splits table format.
+
+    ``split_number`` and ``unit`` are assigned at store time (SmashRun's splits
+    payload carries neither). When ``unit == "mi"`` the split's
+    ``cumulative_distance`` comes back in **miles**, so it's converted to km for
+    the canonical ``cumulative_distance_km`` column; ``split_unit`` still records
+    that these are **mile-boundary** splits (what "1st mile / 2nd mile" needs).
 
     Args:
         split: Split model
         run_id: Run UUID (foreign key)
+        split_number: 1-based sequence; falls back to the model's value
+        unit: "mi" or "km"; falls back to the model's value
 
     Returns:
         Dict ready for Supabase insert/upsert
     """
+    resolved_unit = unit if unit is not None else split.split_unit
+    distance = float(split.cumulative_distance)
+    if resolved_unit == "mi":
+        distance *= MILES_TO_KM
     return {
         "run_id": str(run_id),
-        "split_number": split.split_number,
-        "split_unit": split.split_unit,
-        "cumulative_distance_km": float(split.cumulative_distance),
+        "split_number": split_number if split_number is not None else split.split_number,
+        "split_unit": resolved_unit,
+        "cumulative_distance_km": distance,
         "cumulative_seconds": float(split.cumulative_seconds),
         "speed_kph": float(split.speed_kph) if split.speed_kph else None,
         "heart_rate": split.heart_rate,

--- a/src/shared/supabase_ops/runs_repository.py
+++ b/src/shared/supabase_ops/runs_repository.py
@@ -321,6 +321,34 @@ class RunsRepository:
 
         return cast(list[dict[str, Any]], result.data)
 
+    def set_has_splits(self, run_id: UUID, value: bool = True) -> None:
+        """Flag a run as having (or not having) stored splits."""
+        self.supabase.table("runs").update({"has_splits": value}).eq("id", str(run_id)).execute()
+
+    def get_runs_missing_splits(
+        self,
+        user_id: UUID,
+        since: date | None = None,
+        until: date | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Runs that have no stored splits yet (has_splits = FALSE), newest first.
+
+        Returns just the fields a splits backfill needs: id + source_activity_id.
+        """
+        query = (
+            self.supabase.table("runs")
+            .select("id, source_activity_id, start_date")
+            .eq("user_id", str(user_id))
+            .eq("has_splits", False)
+        )
+        if since is not None:
+            query = query.gte("start_date", since.isoformat())
+        if until is not None:
+            query = query.lte("start_date", until.isoformat())
+        result = query.order("start_date", desc=True).limit(limit).execute()
+        return cast(list[dict[str, Any]], result.data)
+
     def delete_run(self, run_id: UUID) -> None:
         """
         Delete a run and all related data (cascades to splits, laps, etc.).

--- a/tests/test_split_mappers.py
+++ b/tests/test_split_mappers.py
@@ -1,0 +1,42 @@
+"""Tests for split_to_dict — the mile→km conversion is the correctness-critical bit."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from src.shared.models import Split
+from src.shared.supabase_ops.mappers import MILES_TO_KM, split_to_dict
+
+RUN_ID = uuid4()
+
+
+def _split(distance: float, seconds: float) -> Split:
+    # alias fields: distance, seconds, speed, heartRate
+    return Split(distance=distance, seconds=seconds, speed=10.0, heartRate=150)
+
+
+def test_mile_split_distance_converted_to_km() -> None:
+    # A mile-boundary split reports distance in miles; the column is km.
+    s = _split(distance=2.0, seconds=900.0)  # 2 miles in
+    row = split_to_dict(s, RUN_ID, split_number=2, unit="mi")
+    assert row["split_unit"] == "mi"
+    assert row["split_number"] == 2
+    assert row["cumulative_distance_km"] == pytest.approx(2.0 * MILES_TO_KM, abs=1e-6)
+    assert row["cumulative_seconds"] == 900.0
+
+
+def test_km_split_distance_not_converted() -> None:
+    s = _split(distance=3.0, seconds=900.0)  # already km
+    row = split_to_dict(s, RUN_ID, split_number=3, unit="km")
+    assert row["split_unit"] == "km"
+    assert row["cumulative_distance_km"] == pytest.approx(3.0, abs=1e-6)
+
+
+def test_falls_back_to_model_values_when_args_omitted() -> None:
+    s = Split(distance=1.0, seconds=480.0, split_number=1, split_unit="km")
+    row = split_to_dict(s, RUN_ID)
+    assert row["split_number"] == 1
+    assert row["split_unit"] == "km"
+    assert row["cumulative_distance_km"] == pytest.approx(1.0, abs=1e-6)


### PR DESCRIPTION
## Summary
The splits table, `Split` model, and SmashRun client fetch all existed — but **nothing ever stored splits** (`has_splits` hardcoded false, sync never fetched them). So negative-split / per-mile analysis had **no data**. This wires splits end-to-end so it does.

- **`mappers.split_to_dict`** — takes `split_number` + `unit` (SmashRun's payload carries neither) and converts **mile-boundary distance → km** for the canonical `cumulative_distance_km` column, tagging `split_unit="mi"` (what "1st mile / 2nd mile" needs).
- **`runs_repository`** — `set_has_splits` + `get_runs_missing_splits`.
- **`sync.store_run_splits`** — fetch one activity's mile splits, upsert, mark the run.
- **Forward-fill** — `run_user_sync` stores splits for each newly synced run (best-effort, never fails the run sync); **skipped on full/large windows (>50)** to avoid thousands of per-activity calls.
- **Backfill** — `backfill_user_splits` + `POST /sync-splits`: batched, rate-limited (0.4s/run), returns `remaining` so a caller loops until 0. Driven by **`stk splits backfill --since YYYY-MM-DD`**.

## Test plan
- [x] `uv run pytest tests/` (49) + `uv run --project backend pytest backend/tests/` (117) pass
- [x] mile→km conversion, 1-based numbering, unit tagging, has_splits marking covered
- [x] ruff clean
- [ ] After merge + deploy: `stk splits backfill --since 2026-01-01` to populate 2026; tomorrow's run forward-fills automatically
- [ ] Reviewer: SmashRun splits = 1 API call/activity — confirm the >50 inline guard + backfill rate-limit are acceptable

## Follow-up (PR2)
Negative-split analysis: per-mile pace, negative-split rate, avg 1st vs last mile, fade — endpoint + `stk splits show`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)