### PR TITLE
ci: bump backend image tag to f37c014 (deploy /workouts)

### DIFF
--- a/helm/myrunstreak/values.yaml
+++ b/helm/myrunstreak/values.yaml
@@ -69,7 +69,7 @@ backend:
 
   image:
     repository: ghcr.io/silverbeer/myrunstreak-backend
-    tag: "87c94db" # backend-tag
+    tag: "f37c014" # backend-tag
     pullPolicy: IfNotPresent
 
   env:


### PR DESCRIPTION
## Why
Backend Deploy for #98 **built + pushed** `ghcr.io/silverbeer/myrunstreak-backend:f37c014` (digest confirmed), but the auto-commit of the tag to `values.yaml` was **rejected non-fast-forward** — #97 merged into `main` right behind #98's deploy, so the bot's checkout was stale. Re-running failed the same way (it re-checks out the old commit).

So the image + migration are live, but `values.yaml` still points at the old image → `/workouts` routes never deployed.

## Fix
Land the tag bump (87c94db → f37c014). Merge → ArgoCD rolls out the workout backend → `/workouts` live.

## Follow-up (separate ticket)
The deploy's git-auto-commit doesn't rebase/retry, so **any two PRs merged close together break the image-tag commit**. Needs a rebase-and-retry (or consistent GH_PAT). Filing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)