### PR TITLE
feat: add warmup/cooldown to exercise catalog (SB-192)

### DIFF
--- a/.claude/skills/log-workout/SKILL.md
+++ b/.claude/skills/log-workout/SKILL.md
@@ -48,6 +48,9 @@ When given a screenshot or pasted workout (the coach's prescription):
              {"exercise_key":"bicep_hold","position":2,"target_duration_seconds":60,"target_load_kg":9.07}]}
    ```
    `type` ∈ circuit|intervals|test|session. Put per-exercise rounds in `rounds`.
+   **Always bracket the work with `warmup` (position 0) and `cooldown` (last
+   position)** — they're first/last on the card and the coach tracks that the
+   athlete actually did them. Log them in the actuals too.
 3. Create it: `echo '<json>' | stk workout add-template --file -` (or write a temp
    file). Report the name + id.
 

--- a/supabase/migrations/20260620010000_add_warmup_cooldown.sql
+++ b/supabase/migrations/20260620010000_add_warmup_cooldown.sql
@@ -1,0 +1,11 @@
+-- =====================================================
+-- Add warm-up and cool-down to the exercise catalog.
+-- They bracket every session (first + last item on the card) and matter as
+-- much as the work — coaches track that the athlete actually did them.
+-- Modeled as duration-based mobility movements so they round-trip like any
+-- other exercise. Idempotent: safe to re-run.
+-- =====================================================
+INSERT INTO exercises (key, display_name, category, measures, is_benchmark) VALUES
+    ('warmup',   'Warm-up',   'mobility', ARRAY['duration_s'], FALSE),
+    ('cooldown', 'Cool-down', 'mobility', ARRAY['duration_s'], FALSE)
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
Warm-up and cool-down bracket every session — first and last on the workout card — and a coach cares that the athlete actually did them. The catalog didn't have them, so they couldn't be shown or logged.

- New migration `20260620010000_add_warmup_cooldown.sql` — adds `warmup` + `cooldown` as duration-based `mobility` movements (`ON CONFLICT DO NOTHING`, idempotent). Applied to the remote DB by the supabase-migrations workflow on merge.
- `log-workout` skill: always bracket the work with `warmup` (position 0) + `cooldown` (last), in both the plan and the actuals.

After merge (CI applies the migration), I'll rebuild the Saturday Circuit + Monday templates with warm-up/cool-down as the first/last items so `stk workout show` displays them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)