### PR TITLE
feat: invite-only onboarding foundation — invites table + admin issue (SB-188)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,8 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        # Helm templates are Go-templated, not valid standalone YAML.
+        exclude: ^helm/.*/templates/
       - id: check-merge-conflict
       - id: check-added-large-files
 

--- a/backend/admin.py
+++ b/backend/admin.py
@@ -1,0 +1,22 @@
+"""Admin authorization for privileged actions (SB-188).
+
+Admin status is config-driven via ADMIN_USER_IDS — a small, auditable allowlist
+of user UUIDs. No role column on the users table yet; this keeps the surface
+minimal until a real role system lands.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from backend.config import get_settings
+from fastapi import HTTPException, status
+
+
+def require_admin(user_id: UUID) -> None:
+    """Raise 403 unless the user is in the ADMIN_USER_IDS allowlist."""
+    if str(user_id).lower() not in get_settings().admin_ids():
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin privileges required",
+        )

--- a/backend/app.py
+++ b/backend/app.py
@@ -3,7 +3,7 @@
 import logging
 
 from backend.config import get_settings
-from backend.routes import auth_routes, metrics, plan, runs, stats, sync, workouts
+from backend.routes import auth_routes, invites, metrics, plan, runs, stats, sync, workouts
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -46,6 +46,7 @@ def create_app() -> FastAPI:
     app.include_router(metrics.router)
     app.include_router(plan.router)
     app.include_router(workouts.router)
+    app.include_router(invites.router)
 
     return app
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -28,6 +28,14 @@ class Settings(BaseSettings):
     goal_yearly_staleness_days: int = 14
     goal_monthly_staleness_days: int = 3
 
+    # Comma-separated user UUIDs allowed to issue invites (SB-188). Empty = no
+    # admins (invite issuance disabled). Set in the deployed env, not committed.
+    admin_user_ids: str = ""
+
+    def admin_ids(self) -> set[str]:
+        """Parsed set of admin user UUIDs (lowercased, whitespace-trimmed)."""
+        return {p.strip().lower() for p in self.admin_user_ids.split(",") if p.strip()}
+
 
 _settings: Settings | None = None
 

--- a/backend/routes/invites.py
+++ b/backend/routes/invites.py
@@ -1,0 +1,45 @@
+"""/invites — admin-issued invite-only onboarding (SB-188).
+
+Issue + list are admin-only (ADMIN_USER_IDS allowlist). Redemption happens at
+signup (a later slice) and is server-side, so it isn't exposed here.
+"""
+
+from __future__ import annotations
+
+import secrets
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+from backend.admin import require_admin
+from backend.auth import authenticate_request
+from fastapi import APIRouter, Depends, status
+from src.shared.models import Invite, InviteCreate
+from src.shared.supabase_client import get_supabase_client
+from src.shared.supabase_ops import InvitesRepository
+
+router = APIRouter(prefix="/invites", tags=["invites"])
+
+
+@router.post("", response_model=Invite, status_code=status.HTTP_201_CREATED)
+def issue_invite(
+    body: InviteCreate,
+    user_id: UUID = Depends(authenticate_request),
+) -> Invite:
+    """Issue an invite (admin only). Returns the invite incl. its token."""
+    require_admin(user_id)
+    token = secrets.token_urlsafe(32)
+    expires_at = datetime.now(UTC) + timedelta(days=body.expires_in_days)
+    row = InvitesRepository(get_supabase_client()).create(
+        created_by=user_id, email=body.email, token=token, expires_at=expires_at
+    )
+    return Invite(**row)
+
+
+@router.get("", response_model=list[Invite])
+def list_invites(
+    user_id: UUID = Depends(authenticate_request),
+) -> list[Invite]:
+    """List invites you've issued (admin only)."""
+    require_admin(user_id)
+    rows = InvitesRepository(get_supabase_client()).list_by_creator(user_id)
+    return [Invite(**r) for r in rows]

