### PR TITLE
feat: unthrottle history access — raise caps + add filters (SB-184)

### DIFF
--- a/backend/routes/metrics.py
+++ b/backend/routes/metrics.py
@@ -78,9 +78,15 @@ def list_entries(
     date_from: date | None = Query(default=None),
     date_to: date | None = Query(default=None),
     limit: int = Query(default=200, ge=1, le=2000),
+    offset: int = Query(default=0, ge=0, description="Page beyond the limit window (SB-184)"),
 ) -> list[MetricEntry]:
     rows = MetricEntriesRepository(get_supabase_client()).list(
-        user_id, metric_key=metric_key, date_from=date_from, date_to=date_to, limit=limit
+        user_id,
+        metric_key=metric_key,
+        date_from=date_from,
+        date_to=date_to,
+        limit=limit,
+        offset=offset,
     )
     return [MetricEntry(**r) for r in rows]
 

--- a/backend/routes/runs.py
+++ b/backend/routes/runs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import date
 from typing import Any
 from uuid import UUID
 
@@ -46,15 +47,25 @@ async def get_recent_runs(
 
 
 @cached(ttl=60, key_prefix="runs:list")
-async def _list_runs(user_id: UUID, offset: int, limit: int) -> dict[str, Any]:
+async def _list_runs(
+    user_id: UUID,
+    offset: int,
+    limit: int,
+    date_from: date | None = None,
+    date_to: date | None = None,
+    distance_min: float | None = None,
+    distance_max: float | None = None,
+) -> dict[str, Any]:
     supabase = get_supabase_client()
     runs_repo = RunsRepository(supabase)
-    runs_data = runs_repo.get_runs_by_user(user_id, limit=limit, offset=offset)
-
-    total_result = (
-        supabase.table("runs").select("*", count="exact").eq("user_id", str(user_id)).execute()
-    )
-    total = total_result.count or 0
+    filters = {
+        "date_from": date_from,
+        "date_to": date_to,
+        "distance_min": distance_min,
+        "distance_max": distance_max,
+    }
+    runs_data = runs_repo.get_runs_by_user(user_id, limit=limit, offset=offset, **filters)
+    total = runs_repo.count_runs_by_user(user_id, **filters)
 
     runs = [
         {
@@ -81,6 +92,11 @@ async def _list_runs(user_id: UUID, offset: int, limit: int) -> dict[str, Any]:
 async def list_runs(
     user_id: UUID = Depends(authenticate_request),
     offset: int = Query(0, ge=0),
-    limit: int = Query(50, ge=1, le=100),
+    # 366 = a full streak-year (one run/day) in a single page (SB-184).
+    limit: int = Query(50, ge=1, le=366),
+    date_from: date | None = Query(None, description="Runs on/after this date (inclusive)"),
+    date_to: date | None = Query(None, description="Runs on/before this date (inclusive)"),
+    distance_min: float | None = Query(None, ge=0, description="Min distance in km"),
+    distance_max: float | None = Query(None, ge=0, description="Max distance in km"),
 ) -> dict[str, Any]:
-    return await _list_runs(user_id, offset, limit)
+    return await _list_runs(user_id, offset, limit, date_from, date_to, distance_min, distance_max)

--- a/backend/routes/stats.py
+++ b/backend/routes/stats.py
@@ -111,7 +111,8 @@ async def _monthly(user_id: UUID, limit: int) -> dict[str, Any]:
 @router.get("/monthly")
 async def get_monthly_stats(
     user_id: UUID = Depends(authenticate_request),
-    limit: int = Query(12, ge=1, le=60),
+    # 180 months = 15 yrs, covers the full streak's pace history (SB-184).
+    limit: int = Query(12, ge=1, le=180),
 ) -> dict[str, Any]:
     return await _monthly(user_id, limit)
 

--- a/backend/tests/test_runs_history.py
+++ b/backend/tests/test_runs_history.py
@@ -1,0 +1,159 @@
+"""SB-184: full-history access — runs filters/count + metrics paging.
+
+Uses a recording fake supabase client so we can assert the exact query chain
+(gte/lte/range/count) the repos build, without a live database.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+from typing import Any
+from uuid import uuid4
+
+from src.shared.supabase_ops.metrics_repository import MetricEntriesRepository
+from src.shared.supabase_ops.runs_repository import RunsRepository
+
+
+class _RecQuery:
+    """Records every chained call; returns canned data + count on execute()."""
+
+    def __init__(self, rows: list[dict[str, Any]], count: int | None) -> None:
+        self.rows = rows
+        self.count = count
+        self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def _rec(self, name: str, *a: Any, **k: Any) -> _RecQuery:
+        self.calls.append((name, a, k))
+        return self
+
+    def select(self, *a: Any, **k: Any) -> _RecQuery:
+        return self._rec("select", *a, **k)
+
+    def eq(self, *a: Any, **k: Any) -> _RecQuery:
+        return self._rec("eq", *a, **k)
+
+    def gte(self, *a: Any, **k: Any) -> _RecQuery:
+        return self._rec("gte", *a, **k)
+
+    def lte(self, *a: Any, **k: Any) -> _RecQuery:
+        return self._rec("lte", *a, **k)
+
+    def order(self, *a: Any, **k: Any) -> _RecQuery:
+        return self._rec("order", *a, **k)
+
+    def range(self, *a: Any, **k: Any) -> _RecQuery:
+        return self._rec("range", *a, **k)
+
+    def limit(self, *a: Any, **k: Any) -> _RecQuery:
+        return self._rec("limit", *a, **k)
+
+    def execute(self) -> SimpleNamespace:
+        return SimpleNamespace(data=self.rows, count=self.count)
+
+    def filter_calls(self, name: str) -> list[tuple[Any, ...]]:
+        return [a for n, a, _ in self.calls if n == name]
+
+
+class _FakeClient:
+    def __init__(self, rows: list[dict[str, Any]] | None = None, count: int | None = None) -> None:
+        self.query = _RecQuery(rows or [], count)
+
+    def table(self, _name: str) -> _RecQuery:
+        return self.query
+
+
+def test_get_runs_by_user_applies_date_and_distance_filters() -> None:
+    client = _FakeClient(rows=[{"id": "1"}])
+    repo = RunsRepository(client)  # type: ignore[arg-type]
+    uid = uuid4()
+
+    out = repo.get_runs_by_user(
+        uid,
+        limit=366,
+        offset=0,
+        date_from=date(2016, 1, 1),
+        date_to=date(2016, 12, 31),
+        distance_min=42.0,
+        distance_max=50.0,
+    )
+
+    assert out == [{"id": "1"}]
+    gte = client.query.filter_calls("gte")
+    lte = client.query.filter_calls("lte")
+    assert ("start_date", "2016-01-01") in gte
+    assert ("distance_km", 42.0) in gte
+    assert ("start_date", "2016-12-31") in lte
+    assert ("distance_km", 50.0) in lte
+    # paging window: range(offset, offset + limit - 1)
+    assert client.query.filter_calls("range") == [(0, 365)]
+
+
+def test_get_runs_by_user_no_filters_skips_clauses() -> None:
+    client = _FakeClient(rows=[])
+    RunsRepository(client).get_runs_by_user(uuid4(), limit=50)  # type: ignore[arg-type]
+    assert client.query.filter_calls("gte") == []
+    assert client.query.filter_calls("lte") == []
+
+
+def test_count_runs_by_user_returns_count_with_filters() -> None:
+    client = _FakeClient(count=4740)
+    repo = RunsRepository(client)  # type: ignore[arg-type]
+
+    n = repo.count_runs_by_user(uuid4(), distance_min=42.0)
+
+    assert n == 4740
+    assert ("distance_km", 42.0) in client.query.filter_calls("gte")
+
+
+def test_count_runs_by_user_none_count_is_zero() -> None:
+    client = _FakeClient(count=None)
+    assert RunsRepository(client).count_runs_by_user(uuid4()) == 0  # type: ignore[arg-type]
+
+
+async def test_runs_route_passes_filters_to_repo() -> None:
+    from unittest.mock import MagicMock, patch
+
+    import pytest
+
+    pytest.importorskip("fastapi")
+    from backend.routes.runs import list_runs
+
+    repo = MagicMock()
+    repo.get_runs_by_user.return_value = []
+    repo.count_runs_by_user.return_value = 0
+    uid = uuid4()
+
+    with (
+        patch("backend.routes.runs.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.runs.RunsRepository", return_value=repo),
+    ):
+        result = await list_runs(
+            user_id=uid,
+            offset=0,
+            limit=366,
+            date_from=date(2016, 1, 1),
+            date_to=date(2016, 12, 31),
+            distance_min=42.0,
+            distance_max=None,
+        )
+
+    assert result["total"] == 0
+    _, kwargs = repo.get_runs_by_user.call_args
+    assert kwargs["date_from"] == date(2016, 1, 1)
+    assert kwargs["distance_min"] == 42.0
+    assert kwargs["limit"] == 366
+    # count uses the same filters so pagination totals match the filtered set
+    _, ckwargs = repo.count_runs_by_user.call_args
+    assert ckwargs["date_to"] == date(2016, 12, 31)
+
+
+def test_metric_entries_list_pages_with_offset() -> None:
+    client = _FakeClient(rows=[{"id": "e"}])
+    repo = MetricEntriesRepository(client)  # type: ignore[arg-type]
+
+    repo.list(uuid4(), limit=2000, offset=2000)
+
+    # offset paging via range(offset, offset + limit - 1) — reaches old data
+    assert client.query.filter_calls("range") == [(2000, 3999)]
+    assert client.query.filter_calls("limit") == []  # no longer a bare .limit()

--- a/src/shared/supabase_ops/metrics_repository.py
+++ b/src/shared/supabase_ops/metrics_repository.py
@@ -49,6 +49,7 @@ class MetricEntriesRepository:
         date_from: date | None = None,
         date_to: date | None = None,
         limit: int = 1000,
+        offset: int = 0,
     ) -> list[dict[str, Any]]:
         query = self.supabase.table("metric_entries").select("*").eq("user_id", str(user_id))
         if metric_key is not None:
@@ -57,7 +58,8 @@ class MetricEntriesRepository:
             query = query.gte("occurred_on", date_from.isoformat())
         if date_to is not None:
             query = query.lte("occurred_on", date_to.isoformat())
-        result = query.order("occurred_on", desc=True).limit(limit).execute()
+        # range() pages beyond a single limit window so full history is reachable (SB-184).
+        result = query.order("occurred_on", desc=True).range(offset, offset + limit - 1).execute()
         return cast(list[dict[str, Any]], result.data)
 
     def delete(self, user_id: UUID, entry_id: UUID) -> bool:

--- a/src/shared/supabase_ops/runs_repository.py
+++ b/src/shared/supabase_ops/runs_repository.py
@@ -81,30 +81,75 @@ class RunsRepository:
 
         return data_list[0] if data_list else None
 
+    def _apply_run_filters(
+        self,
+        query: Any,
+        date_from: date | None,
+        date_to: date | None,
+        distance_min: float | None,
+        distance_max: float | None,
+    ) -> Any:
+        """Apply optional date/distance filters to a runs query (SB-184)."""
+        if date_from is not None:
+            query = query.gte("start_date", date_from.isoformat())
+        if date_to is not None:
+            query = query.lte("start_date", date_to.isoformat())
+        if distance_min is not None:
+            query = query.gte("distance_km", distance_min)
+        if distance_max is not None:
+            query = query.lte("distance_km", distance_max)
+        return query
+
     def get_runs_by_user(
-        self, user_id: UUID, limit: int = 50, offset: int = 0
+        self,
+        user_id: UUID,
+        limit: int = 50,
+        offset: int = 0,
+        *,
+        date_from: date | None = None,
+        date_to: date | None = None,
+        distance_min: float | None = None,
+        distance_max: float | None = None,
     ) -> list[dict[str, Any]]:
         """
-        Get runs for a specific user with pagination.
+        Get runs for a specific user with pagination + optional filters.
 
         Args:
             user_id: User UUID
             limit: Maximum number of runs to return
             offset: Number of runs to skip
+            date_from: Only runs on/after this date (inclusive)
+            date_to: Only runs on/before this date (inclusive)
+            distance_min: Only runs >= this distance in km
+            distance_max: Only runs <= this distance in km
 
         Returns:
             List of run records
         """
+        query = self.supabase.table("runs").select("*").eq("user_id", str(user_id))
+        query = self._apply_run_filters(query, date_from, date_to, distance_min, distance_max)
         result = (
-            self.supabase.table("runs")
-            .select("*")
-            .eq("user_id", str(user_id))
-            .order("start_date_time_local", desc=True)
+            query.order("start_date_time_local", desc=True)
             .range(offset, offset + limit - 1)
             .execute()
         )
 
         return cast(list[dict[str, Any]], result.data)
+
+    def count_runs_by_user(
+        self,
+        user_id: UUID,
+        *,
+        date_from: date | None = None,
+        date_to: date | None = None,
+        distance_min: float | None = None,
+        distance_max: float | None = None,
+    ) -> int:
+        """Count runs for a user, honoring the same filters as get_runs_by_user."""
+        query = self.supabase.table("runs").select("id", count="exact").eq("user_id", str(user_id))
+        query = self._apply_run_filters(query, date_from, date_to, distance_min, distance_max)
+        result = query.execute()
+        return cast(int, result.count or 0)
 
     def get_runs_by_date_range(
         self, user_id: UUID, start_date: date, end_date: date

--- a/tests/test_planning_service.py
+++ b/tests/test_planning_service.py
@@ -58,6 +58,9 @@ class _FakeQuery:
     def limit(self, *a: Any, **k: Any) -> _FakeQuery:
         return self
 
+    def range(self, *a: Any, **k: Any) -> _FakeQuery:
+        return self
+
     def insert(self, payload: Any) -> _FakeQuery:
         self._mode, self._payload = "insert", payload
         return self


### PR DESCRIPTION
**Pillar 1** — view *everything* across 11 years / 4,740 runs without manual paging or low-cap walls. Covers 3 of SB-184's 4 gaps; the splits-backfill background job is a separate follow-up (deploy-infra heavy).

## Changes
| endpoint | before | after |
|---|---|---|
| `/stats/monthly` | `limit ≤ 60` (~5 yr) | `limit ≤ 180` (15 yr pace history) |
| `/runs` | `limit ≤ 100`, no filters | `limit ≤ 366` (a streak-year/page) + `date_from`/`date_to`/`distance_min`/`distance_max` |
| `/metrics/entries` | `limit ≤ 2000`, no paging | + `offset` paging (reaches data past 2000) |

- `/runs` distance filter → find all 3 marathons in one call (`distance_min=42`).
- `/runs` total count now honors the same filters, so pagination totals match the filtered set.

## Repo
- `RunsRepository`: `_apply_run_filters` (shared by list + count) + new `count_runs_by_user`.
- `MetricEntriesRepository.list`: `.limit()` → `.range(offset, offset+limit-1)`, new `offset` arg.

## Tests
New `test_runs_history.py` (6): filter chains, count w/ filters, none-count→0, route filter pass-through, metrics offset paging. Taught the planning fake `.range()`.

Verified: backend 131@84%, root 52@63%, lint+format clean. (Live verification after deploy — caps are server-side.)

Partially closes SB-184; splits backfill → background job tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)