### PR TITLE
feat: athlete workout tracker — schema + API (SB-190, SB-191)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3,7 +3,7 @@
 import logging
 
 from backend.config import get_settings
-from backend.routes import auth_routes, metrics, plan, runs, stats, sync
+from backend.routes import auth_routes, metrics, plan, runs, stats, sync, workouts
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -45,6 +45,7 @@ def create_app() -> FastAPI:
     app.include_router(auth_routes.router)
     app.include_router(metrics.router)
     app.include_router(plan.router)
+    app.include_router(workouts.router)
 
     return app
 

--- a/backend/routes/workouts.py
+++ b/backend/routes/workouts.py
@@ -1,0 +1,147 @@
+"""/workouts/* — Athlete Training Tracker: exercise catalog, templates, sessions.
+
+JWT-gated; the backend uses the service-role key, so repositories scope every
+query by ``user_id``. Templates and sessions are created with their children
+(items / sets) inline and returned with them nested. See the Athlete Training
+Tracker epic (SB-189).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from uuid import UUID
+
+from backend.auth import authenticate_request
+from backend.cache import invalidate_user
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from src.shared.models.workout import (
+    Exercise,
+    WorkoutSession,
+    WorkoutSessionCreate,
+    WorkoutTemplate,
+    WorkoutTemplateCreate,
+)
+from src.shared.supabase_client import get_supabase_client
+from src.shared.supabase_ops import (
+    ExercisesRepository,
+    WorkoutSessionsRepository,
+    WorkoutTemplatesRepository,
+)
+
+router = APIRouter(prefix="/workouts", tags=["workouts"])
+
+
+# ---------------------------------------------------------------- catalog
+
+
+@router.get("/exercises", response_model=list[Exercise])
+def list_exercises(
+    _user_id: UUID = Depends(authenticate_request),
+) -> list[Exercise]:
+    rows = ExercisesRepository(get_supabase_client()).list_all()
+    return [Exercise(**r) for r in rows]
+
+
+# ---------------------------------------------------------------- templates
+
+
+@router.post("/templates", response_model=WorkoutTemplate, status_code=status.HTTP_201_CREATED)
+async def create_template(
+    body: WorkoutTemplateCreate,
+    user_id: UUID = Depends(authenticate_request),
+) -> WorkoutTemplate:
+    supabase = get_supabase_client()
+    valid = ExercisesRepository(supabase).keys()
+    unknown = {i.exercise_key for i in body.items} - valid
+    if unknown:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, f"Unknown exercise(s): {sorted(unknown)}")
+
+    row = WorkoutTemplatesRepository(supabase).create(
+        user_id, body.model_dump(mode="json", exclude_none=True)
+    )
+    await invalidate_user(user_id)
+    return WorkoutTemplate(**row)
+
+
+@router.get("/templates", response_model=list[WorkoutTemplate])
+def list_templates(
+    user_id: UUID = Depends(authenticate_request),
+) -> list[WorkoutTemplate]:
+    rows = WorkoutTemplatesRepository(get_supabase_client()).list(user_id)
+    return [WorkoutTemplate(**r) for r in rows]
+
+
+@router.get("/templates/{template_id}", response_model=WorkoutTemplate)
+def get_template(
+    template_id: UUID,
+    user_id: UUID = Depends(authenticate_request),
+) -> WorkoutTemplate:
+    row = WorkoutTemplatesRepository(get_supabase_client()).get(user_id, template_id)
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Template not found")
+    return WorkoutTemplate(**row)
+
+
+@router.delete("/templates/{template_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_template(
+    template_id: UUID,
+    user_id: UUID = Depends(authenticate_request),
+) -> None:
+    if not WorkoutTemplatesRepository(get_supabase_client()).delete(user_id, template_id):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Template not found")
+    await invalidate_user(user_id)
+
+
+# ---------------------------------------------------------------- sessions
+
+
+@router.post("/sessions", response_model=WorkoutSession, status_code=status.HTTP_201_CREATED)
+async def create_session(
+    body: WorkoutSessionCreate,
+    user_id: UUID = Depends(authenticate_request),
+) -> WorkoutSession:
+    supabase = get_supabase_client()
+    valid = ExercisesRepository(supabase).keys()
+    unknown = {s.exercise_key for s in body.sets} - valid
+    if unknown:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, f"Unknown exercise(s): {sorted(unknown)}")
+
+    row = WorkoutSessionsRepository(supabase).create(
+        user_id, body.model_dump(mode="json", exclude_none=True)
+    )
+    await invalidate_user(user_id)
+    return WorkoutSession(**row)
+
+
+@router.get("/sessions", response_model=list[WorkoutSession])
+def list_sessions(
+    user_id: UUID = Depends(authenticate_request),
+    date_from: date | None = Query(default=None),
+    date_to: date | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+) -> list[WorkoutSession]:
+    rows = WorkoutSessionsRepository(get_supabase_client()).list(
+        user_id, date_from=date_from, date_to=date_to, limit=limit
+    )
+    return [WorkoutSession(**r) for r in rows]
+
+
+@router.get("/sessions/{session_id}", response_model=WorkoutSession)
+def get_session(
+    session_id: UUID,
+    user_id: UUID = Depends(authenticate_request),
+) -> WorkoutSession:
+    row = WorkoutSessionsRepository(get_supabase_client()).get(user_id, session_id)
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
+    return WorkoutSession(**row)
+
+
+@router.delete("/sessions/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_session(
+    session_id: UUID,
+    user_id: UUID = Depends(authenticate_request),
+) -> None:
+    if not WorkoutSessionsRepository(get_supabase_client()).delete(user_id, session_id):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
+    await invalidate_user(user_id)

--- a/backend/tests/test_workout_repository.py
+++ b/backend/tests/test_workout_repository.py
@@ -1,0 +1,114 @@
+"""Round-trip tests for the workout repositories (SB-191), via a fake client."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from uuid import uuid4
+
+from src.shared.supabase_ops.workout_repository import (
+    WorkoutSessionsRepository,
+    WorkoutTemplatesRepository,
+)
+
+
+class _FakeQuery:
+    def __init__(self, table: str, store: dict):
+        self.table = table
+        self.store = store
+        self._mode = "select"
+        self._payload: Any = None
+
+    def select(self, *a: Any, **k: Any) -> _FakeQuery:
+        return self
+
+    def eq(self, *a: Any, **k: Any) -> _FakeQuery:
+        return self
+
+    def gte(self, *a: Any, **k: Any) -> _FakeQuery:
+        return self
+
+    def lte(self, *a: Any, **k: Any) -> _FakeQuery:
+        return self
+
+    def order(self, *a: Any, **k: Any) -> _FakeQuery:
+        return self
+
+    def limit(self, *a: Any, **k: Any) -> _FakeQuery:
+        return self
+
+    def insert(self, payload: Any) -> _FakeQuery:
+        self._mode, self._payload = "insert", payload
+        return self
+
+    def delete(self) -> _FakeQuery:
+        self._mode = "delete"
+        return self
+
+    def execute(self) -> SimpleNamespace:
+        if self._mode == "insert":
+            rows = self._payload if isinstance(self._payload, list) else [self._payload]
+            out = []
+            for r in rows:
+                row = {"id": str(uuid4()), **r} if "id" not in r else dict(r)
+                self.store.setdefault(self.table, []).append(row)
+                out.append(row)
+            return SimpleNamespace(data=out)
+        if self._mode == "delete":
+            data = self.store.get(self.table, [])
+            self.store[self.table] = []
+            return SimpleNamespace(data=data)
+        return SimpleNamespace(data=list(self.store.get(self.table, [])))
+
+
+class _FakeSupabase:
+    def __init__(self) -> None:
+        self.store: dict[str, list[dict[str, Any]]] = {}
+
+    def table(self, name: str) -> _FakeQuery:
+        return _FakeQuery(name, self.store)
+
+
+def test_template_create_round_trips_with_items():
+    supa = _FakeSupabase()
+    repo = WorkoutTemplatesRepository(supa)
+    user = uuid4()
+    out = repo.create(
+        user,
+        {
+            "name": "Saturday Circuit",
+            "type": "circuit",
+            "rounds": 3,
+            "items": [
+                {"exercise_key": "jump_rope", "position": 0, "target_duration_seconds": 180},
+                {"exercise_key": "pushups", "position": 1, "target_duration_seconds": 30},
+            ],
+        },
+    )
+    assert out["name"] == "Saturday Circuit"
+    assert out["rounds"] == 3
+    assert len(out["items"]) == 2
+    assert all(i["user_id"] == str(user) for i in out["items"])
+    assert all(i["template_id"] == out["id"] for i in out["items"])
+
+
+def test_session_create_round_trips_with_sets():
+    supa = _FakeSupabase()
+    repo = WorkoutSessionsRepository(supa)
+    user = uuid4()
+    out = repo.create(
+        user,
+        {
+            "session_date": "2026-06-20",
+            "type": "test",
+            "sets": [
+                {"exercise_key": "40yd_dash", "distance_m": 36.58, "time_seconds": 5.42},
+                {"exercise_key": "pushups", "round_number": 1, "reps": 22},
+            ],
+        },
+    )
+    assert out["session_date"] == "2026-06-20"
+    assert len(out["sets"]) == 2
+    dash = next(s for s in out["sets"] if s["exercise_key"] == "40yd_dash")
+    assert dash["time_seconds"] == 5.42
+    assert all(s["session_id"] == out["id"] for s in out["sets"])