--- a/backend/tests/test_invites.py
+++ b/backend/tests/test_invites.py
@@ -1,0 +1,162 @@
+"""SB-188: invite-only onboarding — repo round-trip + admin gate + route."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from src.shared.supabase_ops.invites_repository import InvitesRepository
+
+
+class _FakeQ:
+    def __init__(self, store: list[dict[str, Any]]) -> None:
+        self.store = store
+        self._mode = "select"
+        self._payload: Any = None
+        self._eq: dict[str, Any] = {}
+
+    def insert(self, payload: Any) -> _FakeQ:
+        self._mode, self._payload = "insert", payload
+        return self
+
+    def select(self, *a: Any, **k: Any) -> _FakeQ:
+        self._mode = "select"
+        return self
+
+    def update(self, payload: Any) -> _FakeQ:
+        self._mode, self._payload = "update", payload
+        return self
+
+    def eq(self, col: str, val: Any) -> _FakeQ:
+        self._eq[col] = val
+        return self
+
+    def order(self, *a: Any, **k: Any) -> _FakeQ:
+        return self
+
+    def _match(self) -> list[dict[str, Any]]:
+        return [r for r in self.store if all(r.get(k) == v for k, v in self._eq.items())]
+
+    def execute(self) -> SimpleNamespace:
+        if self._mode == "insert":
+            row = {
+                "id": str(uuid4()),
+                "redeemed_at": None,
+                "redeemed_by": None,
+                "created_at": "2026-06-20T00:00:00+00:00",
+                **self._payload,
+            }
+            self.store.append(row)
+            return SimpleNamespace(data=[row])
+        if self._mode == "update":
+            rows = self._match()
+            for r in rows:
+                r.update(self._payload)
+            return SimpleNamespace(data=rows)
+        return SimpleNamespace(data=self._match())
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.store: list[dict[str, Any]] = []
+
+    def table(self, _name: str) -> _FakeQ:
+        return _FakeQ(self.store)
+
+
+def test_invite_create_list_get_redeem_roundtrip() -> None:
+    repo = InvitesRepository(_FakeClient())  # type: ignore[arg-type]
+    admin = uuid4()
+    exp = datetime.now(UTC) + timedelta(days=14)
+
+    created = repo.create(admin, "friend@example.com", "tok-abc", exp)
+    assert created["token"] == "tok-abc"
+    assert created["redeemed_at"] is None
+
+    listed = repo.list_by_creator(admin)
+    assert len(listed) == 1 and listed[0]["email"] == "friend@example.com"
+
+    found = repo.get_by_token("tok-abc")
+    assert found is not None and found["email"] == "friend@example.com"
+    assert repo.get_by_token("nope") is None
+
+    invitee = uuid4()
+    redeemed = repo.mark_redeemed("tok-abc", invitee, datetime.now(UTC))
+    assert redeemed["redeemed_by"] == str(invitee)
+    assert repo.get_by_token("tok-abc")["redeemed_at"] is not None  # type: ignore[index]
+
+
+def test_require_admin_allows_listed_denies_others() -> None:
+    from backend.admin import require_admin
+
+    admin = uuid4()
+    other = uuid4()
+    settings = SimpleNamespace(admin_ids=lambda: {str(admin).lower()})
+
+    with patch("backend.admin.get_settings", return_value=settings):
+        require_admin(admin)  # no raise
+        with pytest.raises(HTTPException) as exc:
+            require_admin(other)
+    assert exc.value.status_code == 403
+
+
+def test_settings_admin_ids_parsing() -> None:
+    from backend.config import Settings
+
+    s = Settings(
+        supabase_url="x",
+        supabase_anon_key="x",
+        supabase_service_role_key="x",
+        supabase_jwt_secret="x",
+        admin_user_ids=" ABC , def,, ",
+    )
+    assert s.admin_ids() == {"abc", "def"}
+
+
+def test_issue_invite_route_denies_non_admin() -> None:
+    from backend.routes.invites import issue_invite
+    from src.shared.models import InviteCreate
+
+    empty = SimpleNamespace(admin_ids=lambda: set())
+    with patch("backend.admin.get_settings", return_value=empty):
+        with pytest.raises(HTTPException) as exc:
+            issue_invite(InviteCreate(email="x@example.com"), user_id=uuid4())
+    assert exc.value.status_code == 403
+
+
+def test_issue_invite_route_admin_issues_token() -> None:
+    from backend.routes.invites import issue_invite
+    from src.shared.models import InviteCreate
+
+    admin = uuid4()
+    repo = MagicMock()
+    repo.create.side_effect = lambda created_by, email, token, expires_at: {
+        "id": str(uuid4()),
+        "token": token,
+        "email": email,
+        "created_by": str(created_by),
+        "expires_at": expires_at.isoformat(),
+        "redeemed_at": None,
+        "redeemed_by": None,
+        "created_at": "2026-06-20T00:00:00+00:00",
+    }
+
+    with (
+        patch("backend.routes.invites.require_admin", return_value=None),
+        patch("backend.routes.invites.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.invites.InvitesRepository", return_value=repo),
+    ):
+        out = issue_invite(
+            InviteCreate(email="friend@example.com", expires_in_days=7), user_id=admin
+        )
+
+    assert out.email == "friend@example.com"
+    assert out.token  # a token was generated
+    _, kwargs = repo.create.call_args
+    assert kwargs["created_by"] == admin
+    assert len(kwargs["token"]) >= 32  # token_urlsafe(32)

--- a/helm/myrunstreak/templates/backend.yaml
+++ b/helm/myrunstreak/templates/backend.yaml
@@ -39,6 +39,8 @@ spec:
               value: {{ .Values.backend.env.cacheEnabled | default "true" | quote }}
             - name: CACHE_DEFAULT_TTL_SECONDS
               value: {{ .Values.backend.env.cacheDefaultTtlSeconds | default 60 | quote }}
+            - name: ADMIN_USER_IDS
+              value: {{ .Values.backend.env.adminUserIds | default "" | quote }}
             - name: SUPABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/helm/myrunstreak/values.yaml
+++ b/helm/myrunstreak/values.yaml
@@ -78,6 +78,9 @@ backend:
     corsAllowOrigins: "*"
     cacheEnabled: "true"
     cacheDefaultTtlSeconds: 60
+    # Comma-separated user UUIDs allowed to issue invites (SB-188). Set the
+    # owner's UUID here to enable invite issuance; empty = disabled.
+    adminUserIds: ""
 
   resources:
     requests:

--- a/src/shared/models/__init__.py
+++ b/src/shared/models/__init__.py
@@ -10,6 +10,7 @@ from .enums import (
     WeatherType,
 )
 from .goal import Goal
+from .invite import Invite, InviteCreate
 from .metric import (
     GoalComparator,
     GoalKind,
@@ -65,6 +66,9 @@ __all__ = [
     "Activity",
     "Goal",
     "Split",
+    # Invites
+    "Invite",
+    "InviteCreate",
     # Metric tracking
     "MetricType",
     "MetricEntry",

--- a/src/shared/models/invite.py
+++ b/src/shared/models/invite.py
@@ -1,0 +1,30 @@
+"""Models for invite-only onboarding (SB-188)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class InviteCreate(BaseModel):
+    """Admin request to issue an invite."""
+
+    email: str = Field(min_length=3, description="Who the invite is for")
+    expires_in_days: int = Field(
+        default=14, ge=1, le=90, description="Days until the token expires"
+    )
+
+
+class Invite(BaseModel):
+    """An issued invite (the token is only meaningful before redemption)."""
+
+    id: UUID
+    token: str
+    email: str
+    created_by: UUID
+    expires_at: datetime
+    redeemed_at: datetime | None = None
+    redeemed_by: UUID | None = None
+    created_at: datetime

