### PR TITLE
feat: log-workout capture skill + stk workout CLI (SB-192)

### DIFF
--- a/.claude/skills/log-workout/SKILL.md
+++ b/.claude/skills/log-workout/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: log-workout
+description: >-
+  Capture and review an athlete's strength & conditioning workouts via the `stk
+  workout` CLI. Use when the user wants to turn a coach's workout plan
+  (a screenshot or pasted text) into a reusable template, log what an athlete
+  actually did (spoken or typed — "set 2, 18 reps, 40-dash 5.4"), or see
+  progress ("how's his 40 trending", "is he getting stronger"). The data/API own
+  every number; this skill parses, flags implausible values, confirms back, and
+  narrates — it never invents results.
+---
+
+# Log Workout — capture + review for the Athlete Training Tracker
+
+Turn a coach's plan into a **template**, log an athlete's **actuals** against it,
+and read back **progress**. Built for the trainer-as-buyer flow: the coach (or
+parent) speaks/screenshots; this skill structures it.
+
+## The one rule
+
+> **Never invent a number. Parse what you're given, flag what looks off, confirm
+> before saving.** A test time or rep count is the athlete's real performance —
+> getting it wrong corrupts the progress trend. When unsure, ask.
+
+## Prerequisite
+
+`stk` must be authed (`stk auth status` → active) and the `/workouts` API live.
+The CLI is the deterministic interface; you build JSON and pipe it in via `-`.
+
+## Units: store canonical, speak natural
+
+The API stores **kg** (load) and **meters** (distance); the gym speaks **lb** and
+**yards**. Convert when building JSON, convert back when narrating.
+`lb × 0.453592 = kg` · `yd × 0.9144 = m` (40 yd = 36.58 m, 20 lb = 9.07 kg).
+
+## Flow A — parse a plan → a template
+
+When given a screenshot or pasted workout (the coach's prescription):
+
+1. Get valid exercise keys: `stk workout exercises --json` (keys + which `measures`
+   each uses). Map the plan's movements to keys (e.g. "push-ups" → `pushups`,
+   "bicep 90° holds" → `bicep_hold`). If a movement has **no catalog key**, tell
+   the user — the catalog is fixed; a new exercise needs adding (don't guess a key).
+2. Build a template JSON:
+   ```json
+   {"name":"Saturday Circuit","type":"circuit","rounds":3,"source":"Matthew",
+    "items":[{"exercise_key":"jump_rope","position":0,"target_duration_seconds":180},
+             {"exercise_key":"bicep_hold","position":2,"target_duration_seconds":60,"target_load_kg":9.07}]}
+   ```
+   `type` ∈ circuit|intervals|test|session. Put per-exercise rounds in `rounds`.
+3. Create it: `echo '<json>' | stk workout add-template --file -` (or write a temp
+   file). Report the name + id.
+
+## Flow B — log the actuals → a session (the live capture)
+
+When the user reads/speaks what the athlete did ("set 2, interval 12s, 18 reps;
+40-dash 5.4"):
+
+1. Pull the matching template: `stk workout templates --json` → it tells you the
+   expected exercises, rounds, and targets — **use them as expectations.**
+2. Parse the actuals into `exercise_sets`. Map the spoken dimension to the right
+   column:
+   - reps → `reps`; held/timed → `duration_seconds`; a sprint/test result →
+     `time_seconds`; a measured distance (frog jump, broad jump) → `distance_m`;
+     load → `load_kg`. Tag `round_number`/`set_index` and `variant`
+     (front|back|left|right|forward|backward).
+   - Rest/interval timing → `started_at`/`ended_at` when given (enables density).
+3. **Plausibility-check against the template + catalog:** a 40-yd dash of "54s"
+   → "did you mean 5.4?"; 200 push-ups in 30s → confirm; a load far off the
+   target → confirm. Flag, don't silently store.
+4. **Confirm back** a compact summary, then log only on a yes:
+   ```
+   Logging — Sat Jun 20, Saturday Circuit:
+     push-ups  R1 22 · R2 20 · R3 18
+     40-yd dash  5.4 s   (vs last 5.6 — faster!)
+     planks felt hard (RPE 8)
+   Save? 
+   ```
+5. Save: `echo '<session json>' | stk workout log --file -`. Session JSON:
+   ```json
+   {"session_date":"2026-06-20","type":"circuit","template_id":"<id>","how_felt":"strong",
+    "sets":[{"exercise_key":"pushups","round_number":1,"reps":22},
+            {"exercise_key":"40yd_dash","distance_m":36.58,"time_seconds":5.4}]}
+   ```
+
+## Flow C — progress (the coach's feedback loop)
+
+`stk workout sessions --since <date> --json` → read sets across sessions and
+narrate, the same way running splits/PRs are analyzed:
+- **Speed tests:** trend `time_seconds` for `40yd_dash` etc. **down** = faster.
+  "His 40 went 5.8 → 5.4 over the block."
+- **Strength/volume:** reps × load over time per exercise; max plank/hold.
+- **Density:** from `started_at`/`ended_at`, work vs rest per session; rest
+  shrinking while output holds = fitter.
+Lead with what improved, name the marker, keep it short — it's coaching, not a dump.
+
+## Voice / wearable note
+
+The actuals can come from a transcript (phone memo, AirPods dictation, a wearable
+recorder). Treat the transcript as the spoken input to Flow B — same parse,
+same plausibility + confirm-back. Couple to the transcript, not any one device.
+
+## Distribution
+
+Version-controlled at `.claude/skills/log-workout/`. Copy/symlink into
+`~/.claude/skills/log-workout/` to use outside this repo. Needs only the `stk`
+CLI (authed).

--- a/src/cli/commands/workout.py
+++ b/src/cli/commands/workout.py
@@ -1,0 +1,114 @@
+"""Workout commands for stk CLI — the deterministic interface the log-workout skill drives.
+
+Templates and sessions have nested children (items / sets), so the create
+commands take a JSON file (or stdin via '-') rather than a wall of flags. The
+skill builds the JSON, calls these, and reads the result back.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import typer
+
+from cli import api, display
+
+workout_app = typer.Typer(help="Athlete workout tracker — templates, sessions, progress.")
+
+
+def _load(path: str) -> dict[str, Any]:
+    raw = sys.stdin.read() if path == "-" else open(path).read()
+    data: dict[str, Any] = json.loads(raw)
+    return data
+
+
+def _dump(data: Any) -> None:
+    print(json.dumps(data, indent=2, default=str))
+
+
+def exercises(
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
+) -> None:
+    """List the exercise catalog (valid exercise keys + their measures)."""
+    data = api.request("workouts/exercises")
+    if json_output:
+        _dump(data)
+        return
+    for e in data:
+        flag = " [test]" if e.get("is_benchmark") else ""
+        display.console.print(
+            f"  {e['key']:<16} {e['display_name']}{flag}  ({', '.join(e['measures'])})"
+        )
+
+
+def templates(
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
+) -> None:
+    """List your workout templates."""
+    data = api.request("workouts/templates")
+    if json_output:
+        _dump(data)
+        return
+    for t in data:
+        display.console.print(
+            f"  [bold]{t['name']}[/bold]  ({t['type']}, x{t['rounds']})  id={t['id'][:8]}  "
+            f"{len(t.get('items', []))} exercises"
+        )
+
+
+def sessions(
+    since: str = typer.Option(None, "--since", "-s", help="Only sessions on/after YYYY-MM-DD"),
+    limit: int = typer.Option(30, "--limit", "-l"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
+) -> None:
+    """List logged sessions (newest first)."""
+    params: dict[str, Any] = {"limit": limit}
+    if since is not None:
+        params["since"] = since
+    data = api.request("workouts/sessions", params)
+    if json_output:
+        _dump(data)
+        return
+    for s in data:
+        display.console.print(
+            f"  {s['session_date']}  {s['type']}  {len(s.get('sets', []))} sets  id={s['id'][:8]}"
+        )
+
+
+def add_template(
+    file: str = typer.Option(..., "--file", "-f", help="JSON file (or '-' for stdin)"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
+) -> None:
+    """Create a template from a JSON file (the coach's plan)."""
+    result = api.post_request("workouts/templates", _load(file))
+    if json_output:
+        _dump(result)
+    else:
+        display.console.print(
+            f"[green]Template created[/green] '{result['name']}' "
+            f"({len(result.get('items', []))} exercises)  id={result['id']}"
+        )
+
+
+def log(
+    file: str = typer.Option(..., "--file", "-f", help="JSON file (or '-' for stdin)"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
+) -> None:
+    """Log a session from a JSON file (the actuals)."""
+    result = api.post_request("workouts/sessions", _load(file))
+    if json_output:
+        _dump(result)
+    else:
+        display.console.print(
+            f"[green]Session logged[/green] {result['session_date']} "
+            f"({len(result.get('sets', []))} sets)  id={result['id']}"
+        )
+
+
+workout_app.command(name="exercises")(exercises)
+workout_app.command(name="templates")(templates)
+workout_app.command(name="sessions")(sessions)
+workout_app.command(name="add-template")(add_template)
+workout_app.command(name="log")(log)

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -17,7 +17,7 @@ import typer
 from rich.console import Console
 
 from cli import __version__
-from cli.commands import auth, plan, runs, splits, stats, sync
+from cli.commands import auth, plan, runs, splits, stats, sync, workout
 
 # Create the main app
 app = typer.Typer(
@@ -33,6 +33,7 @@ app.add_typer(plan.plan_app, name="plan", help="Adaptive monthly plan")
 app.add_typer(plan.constraint_app, name="constraint", help="Plan constraints (travel, injury)")
 app.add_typer(plan.readiness_app, name="readiness", help="Daily readiness check-in")
 app.add_typer(splits.splits_app, name="splits", help="Per-mile splits")
+app.add_typer(workout.workout_app, name="workout", help="Athlete workout tracker")
 
 # Console for output
 console = Console()


### PR DESCRIPTION
## What

The **capture layer** for the Athlete Training Tracker (SB-189 epic). Schema + API shipped in #98; this adds how a coach/parent actually gets data in and out — a deterministic `stk workout` CLI plus the multimodal `log-workout` skill that drives it (same pattern as the planning skill drives `stk plan`).

## `stk workout` CLI
Nested payloads (templates have items, sessions have sets), so creates take JSON via `--file` / stdin `-`:

| command | does |
|---|---|
| `exercises` | list catalog (valid keys + measures) |
| `templates` | list your templates |
| `sessions --since --limit` | list logged sessions |
| `add-template --file -` | create template from a plan |
| `log --file -` | log a session from actuals |

## `log-workout` skill
- **Flow A** — screenshot/text plan → template (map movements to catalog keys; flag unknown movements, don't guess)
- **Flow B** — spoken/typed actuals → session, with **plausibility flags + confirm-back** before saving. The one rule: never invent a number.
- **Flow C** — progress narration (40yd trend, strength/volume, rest density)
- Canonical units (kg/m) at the edge, speak lb/yd. Device-agnostic transcript (phone memo / wearable / dictation).

## Verified
- `stk workout templates` / `exercises` run live against prod `/workouts` (2 templates, 13-movement catalog)
- ruff clean, format applied
- tests: 3 model + 2 repo green (`uv run --project backend python -m pytest`)

Closes SB-192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)