### PR TITLE
feat: negative-split analysis over per-mile splits

### DIFF
--- a/backend/routes/stats.py
+++ b/backend/routes/stats.py
@@ -13,6 +13,7 @@ from zoneinfo import ZoneInfo
 from backend.auth import authenticate_request
 from backend.cache import cached
 from backend.goals import build_goals_block
+from backend.splits_analysis import analyze_run, summarize
 from backend.streaks import compute_streaks
 from fastapi import APIRouter, Depends, Query
 from src.shared.supabase_client import get_supabase_client
@@ -206,3 +207,38 @@ async def get_goals(
     GoalProgress structure.
     """
     return await _goals(user_id)
+
+
+@router.get("/splits")
+def get_split_analysis(
+    user_id: UUID = Depends(authenticate_request),
+    since: date | None = Query(default=None, description="Only runs on/after this date"),
+    until: date | None = Query(default=None, description="Only runs on/before this date"),
+    limit: int = Query(default=30, ge=1, le=200, description="Most-recent N runs with splits"),
+) -> dict[str, Any]:
+    """Negative-split / per-mile pace analysis over recent runs that have splits.
+
+    Returns a headline summary (negative-split rate, avg 1st vs last mile, fade)
+    plus a per-run breakdown. Empty when no runs have splits yet (run
+    ``stk splits backfill`` first).
+    """
+    supabase = get_supabase_client()
+    runs_repo = RunsRepository(supabase)
+    runs = runs_repo.get_runs_with_splits(user_id, since=since, until=until, limit=limit)
+
+    per_run: list[dict[str, Any]] = []
+    for run in runs:
+        rows = runs_repo.get_splits_for_run(UUID(run["id"]))
+        analysis = analyze_run(rows)
+        if analysis is None:
+            continue
+        per_run.append(
+            {
+                "run_id": run["id"],
+                "date": run.get("start_date"),
+                "distance_km": run.get("distance_km"),
+                **{k: v for k, v in analysis.items() if k != "splits"},
+            }
+        )
+
+    return {"summary": summarize(list(per_run)), "runs": per_run}

--- a/backend/splits_analysis.py
+++ b/backend/splits_analysis.py
@@ -1,0 +1,98 @@
+"""Per-mile split analysis — pure functions over stored splits.
+
+Splits are stored cumulatively (``cumulative_distance_km`` / ``cumulative_seconds``
+at each mile boundary). These functions difference them into per-mile paces and
+derive negative-split / fade stats. No I/O — trivially unit-testable.
+
+Paces are min/mile (the runner's unit), computed from canonical km.
+"""
+
+from __future__ import annotations
+
+from statistics import mean
+from typing import Any
+
+KM_TO_MILES = 0.621371
+
+
+def per_mile_splits(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Difference cumulative split rows into per-mile pieces (pace in min/mile).
+
+    Rows need ``split_number``, ``cumulative_distance_km``, ``cumulative_seconds``.
+    Degenerate pieces (non-positive distance/time) are dropped. The final partial
+    mile is kept but its pace is still per-mile-normalized.
+    """
+    ordered = sorted(rows, key=lambda r: r["split_number"])
+    out: list[dict[str, Any]] = []
+    prev_km = 0.0
+    prev_s = 0.0
+    for r in ordered:
+        cum_km = float(r["cumulative_distance_km"])
+        cum_s = float(r["cumulative_seconds"])
+        dist_mi = (cum_km - prev_km) * KM_TO_MILES
+        secs = cum_s - prev_s
+        prev_km, prev_s = cum_km, cum_s
+        if dist_mi <= 0 or secs <= 0:
+            continue
+        out.append(
+            {
+                "split_number": r["split_number"],
+                "distance_mi": round(dist_mi, 3),
+                "seconds": round(secs, 1),
+                "pace_min_per_mi": round((secs / dist_mi) / 60.0, 2),
+                "heart_rate": r.get("heart_rate"),
+            }
+        )
+    return out
+
+
+def analyze_run(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Per-run split stats, or None when there aren't ≥2 usable splits."""
+    splits = per_mile_splits(rows)
+    if len(splits) < 2:
+        return None
+    paces = [s["pace_min_per_mi"] for s in splits]
+    n = len(paces)
+    half = n // 2
+    first_half = mean(paces[:half]) if half else paces[0]
+    second_half = mean(paces[half:])
+    return {
+        "n_splits": n,
+        "first_mile_pace": paces[0],
+        "last_mile_pace": paces[-1],
+        "first_half_pace": round(first_half, 2),
+        "second_half_pace": round(second_half, 2),
+        # Negative split = second half faster (lower pace) than first.
+        "negative_split": second_half < first_half,
+        "fastest_mile_pace": min(paces),
+        "slowest_mile_pace": max(paces),
+        # +% = slowed down over the run (fade); −% = sped up (negative split).
+        "fade_pct": round((paces[-1] - paces[0]) / paces[0] * 100, 1),
+        "splits": splits,
+    }
+
+
+def summarize(run_analyses: list[dict[str, Any] | None]) -> dict[str, Any]:
+    """Aggregate per-run analyses into a headline summary."""
+    analyses = [a for a in run_analyses if a]
+    if not analyses:
+        return {"runs_analyzed": 0}
+    neg = sum(1 for a in analyses if a["negative_split"])
+    return {
+        "runs_analyzed": len(analyses),
+        "negative_split_rate_pct": round(neg / len(analyses) * 100, 1),
+        "avg_first_mile_pace": round(mean(a["first_mile_pace"] for a in analyses), 2),
+        "avg_last_mile_pace": round(mean(a["last_mile_pace"] for a in analyses), 2),
+        "avg_fade_pct": round(mean(a["fade_pct"] for a in analyses), 1),
+    }
+
+
+def format_pace(min_per_mi: float | None) -> str | None:
+    """9.51 → '9:31 /mi'."""
+    if min_per_mi is None:
+        return None
+    minutes = int(min_per_mi)
+    seconds = round((min_per_mi - minutes) * 60)
+    if seconds == 60:
+        minutes, seconds = minutes + 1, 0
+    return f"{minutes}:{seconds:02d} /mi"

--- a/backend/tests/test_splits_analysis.py
+++ b/backend/tests/test_splits_analysis.py
@@ -1,0 +1,69 @@
+"""Tests for backend.splits_analysis — pure per-mile split math."""
+
+from __future__ import annotations
+
+from backend.splits_analysis import (
+    KM_TO_MILES,
+    analyze_run,
+    format_pace,
+    per_mile_splits,
+    summarize,
+)
+
+MI_KM = 1.0 / KM_TO_MILES  # one mile in km
+
+
+def _rows(paces_sec_per_mile: list[float]) -> list[dict]:
+    """Build cumulative split rows from a list of per-mile durations (seconds)."""
+    rows = []
+    cum_km = 0.0
+    cum_s = 0.0
+    for i, secs in enumerate(paces_sec_per_mile, start=1):
+        cum_km += MI_KM
+        cum_s += secs
+        rows.append(
+            {"split_number": i, "cumulative_distance_km": cum_km, "cumulative_seconds": cum_s}
+        )
+    return rows
+
+
+def test_per_mile_splits_differences_cumulative() -> None:
+    splits = per_mile_splits(_rows([480.0, 470.0]))  # 8:00, 7:50
+    assert len(splits) == 2
+    assert splits[0]["pace_min_per_mi"] == 8.0
+    assert splits[1]["pace_min_per_mi"] == round(470 / 60, 2)
+
+
+def test_negative_split_detected() -> None:
+    # second half faster than first → negative split
+    a = analyze_run(_rows([540.0, 540.0, 480.0, 480.0]))  # 9:00,9:00,8:00,8:00
+    assert a is not None
+    assert a["negative_split"] is True
+    assert a["fade_pct"] < 0  # sped up
+    assert a["first_mile_pace"] == 9.0
+    assert a["last_mile_pace"] == 8.0
+
+
+def test_positive_split_is_not_negative() -> None:
+    a = analyze_run(_rows([480.0, 480.0, 540.0, 540.0]))  # faded
+    assert a is not None
+    assert a["negative_split"] is False
+    assert a["fade_pct"] > 0
+
+
+def test_single_split_returns_none() -> None:
+    assert analyze_run(_rows([480.0])) is None
+
+
+def test_summarize_rate_and_averages() -> None:
+    neg = analyze_run(_rows([540.0, 480.0]))
+    pos = analyze_run(_rows([480.0, 540.0]))
+    out = summarize([neg, pos, None])
+    assert out["runs_analyzed"] == 2
+    assert out["negative_split_rate_pct"] == 50.0
+
+
+def test_format_pace() -> None:
+    assert format_pace(9.5) == "9:30 /mi"
+    assert format_pace(7.99) == "7:59 /mi"
+    assert format_pace(None) is None

--- a/src/cli/commands/splits.py
+++ b/src/cli/commands/splits.py
@@ -1,15 +1,66 @@
-"""Splits commands for stk CLI — per-mile splits backfill (analysis: PR2)."""
+"""Splits commands for stk CLI — backfill + negative-split analysis."""
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import typer
 
-from cli import display
+from cli import api, display
 from cli.api import post_request
 
-splits_app = typer.Typer(help="Per-mile splits — backfill from SmashRun.")
+splits_app = typer.Typer(help="Per-mile splits — backfill + analysis.")
+
+
+def _fmt_pace(p: float | None) -> str:
+    if p is None:
+        return "—"
+    m = int(p)
+    s = round((p - m) * 60)
+    if s == 60:
+        m, s = m + 1, 0
+    return f"{m}:{s:02d}"
+
+
+def show(
+    since: str = typer.Option(None, "--since", "-s", help="Only runs on/after YYYY-MM-DD"),
+    limit: int = typer.Option(30, "--limit", "-l", help="Most-recent N runs with splits"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
+) -> None:
+    """Negative-split analysis: per-mile pace, 1st-vs-last mile, fade.
+
+    stk splits show --since 2026-06-01
+    """
+    params: dict[str, Any] = {"limit": limit}
+    if since is not None:
+        params["since"] = since
+    data = api.request("stats/splits", params)
+
+    if json_output:
+        print(json.dumps(data, indent=2, default=str))
+        return
+
+    s = data.get("summary", {})
+    if not s.get("runs_analyzed"):
+        display.display_info("No runs with splits yet. Run 'stk splits backfill' first.")
+        return
+    display.console.print(
+        f"[bold]Splits — {s['runs_analyzed']} runs[/bold]  "
+        f"negative-split rate [cyan]{s['negative_split_rate_pct']}%[/cyan]"
+    )
+    display.console.print(
+        f"  avg 1st mile {_fmt_pace(s['avg_first_mile_pace'])}  ·  "
+        f"avg last mile {_fmt_pace(s['avg_last_mile_pace'])}  ·  "
+        f"avg fade {s['avg_fade_pct']:+}%"
+    )
+    display.console.print()
+    for r in data.get("runs", [])[:limit]:
+        flag = "📉 neg" if r["negative_split"] else f"{r['fade_pct']:+}%"
+        display.console.print(
+            f"  {r['date']}  {_fmt_pace(r['first_mile_pace'])}→{_fmt_pace(r['last_mile_pace'])}"
+            f"  fastest {_fmt_pace(r['fastest_mile_pace'])}  [{flag}]"
+        )
 
 
 def backfill(
@@ -47,3 +98,4 @@ def backfill(
 
 
 splits_app.command(name="backfill")(backfill)
+splits_app.command(name="show")(show)

--- a/src/shared/supabase_ops/runs_repository.py
+++ b/src/shared/supabase_ops/runs_repository.py
@@ -321,6 +321,27 @@ class RunsRepository:
 
         return cast(list[dict[str, Any]], result.data)
 
+    def get_runs_with_splits(
+        self,
+        user_id: UUID,
+        since: date | None = None,
+        until: date | None = None,
+        limit: int = 30,
+    ) -> list[dict[str, Any]]:
+        """Runs that have stored splits (has_splits = TRUE), newest first."""
+        query = (
+            self.supabase.table("runs")
+            .select("id, start_date, distance_km")
+            .eq("user_id", str(user_id))
+            .eq("has_splits", True)
+        )
+        if since is not None:
+            query = query.gte("start_date", since.isoformat())
+        if until is not None:
+            query = query.lte("start_date", until.isoformat())
+        result = query.order("start_date", desc=True).limit(limit).execute()
+        return cast(list[dict[str, Any]], result.data)
+
     def set_has_splits(self, run_id: UUID, value: bool = True) -> None:
         """Flag a run as having (or not having) stored splits."""
         self.supabase.table("runs").update({"has_splits": value}).eq("id", str(run_id)).execute()


### PR DESCRIPTION
## Summary
**Stacked on #95** (splits sync) — base branch `feat/splits-sync`. Turns the stored mile splits into the analysis you wanted: negative splits, 1st-vs-last mile, fade.

- **`backend/splits_analysis.py`** (pure): `per_mile_splits` differences cumulative rows into per-mile paces (min/mile); `analyze_run` derives negative-split (2nd half faster), first/last/fastest/slowest mile, fade %; `summarize` aggregates negative-split rate + averages across runs.
- **`GET /stats/splits?since=&until=&limit=`** — headline summary + per-run breakdown over recent runs that have splits.
- **`runs_repository.get_runs_with_splits`**.
- **`stk splits show`** — rendered summary + per-run pace lines (`--json` for raw).

## Merge order
Merge **#95 first**, then this. (Base is `feat/splits-sync`; GitHub retargets to `main` after #95 merges.)

## Test plan
- [x] `uv run --project backend pytest backend/tests/` (123) + `uv run pytest tests/` (49) pass
- [x] negative vs positive detection, differencing, single-split guard, summary rate/avgs, pace formatting
- [x] ruff + mypy clean on new code
- [ ] After both merge + deploy + `stk splits backfill`: `stk splits show --since 2026-06-01` shows real negative-split rate / 1st-vs-last mile

🤖 Generated with [Claude Code](https://claude.com/claude-code)