--- a/src/shared/supabase_ops/__init__.py
+++ b/src/shared/supabase_ops/__init__.py
@@ -1,6 +1,7 @@
 """Supabase database operations for MyRunStreak.com."""
 
 from .goals_repository import GoalsRepository
+from .invites_repository import InvitesRepository
 from .mappers import activity_to_run_dict, split_to_dict
 from .metrics_repository import (
     MetricEntriesRepository,
@@ -23,6 +24,7 @@ from .workout_repository import (
 
 __all__ = [
     "GoalsRepository",
+    "InvitesRepository",
     "MetricEntriesRepository",
     "MetricGoalsRepository",
     "MetricTypesRepository",

--- a/src/shared/supabase_ops/invites_repository.py
+++ b/src/shared/supabase_ops/invites_repository.py
@@ -1,0 +1,58 @@
+"""Repository for invite-only onboarding (SB-188).
+
+The backend connects with the service-role key (bypasses RLS), so every query
+here scopes by the relevant id in code. Issue + redeem are server-side.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, cast
+from uuid import UUID
+
+from supabase import Client
+
+
+class InvitesRepository:
+    """Issue/list/redeem invites."""
+
+    def __init__(self, supabase: Client):
+        self.supabase = supabase
+
+    def create(
+        self, created_by: UUID, email: str, token: str, expires_at: datetime
+    ) -> dict[str, Any]:
+        row = {
+            "created_by": str(created_by),
+            "email": email,
+            "token": token,
+            "expires_at": expires_at.isoformat(),
+        }
+        result = self.supabase.table("invites").insert(row).execute()
+        return cast(list[dict[str, Any]], result.data)[0]
+
+    def list_by_creator(self, created_by: UUID) -> list[dict[str, Any]]:
+        result = (
+            self.supabase.table("invites")
+            .select("*")
+            .eq("created_by", str(created_by))
+            .order("created_at", desc=True)
+            .execute()
+        )
+        return cast(list[dict[str, Any]], result.data)
+
+    def get_by_token(self, token: str) -> dict[str, Any] | None:
+        """Look up an invite by its token (for server-side redemption)."""
+        result = self.supabase.table("invites").select("*").eq("token", token).execute()
+        data = cast(list[dict[str, Any]], result.data)
+        return data[0] if data else None
+
+    def mark_redeemed(self, token: str, redeemed_by: UUID, redeemed_at: datetime) -> dict[str, Any]:
+        """Consume an invite. Caller must verify it's unredeemed + unexpired first."""
+        result = (
+            self.supabase.table("invites")
+            .update({"redeemed_at": redeemed_at.isoformat(), "redeemed_by": str(redeemed_by)})
+            .eq("token", token)
+            .execute()
+        )
+        return cast(list[dict[str, Any]], result.data)[0]

--- a/stk/src/cli/commands/invite.py
+++ b/stk/src/cli/commands/invite.py
@@ -1,0 +1,36 @@
+"""Invite commands for stk CLI — admin-only invite-only onboarding (SB-188)."""
+
+from __future__ import annotations
+
+import typer
+
+from cli import api, display
+
+invite_app = typer.Typer(help="Issue + list onboarding invites (admin only).")
+
+
+def create(
+    email: str = typer.Option(..., "--email", "-e", help="Who the invite is for"),
+    days: int = typer.Option(14, "--days", "-d", help="Days until the token expires"),
+) -> None:
+    """Issue an invite. Prints the token to share with the invitee."""
+    result = api.post_request("invites", {"email": email, "expires_in_days": days})
+    display.console.print(
+        f"[green]Invite issued[/green] for {result['email']} (expires {result['expires_at'][:10]})"
+    )
+    display.console.print(f"  token: [bold]{result['token']}[/bold]")
+
+
+def list_invites() -> None:
+    """List invites you've issued."""
+    rows = api.request("invites")
+    if not rows:
+        display.console.print("No invites issued yet.")
+        return
+    for r in rows:
+        state = "redeemed" if r.get("redeemed_at") else "open"
+        display.console.print(f"  {r['email']:<30} {state:<9} expires {r['expires_at'][:10]}")
+
+
+invite_app.command(name="create")(create)
+invite_app.command(name="list")(list_invites)

--- a/stk/src/cli/main.py
+++ b/stk/src/cli/main.py
@@ -17,7 +17,7 @@ import typer
 from rich.console import Console
 
 from cli import __version__
-from cli.commands import auth, plan, runs, splits, stats, sync, workout
+from cli.commands import auth, invite, plan, runs, splits, stats, sync, workout
 
 # Create the main app
 app = typer.Typer(
@@ -34,6 +34,7 @@ app.add_typer(plan.constraint_app, name="constraint", help="Plan constraints (tr
 app.add_typer(plan.readiness_app, name="readiness", help="Daily readiness check-in")
 app.add_typer(splits.splits_app, name="splits", help="Per-mile splits")
 app.add_typer(workout.workout_app, name="workout", help="Athlete workout tracker")
+app.add_typer(invite.invite_app, name="invite", help="Invite-only onboarding (admin)")
 
 # Console for output
 console = Console()

--- a/supabase/migrations/20260620020000_create_invites.sql
+++ b/supabase/migrations/20260620020000_create_invites.sql
@@ -1,0 +1,36 @@
+-- =====================================================
+-- Invite-only onboarding (SB-188): an admin issues an invite (token + email,
+-- with an expiry); the invitee self-signs-up with the token and sets their own
+-- password via Supabase Auth. This table is the issue/redeem ledger.
+--
+-- The backend connects with the service-role key (bypasses RLS) and scopes
+-- every query in code; RLS here is the second line of defence for direct
+-- anon-key access. Issue + redeem are server-side (service-role) operations,
+-- so the only end-user-facing policy is "see the invites you issued".
+-- =====================================================
+CREATE TABLE invites (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    token TEXT NOT NULL UNIQUE,                 -- opaque, URL-safe; what the invitee redeems
+    email TEXT NOT NULL,                        -- who it was issued to
+    created_by UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    expires_at TIMESTAMPTZ NOT NULL,
+    redeemed_at TIMESTAMPTZ,                    -- NULL until redeemed
+    redeemed_by UUID REFERENCES users(user_id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_invites_token ON invites (token);
+CREATE INDEX idx_invites_created_by ON invites (created_by);
+
+COMMENT ON TABLE invites IS 'Invite-only onboarding ledger (SB-188): admin issues, invitee redeems at signup';
+COMMENT ON COLUMN invites.token IS 'Opaque URL-safe secret the invitee presents to sign up';
+COMMENT ON COLUMN invites.redeemed_at IS 'Set when the invite is consumed; a non-NULL value means it can no longer be used';
+
+-- RLS: strict. Issue/redeem run server-side via the service-role key (which
+-- bypasses these). The only anon-key-reachable action is reading invites you
+-- issued — never another admin's, never by token (redeem is server-side only).
+ALTER TABLE invites ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "own invites select"
+    ON invites FOR SELECT
+    USING (created_by = auth.uid());


### PR DESCRIPTION
**Pillar 5** first slice. Self-signup-with-token model (your chosen design). This lands the **issue/list** half; the invitee **redeem + gated signup** is the next slice.

## What's here
- **Migration** `20260620020000_create_invites.sql` — `invites` table (token, email, created_by, expires_at, redeemed_at/by) + strict RLS (`see-your-own`; issue/redeem are server-side via service-role). Auto-applies on merge.
- **Admin model** — config-driven `ADMIN_USER_IDS` allowlist + `require_admin()` → 403. No users-table role column yet; keeps the auth surface minimal until a real role system lands.
- **`InvitesRepository`** — create / list_by_creator / get_by_token / mark_redeemed (last two ready for the redeem slice).
- **`/invites`** — admin-only `POST` (issue, returns token) + `GET` (list yours).
- **stk** — `stk invite create --email <e> [--days N]`, `stk invite list`.
- **helm** — `ADMIN_USER_IDS` wired into backend env (`values.adminUserIds`).
- **pre-commit** — exclude helm templates from `check-yaml` (they're Go-templated, not valid YAML).

## Tests
`test_invites.py` (5): repo round-trip (incl. redeem), admin allow/deny, settings parsing, route gate (non-admin 403, admin issues a 32-byte token). Verified backend 136@84%, root 52@63%, lint+format clean on all three projects, helm renders the env.

## To enable after merge+deploy
Set `backend.env.adminUserIds` to the owner's user UUID (empty = issuance disabled). Then `stk invite create --email <co-builder>`.

Part of SB-188 — foundation only; **redeem + gated signup to follow**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)