--- a/src/shared/models/__init__.py
+++ b/src/shared/models/__init__.py
@@ -46,6 +46,19 @@ from .units import (
     km_to_miles,
     miles_to_km,
 )
+from .workout import (
+    Exercise,
+    ExerciseCategory,
+    ExerciseSet,
+    ExerciseSetCreate,
+    TemplateItem,
+    TemplateItemCreate,
+    WorkoutSession,
+    WorkoutSessionCreate,
+    WorkoutTemplate,
+    WorkoutTemplateCreate,
+    WorkoutType,
+)
 
 __all__ = [
     # Main models
@@ -65,6 +78,18 @@ __all__ = [
     "GoalPeriod",
     "GoalComparator",
     "GoalStatus",
+    # Workouts
+    "Exercise",
+    "ExerciseCategory",
+    "WorkoutType",
+    "TemplateItem",
+    "TemplateItemCreate",
+    "WorkoutTemplate",
+    "WorkoutTemplateCreate",
+    "ExerciseSet",
+    "ExerciseSetCreate",
+    "WorkoutSession",
+    "WorkoutSessionCreate",
     # Planning
     "ActualEntry",
     "PlanConstraint",

--- a/src/shared/models/workout.py
+++ b/src/shared/models/workout.py
@@ -1,0 +1,149 @@
+"""Athlete Training Tracker — workout models (SB-190).
+
+Structured S&C workouts: a coach's template, logged sessions, and the per-
+exercise sets actually performed. Mirrors the schema in
+supabase/migrations/20260620000000_create_workouts.sql. Additive to the metric
+engine; see the Athlete Training Tracker epic.
+
+Loads are canonical kg, distances canonical m (convert at the presentation edge).
+Each exercise records only the dimensions it uses (reps / duration_seconds /
+load_kg / distance_m / time_seconds) — same wide-nullable approach as splits.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from enum import StrEnum
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class ExerciseCategory(StrEnum):
+    strength = "strength"
+    speed = "speed"
+    power = "power"
+    mobility = "mobility"
+    cardio = "cardio"
+    test = "test"  # benchmark tests: 40yd dash, vertical, broad jump, 5-10-5
+
+
+class WorkoutType(StrEnum):
+    circuit = "circuit"
+    intervals = "intervals"
+    test = "test"
+    session = "session"
+
+
+class Exercise(BaseModel):
+    """A row in the global movement catalog."""
+
+    key: str
+    display_name: str
+    category: ExerciseCategory
+    measures: list[str] = Field(default_factory=list)
+    is_benchmark: bool = False
+
+
+# --------------------------------------------------------------------------- #
+# Templates (the coach's prescribed plan)
+# --------------------------------------------------------------------------- #
+class TemplateItemCreate(BaseModel):
+    """One prescribed exercise within a template."""
+
+    exercise_key: str
+    position: int = 0
+    target_reps: int | None = Field(default=None, ge=0)
+    target_duration_seconds: float | None = Field(default=None, ge=0)
+    target_load_kg: float | None = Field(default=None, ge=0)
+    target_distance_m: float | None = Field(default=None, ge=0)
+    rest_seconds: float | None = Field(default=None, ge=0)
+    variant: str | None = None
+    notes: str | None = None
+
+
+class TemplateItem(TemplateItemCreate):
+    id: UUID
+    user_id: UUID
+    template_id: UUID
+
+
+class WorkoutTemplateCreate(BaseModel):
+    """Input for creating a template, optionally with its items inline."""
+
+    name: str
+    type: WorkoutType = WorkoutType.circuit
+    rounds: int = Field(default=1, ge=1)
+    source: str | None = None
+    notes: str | None = None
+    items: list[TemplateItemCreate] = Field(default_factory=list)
+
+
+class WorkoutTemplate(BaseModel):
+    """A stored template."""
+
+    id: UUID
+    user_id: UUID
+    name: str
+    type: WorkoutType
+    rounds: int
+    source: str | None = None
+    notes: str | None = None
+    items: list[TemplateItem] = Field(default_factory=list)
+    created_at: datetime | None = None
+
+
+# --------------------------------------------------------------------------- #
+# Sessions + sets (the actual performance)
+# --------------------------------------------------------------------------- #
+class ExerciseSetCreate(BaseModel):
+    """One logged set. Fills only the dimensions the exercise uses."""
+
+    exercise_key: str
+    round_number: int | None = Field(default=None, ge=1)
+    set_index: int | None = Field(default=None, ge=1)
+    variant: str | None = None
+    reps: int | None = Field(default=None, ge=0)
+    duration_seconds: float | None = Field(default=None, ge=0)
+    load_kg: float | None = Field(default=None, ge=0)
+    distance_m: float | None = Field(default=None, ge=0)
+    time_seconds: float | None = Field(default=None, ge=0)
+    rpe: int | None = Field(default=None, ge=1, le=10)
+    started_at: datetime | None = None
+    ended_at: datetime | None = None
+    notes: str | None = None
+    extra: dict[str, Any] | None = None
+
+
+class ExerciseSet(ExerciseSetCreate):
+    id: UUID
+    user_id: UUID
+    session_id: UUID
+
+
+class WorkoutSessionCreate(BaseModel):
+    """Input for logging a session, optionally with its sets inline."""
+
+    session_date: date
+    template_id: UUID | None = None
+    type: WorkoutType = WorkoutType.circuit
+    total_minutes: float | None = Field(default=None, ge=0)
+    how_felt: str | None = None
+    notes: str | None = None
+    sets: list[ExerciseSetCreate] = Field(default_factory=list)
+
+
+class WorkoutSession(BaseModel):
+    """A stored session with its sets."""
+
+    id: UUID
+    user_id: UUID
+    session_date: date
+    template_id: UUID | None = None
+    type: WorkoutType
+    total_minutes: float | None = None
+    how_felt: str | None = None
+    notes: str | None = None
+    sets: list[ExerciseSet] = Field(default_factory=list)
+    created_at: datetime | None = None

--- a/src/shared/supabase_ops/__init__.py
+++ b/src/shared/supabase_ops/__init__.py
@@ -13,6 +13,11 @@ from .planning_repository import (
     ReadinessRepository,
 )
 from .runs_repository import RunsRepository
+from .workout_repository import (
+    ExercisesRepository,
+    WorkoutSessionsRepository,
+    WorkoutTemplatesRepository,
+)
 from .token_repository import TokenRepository
 from .users_repository import UsersRepository
 
@@ -27,6 +32,9 @@ __all__ = [
     "RunsRepository",
     "TokenRepository",
     "UsersRepository",
+    "ExercisesRepository",
+    "WorkoutTemplatesRepository",
+    "WorkoutSessionsRepository",
     "activity_to_run_dict",
     "split_to_dict",
 ]

--- a/src/shared/supabase_ops/workout_repository.py
+++ b/src/shared/supabase_ops/workout_repository.py
@@ -1,0 +1,171 @@
+"""Repositories for the Athlete Training Tracker tables (SB-191).
+
+exercises (catalog) + workout_templates/template_items + workout_sessions/
+exercise_sets. Like the other repos, the backend uses the service-role key, so
+every query scopes by ``user_id`` itself; the DB policies are a second guard.
+
+Templates and sessions are created with their children inline (items / sets) in
+one call, and read back with the children nested.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import date
+from typing import Any, cast
+from uuid import UUID
+
+from supabase import Client
+
+
+class ExercisesRepository:
+    """Read-only global movement catalog."""
+
+    def __init__(self, supabase: Client):
+        self.supabase = supabase
+
+    def list_all(self) -> list[dict[str, Any]]:
+        result = (
+            self.supabase.table("exercises").select("*").order("category").order("key").execute()
+        )
+        return cast(list[dict[str, Any]], result.data)
+
+    def keys(self) -> set[str]:
+        result = self.supabase.table("exercises").select("key").execute()
+        return {r["key"] for r in cast(list[dict[str, Any]], result.data)}
+
+
+class WorkoutTemplatesRepository:
+    """Per-user workout templates (the coach's plan) + their items."""
+
+    def __init__(self, supabase: Client):
+        self.supabase = supabase
+
+    def create(self, user_id: UUID, payload: dict[str, Any]) -> dict[str, Any]:
+        items: Sequence[dict[str, Any]] = payload.pop("items", []) or []
+        row = (
+            self.supabase.table("workout_templates")
+            .insert({**payload, "user_id": str(user_id)})
+            .execute()
+        )
+        template = cast(list[dict[str, Any]], row.data)[0]
+        if items:
+            item_rows = [
+                {**it, "user_id": str(user_id), "template_id": template["id"]} for it in items
+            ]
+            self.supabase.table("template_items").insert(item_rows).execute()
+        got = self.get(user_id, UUID(template["id"]))
+        assert got is not None
+        return got
+
+    def list(self, user_id: UUID) -> list[dict[str, Any]]:
+        result = (
+            self.supabase.table("workout_templates")
+            .select("*")
+            .eq("user_id", str(user_id))
+            .order("created_at", desc=True)
+            .execute()
+        )
+        return cast(list[dict[str, Any]], result.data)
+
+    def get(self, user_id: UUID, template_id: UUID) -> dict[str, Any] | None:
+        result = (
+            self.supabase.table("workout_templates")
+            .select("*")
+            .eq("id", str(template_id))
+            .eq("user_id", str(user_id))
+            .execute()
+        )
+        rows = cast(list[dict[str, Any]], result.data)
+        if not rows:
+            return None
+        template = rows[0]
+        items = (
+            self.supabase.table("template_items")
+            .select("*")
+            .eq("template_id", str(template_id))
+            .order("position")
+            .execute()
+        )
+        template["items"] = cast(list[dict[str, Any]], items.data)
+        return template
+
+    def delete(self, user_id: UUID, template_id: UUID) -> bool:
+        result = (
+            self.supabase.table("workout_templates")
+            .delete()
+            .eq("id", str(template_id))
+            .eq("user_id", str(user_id))
+            .execute()
+        )
+        return bool(cast(list[dict[str, Any]], result.data))
+
+
+class WorkoutSessionsRepository:
+    """Per-user logged sessions + their exercise sets."""
+
+    def __init__(self, supabase: Client):
+        self.supabase = supabase
+
+    def create(self, user_id: UUID, payload: dict[str, Any]) -> dict[str, Any]:
+        sets: Sequence[dict[str, Any]] = payload.pop("sets", []) or []
+        row = (
+            self.supabase.table("workout_sessions")
+            .insert({**payload, "user_id": str(user_id)})
+            .execute()
+        )
+        session = cast(list[dict[str, Any]], row.data)[0]
+        if sets:
+            set_rows = [{**s, "user_id": str(user_id), "session_id": session["id"]} for s in sets]
+            self.supabase.table("exercise_sets").insert(set_rows).execute()
+        got = self.get(user_id, UUID(session["id"]))
+        assert got is not None
+        return got
+
+    def list(
+        self,
+        user_id: UUID,
+        date_from: date | None = None,
+        date_to: date | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        query = self.supabase.table("workout_sessions").select("*").eq("user_id", str(user_id))
+        if date_from is not None:
+            query = query.gte("session_date", date_from.isoformat())
+        if date_to is not None:
+            query = query.lte("session_date", date_to.isoformat())
+        result = query.order("session_date", desc=True).limit(limit).execute()
+        return cast(list[dict[str, Any]], result.data)
+
+    def get(self, user_id: UUID, session_id: UUID) -> dict[str, Any] | None:
+        result = (
+            self.supabase.table("workout_sessions")
+            .select("*")
+            .eq("id", str(session_id))
+            .eq("user_id", str(user_id))
+            .execute()
+        )
+        rows = cast(list[dict[str, Any]], result.data)
+        if not rows:
+            return None
+        session = rows[0]
+        sets = (
+            self.supabase.table("exercise_sets")
+            .select("*")
+            .eq("session_id", str(session_id))
+            .order("round_number")
+            .order("set_index")
+            .execute()
+        )
+        session["sets"] = cast(list[dict[str, Any]], sets.data)
+        return session
+
+    def delete(self, user_id: UUID, session_id: UUID) -> bool:
+        result = (
+            self.supabase.table("workout_sessions")
+            .delete()
+            .eq("id", str(session_id))
+            .eq("user_id", str(user_id))
+            .execute()
+        )
+        return bool(cast(list[dict[str, Any]], result.data))

--- a/supabase/migrations/20260620000000_create_workouts.sql
+++ b/supabase/migrations/20260620000000_create_workouts.sql
@@ -1,0 +1,188 @@
+-- =====================================================
+-- Athlete Training Tracker — structured workouts (SB-190)
+-- =====================================================
+-- Records structured S&C workouts: a coach's template, logged sessions, and the
+-- per-exercise sets actually performed. Additive — the metric_* tables are
+-- untouched. Mirrors the running pattern (session -> measurements -> progress):
+-- a workout_session is like a run, exercise_sets are like splits (timed
+-- segments + rest gaps via started_at/ended_at).
+--
+--   exercises          global catalog of movements (like metric_types)
+--   workout_templates  a coach's prescribed plan + template_items
+--   workout_sessions   a logged session (per athlete user)
+--   exercise_sets      the ACTUAL performance — the heart of progress
+--
+-- Heterogeneous measures: each exercise fills only the dimension columns it uses
+-- (reps | duration_seconds | load_kg | distance_m | time_seconds) — same wide-
+-- nullable approach as the splits table. Performance tests (40yd dash, vertical)
+-- live here too: fixed distance, measured time, trended over the season.
+--
+-- RLS: per-user tables are STRICT (user_id = auth.uid()), no anon escape.
+-- exercises is a public read-only catalog.
+-- =====================================================
+
+-- ===== Enums =====
+CREATE TYPE exercise_category AS ENUM ('strength', 'speed', 'power', 'mobility', 'cardio', 'test');
+CREATE TYPE workout_type AS ENUM ('circuit', 'intervals', 'test', 'session');
+
+-- =====================================================
+-- exercises — global catalog (writes via migrations / service role only)
+-- =====================================================
+CREATE TABLE exercises (
+    key TEXT PRIMARY KEY,                        -- slug: pushups, 40yd_dash, plank
+    display_name TEXT NOT NULL,
+    category exercise_category NOT NULL,
+    measures TEXT[] NOT NULL DEFAULT '{}',       -- dims used: reps,duration_s,load_kg,distance_m,time_s
+    is_benchmark BOOLEAN NOT NULL DEFAULT FALSE, -- TRUE for tracked tests (40yd, vertical, broad)
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+COMMENT ON TABLE exercises IS 'Global catalog of movements; category test + is_benchmark flag the speed/power progress markers';
+COMMENT ON COLUMN exercises.measures IS 'Which dimensions this exercise records: reps,duration_s,load_kg,distance_m,time_s';
+
+INSERT INTO exercises (key, display_name, category, measures, is_benchmark) VALUES
+    ('40yd_dash',     '40-yard dash',        'test',     ARRAY['distance_m','time_s'],          TRUE),
+    ('vertical_jump', 'Vertical jump',       'test',     ARRAY['distance_m'],                   TRUE),
+    ('broad_jump',    'Broad jump',          'test',     ARRAY['distance_m'],                   TRUE),
+    ('pro_agility',   '5-10-5 pro agility',  'test',     ARRAY['time_s'],                       TRUE),
+    ('pushups',       'Push-ups',            'strength', ARRAY['reps','duration_s'],            FALSE),
+    ('plank',         'Plank',               'strength', ARRAY['duration_s'],                   FALSE),
+    ('jump_rope',     'Jump rope',           'cardio',   ARRAY['duration_s'],                   FALSE),
+    ('lunge',         'Lunges',              'strength', ARRAY['reps'],                         FALSE),
+    ('frog_jump',     'Frog jumps',          'power',    ARRAY['reps','distance_m','time_s'],   FALSE),
+    ('hill_sprint',   'Hill sprint',         'speed',    ARRAY['duration_s','distance_m'],      FALSE),
+    ('bicep_hold',    'Bicep 90° hold',      'strength', ARRAY['duration_s','load_kg'],         FALSE),
+    ('row_hold',      'Bent-over row hold',  'strength', ARRAY['duration_s','load_kg'],         FALSE),
+    ('back_bridge',   'Back bridge',         'mobility', ARRAY['duration_s'],                   FALSE);
+
+-- =====================================================
+-- workout_templates — a coach's prescribed plan
+-- =====================================================
+CREATE TABLE workout_templates (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    name TEXT NOT NULL,                          -- "Take-home #1", "Saturday Circuit"
+    type workout_type NOT NULL DEFAULT 'circuit',
+    rounds INTEGER NOT NULL DEFAULT 1 CHECK (rounds >= 1),
+    source TEXT,                                 -- coach name, e.g. "Matthew"
+    notes TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_workout_templates_user ON workout_templates (user_id);
+
+-- =====================================================
+-- template_items — exercises prescribed in a template
+-- =====================================================
+CREATE TABLE template_items (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,  -- denormalized for RLS
+    template_id UUID NOT NULL REFERENCES workout_templates(id) ON DELETE CASCADE,
+    exercise_key TEXT NOT NULL REFERENCES exercises(key),
+    position INTEGER NOT NULL DEFAULT 0,
+    target_reps INTEGER,
+    target_duration_seconds NUMERIC(8, 2),
+    target_load_kg NUMERIC(6, 2),
+    target_distance_m NUMERIC(8, 2),
+    rest_seconds NUMERIC(8, 2),
+    variant TEXT,
+    notes TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_template_items_template ON template_items (template_id, position);
+
+-- =====================================================
+-- workout_sessions — a logged session
+-- =====================================================
+CREATE TABLE workout_sessions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    session_date DATE NOT NULL,
+    template_id UUID REFERENCES workout_templates(id) ON DELETE SET NULL,
+    type workout_type NOT NULL DEFAULT 'circuit',
+    total_minutes NUMERIC(6, 1),
+    how_felt TEXT,
+    notes TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_workout_sessions_user_date ON workout_sessions (user_id, session_date DESC);
+
+-- =====================================================
+-- exercise_sets — the ACTUAL performance (heart of progress)
+-- =====================================================
+CREATE TABLE exercise_sets (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,  -- denormalized for RLS
+    session_id UUID NOT NULL REFERENCES workout_sessions(id) ON DELETE CASCADE,
+    exercise_key TEXT NOT NULL REFERENCES exercises(key),
+
+    round_number INTEGER,
+    set_index INTEGER,
+    variant TEXT,                                -- front|back|left|right|forward|backward
+
+    -- Dimension columns: an exercise fills only the ones it uses.
+    reps INTEGER,
+    duration_seconds NUMERIC(8, 2),
+    load_kg NUMERIC(6, 2),
+    distance_m NUMERIC(8, 2),
+    time_seconds NUMERIC(8, 3),                  -- a measured result (sprint time)
+
+    rpe INTEGER CHECK (rpe IS NULL OR rpe BETWEEN 1 AND 10),
+    started_at TIMESTAMPTZ,                       -- per-set wall-clock -> rest/density analysis
+    ended_at TIMESTAMPTZ,
+    notes TEXT,
+    extra JSONB,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_exercise_sets_session ON exercise_sets (session_id, round_number, set_index);
+CREATE INDEX idx_exercise_sets_user_exercise ON exercise_sets (user_id, exercise_key);
+
+COMMENT ON TABLE exercise_sets IS 'Per-exercise sets actually performed; wide-nullable dims + started/ended for rest/density (like splits)';
+
+-- =====================================================
+-- Triggers — updated_at (function from initial_schema)
+-- =====================================================
+CREATE TRIGGER update_exercises_updated_at BEFORE UPDATE ON exercises
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_workout_templates_updated_at BEFORE UPDATE ON workout_templates
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_workout_sessions_updated_at BEFORE UPDATE ON workout_sessions
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- =====================================================
+-- Row Level Security
+-- =====================================================
+ALTER TABLE exercises ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "exercises readable by all" ON exercises FOR SELECT USING (TRUE);
+
+-- Per-user tables: strict, no anon escape.
+ALTER TABLE workout_templates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE template_items ENABLE ROW LEVEL SECURITY;
+ALTER TABLE workout_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE exercise_sets ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "own workout_templates select" ON workout_templates FOR SELECT USING (user_id = auth.uid());
+CREATE POLICY "own workout_templates insert" ON workout_templates FOR INSERT WITH CHECK (user_id = auth.uid());
+CREATE POLICY "own workout_templates update" ON workout_templates FOR UPDATE USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "own workout_templates delete" ON workout_templates FOR DELETE USING (user_id = auth.uid());
+
+CREATE POLICY "own template_items select" ON template_items FOR SELECT USING (user_id = auth.uid());
+CREATE POLICY "own template_items insert" ON template_items FOR INSERT WITH CHECK (user_id = auth.uid());
+CREATE POLICY "own template_items update" ON template_items FOR UPDATE USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "own template_items delete" ON template_items FOR DELETE USING (user_id = auth.uid());
+
+CREATE POLICY "own workout_sessions select" ON workout_sessions FOR SELECT USING (user_id = auth.uid());
+CREATE POLICY "own workout_sessions insert" ON workout_sessions FOR INSERT WITH CHECK (user_id = auth.uid());
+CREATE POLICY "own workout_sessions update" ON workout_sessions FOR UPDATE USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "own workout_sessions delete" ON workout_sessions FOR DELETE USING (user_id = auth.uid());
+
+CREATE POLICY "own exercise_sets select" ON exercise_sets FOR SELECT USING (user_id = auth.uid());
+CREATE POLICY "own exercise_sets insert" ON exercise_sets FOR INSERT WITH CHECK (user_id = auth.uid());
+CREATE POLICY "own exercise_sets update" ON exercise_sets FOR UPDATE USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "own exercise_sets delete" ON exercise_sets FOR DELETE USING (user_id = auth.uid());

--- a/tests/test_workout_models.py
+++ b/tests/test_workout_models.py
@@ -1,0 +1,82 @@
+"""Round-trip tests for workout models (SB-190).
+
+Proves the model handles both shapes the trainer uses: a multi-round circuit and
+a 40-yd-dash performance test.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from src.shared.models import (
+    ExerciseSetCreate,
+    TemplateItemCreate,
+    WorkoutSessionCreate,
+    WorkoutTemplateCreate,
+    WorkoutType,
+)
+
+YARD_M = 0.9144
+FORTY_YD_M = 40 * YARD_M
+
+
+def test_circuit_template_round_trips():
+    # Matthew's Saturday circuit (subset), 3 rounds.
+    t = WorkoutTemplateCreate(
+        name="Saturday Circuit",
+        type=WorkoutType.circuit,
+        rounds=3,
+        source="Matthew",
+        items=[
+            TemplateItemCreate(exercise_key="jump_rope", position=0, target_duration_seconds=180),
+            TemplateItemCreate(exercise_key="pushups", position=1, target_duration_seconds=30),
+            TemplateItemCreate(
+                exercise_key="bicep_hold",
+                position=2,
+                target_duration_seconds=60,
+                target_load_kg=9.07,
+            ),
+            TemplateItemCreate(
+                exercise_key="plank", position=3, target_duration_seconds=60, variant="front"
+            ),
+        ],
+    )
+    assert t.rounds == 3
+    assert len(t.items) == 4
+    assert t.items[2].target_load_kg == 9.07
+
+
+def test_circuit_session_with_sets_and_rest_timeline():
+    # A logged round of the circuit, with per-set wall-clock for rest/density.
+    s = WorkoutSessionCreate(
+        session_date=date(2026, 6, 20),
+        type=WorkoutType.circuit,
+        total_minutes=32.0,
+        how_felt="strong",
+        sets=[
+            ExerciseSetCreate(exercise_key="jump_rope", round_number=1, duration_seconds=180),
+            ExerciseSetCreate(exercise_key="pushups", round_number=1, reps=22, rpe=8),
+            ExerciseSetCreate(exercise_key="lunge", round_number=1, reps=10, variant="left"),
+            ExerciseSetCreate(exercise_key="lunge", round_number=1, reps=10, variant="right"),
+        ],
+    )
+    assert len(s.sets) == 4
+    assert s.sets[1].reps == 22
+    assert {st.variant for st in s.sets if st.exercise_key == "lunge"} == {"left", "right"}
+
+
+def test_40yd_dash_test_result():
+    # A performance test: fixed distance, measured time — the speed progress marker.
+    s = WorkoutSessionCreate(
+        session_date=date(2026, 6, 20),
+        type=WorkoutType.test,
+        sets=[
+            ExerciseSetCreate(
+                exercise_key="40yd_dash", distance_m=FORTY_YD_M, time_seconds=5.42, set_index=1
+            ),
+        ],
+    )
+    dash = s.sets[0]
+    assert dash.exercise_key == "40yd_dash"
+    assert dash.time_seconds == 5.42
+    assert round(dash.distance_m, 2) == round(FORTY_YD_M, 2)


### PR DESCRIPTION
## Summary
The **demo slice** of the Athlete Training Tracker ([SB-189](https://linear.app/silverbeer/issue/SB-189)) — record structured S&C workouts + the sets actually performed, so a young athlete's **strength + speed progress** can be tracked. Additive; the metric engine is untouched. Closes **SB-190** (schema) + **SB-191** (API).

**Schema** — `exercises` catalog (seeded with the trainer's movements + tests: 40yd dash, vertical/broad jump, 5-10-5, push-ups, plank, jump rope, lunge, frog jump, hill sprint, holds, bridge), `workout_templates`/`template_items` (the coach's plan), `workout_sessions`/`exercise_sets`. Heterogeneous measures via **wide-nullable dimension columns** (reps/duration_s/load_kg/distance_m/time_s) — same approach as `splits`. `exercise_sets` carries `started_at`/`ended_at` for **rest/density** analysis. Strict per-user RLS; `exercises` is a public catalog.

**Models** — `Exercise`, `WorkoutTemplate`(+items), `WorkoutSession`(+sets) with Create variants. Round-trips a 3-round circuit and a 40yd-dash test.

**API** — `workout_repository` (templates/sessions created with children inline, read back nested) + `/workouts` routes (catalog, template + session CRUD, JWT-gated, exercise-key validation).

## Test plan
- [x] `uv run pytest tests/` (52) + `uv run --project backend pytest backend/tests/` (125) pass
- [x] ruff + mypy clean on new code
- [ ] After merge: apply the migration (`supabase db push`), backend deploys → log today's real take-home workout via `/workouts/sessions`

## Next
P1 ([SB-192](https://linear.app/silverbeer/issue/SB-192)) — the capture skill (screenshot plan + voice actuals). For *today*, we'll log the paper-recorded workout straight via the API to validate end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes SB-190