### PR TITLE
ci: enforce coverage floor on PRs (SB-174)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,8 @@ jobs:
         run: uv run ruff check src/ tests/
       - name: Ruff format check
         run: uv run ruff format --check src/ tests/
-      - name: Run tests
-        run: uv run pytest tests/ -q
+      - name: Run tests (coverage floor 60%)
+        run: uv run pytest tests/ -q --cov-fail-under=60
 
   backend:
     name: Backend suite
@@ -50,7 +50,9 @@ jobs:
         run: uv run --project backend ruff check backend/
       - name: Ruff format check
         run: uv run --project backend ruff format --check backend/
-      - name: Run tests
-        run: uv run --project backend python -m pytest backend/tests/ -q
+      - name: Run tests (coverage floor 80%)
+        run: >-
+          uv run --project backend python -m pytest backend/tests/ -q
+          --cov=backend --cov-report=term-missing --cov-fail-under=80
       - name: Build Docker image
         run: docker build -f backend/Dockerfile -t myrunstreak-backend:test .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,13 @@ python_files = "test_*.py"
 python_functions = "test_*"
 addopts = "-v --cov=src --cov-report=term-missing"
 
+[tool.coverage.run]
+# The CLI is a thin client exercised end-to-end against the live API, not by
+# the root unit suite — measuring it here would only depress the floor with
+# untestable glue. The coverage gate (SB-174) tracks the pure logic in
+# src/shared.
+omit = ["src/cli/*"]
+
 [tool.mypy]
 python_version = "3.12"
 strict = true


### PR DESCRIPTION
Completes the SB-172 safety-net trilogy: **gate (SB-173) + pre-commit (SB-175) + floor (this)**.

A PR that drops a tested path now fails CI. Floors set just **below** current coverage so they catch regressions without breaking the build, and ratchet up over time.

| project | floor | current |
|---|---|---|
| root (`src/`, cli omitted) | 60% | 64% |
| backend | 80% | 83% |

- `src/cli/*` omitted via `[tool.coverage.run]` — it's a thin client exercised end-to-end against the live API, not by the root unit suite; measuring it would only depress the floor with untestable glue.
- root inherits `--cov` from pytest addopts → CI appends `--cov-fail-under=60`
- backend CI step adds `--cov=backend --cov-report=term-missing --cov-fail-under=80`

## Verified locally
- root passes at 60 (64.02%), **fails at 99** (gate proven)
- backend passes at 80 (82.54%)
- pre-push hook ran both suites green before the push

Closes SB-174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)