### PR TITLE
feat: invite-only web signup + landing (SB-188)

### DIFF
--- a/frontend/src/components/LoginForm.vue
+++ b/frontend/src/components/LoginForm.vue
@@ -4,7 +4,7 @@
       <span class="text-5xl">🏃</span>
       <h1 class="mt-3 text-2xl font-bold text-gray-900">MyRunStreak</h1>
       <p class="mt-1 text-sm text-gray-500">
-        {{ mode === 'signup' ? 'Create your account' : mode === 'forgot' ? 'Reset your password' : 'Sign in to your account' }}
+        {{ mode === 'forgot' ? 'Reset your password' : 'Sign in to your account' }}
       </p>
     </div>
 
@@ -46,31 +46,6 @@
       </button>
     </form>
 
-    <!-- Sign up -->
-    <form v-else-if="mode === 'signup'" @submit.prevent="handleSignUp" class="space-y-4">
-      <div>
-        <label for="signup-email" class="form-label">Email</label>
-        <input id="signup-email" v-model="email" type="email" required autocomplete="email"
-          class="form-input" placeholder="you@example.com" :disabled="auth.loading" />
-      </div>
-      <div>
-        <label for="signup-password" class="form-label">Password</label>
-        <input id="signup-password" v-model="password" type="password" required autocomplete="new-password"
-          class="form-input" placeholder="••••••••" minlength="6" :disabled="auth.loading" />
-      </div>
-
-      <div v-if="auth.error" class="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-3 py-2">
-        {{ auth.error }}
-      </div>
-      <div v-if="signupSuccess" class="bg-green-50 border border-green-200 text-green-700 text-sm rounded-lg px-3 py-2">
-        Check your email to confirm your account.
-      </div>
-
-      <button type="submit" class="btn-primary w-full py-2.5" :disabled="auth.loading || signupSuccess">
-        {{ auth.loading ? 'Creating account…' : 'Create account' }}
-      </button>
-    </form>
-
     <!-- Forgot password -->
     <form v-else-if="mode === 'forgot'" @submit.prevent="handleForgotPassword" class="space-y-4">
       <div>
@@ -97,9 +72,8 @@
         <p>
           <button @click="switchMode('forgot')" class="text-brand-600 hover:underline font-medium">Forgot password?</button>
         </p>
-        <p>
-          No account?
-          <button @click="switchMode('signup')" class="text-brand-600 hover:underline font-medium">Sign up</button>
+        <p class="text-xs text-gray-400">
+          MyRunStreak is invite-only. Got an invite link? It'll bring you straight to sign-up.
         </p>
       </template>
       <template v-else>
@@ -120,17 +94,15 @@ const auth = useAuthStore()
 const router = useRouter()
 const route = useRoute()
 
-type Mode = 'login' | 'signup' | 'forgot'
+type Mode = 'login' | 'forgot'
 const mode = ref<Mode>('login')
 const email = ref('')
 const password = ref('')
-const signupSuccess = ref(false)
 const resetSent = ref(false)
 
 const switchMode = (next: Mode) => {
   mode.value = next
   auth.clearError()
-  signupSuccess.value = false
   resetSent.value = false
 }
 
@@ -144,13 +116,6 @@ const handleSignIn = async () => {
 
 const handleGoogleSignIn = async () => {
   await auth.signInWithGoogle()
-}
-
-const handleSignUp = async () => {
-  const result = await auth.signUp(email.value, password.value)
-  if (result.success) {
-    signupSuccess.value = true
-  }
 }
 
 const handleForgotPassword = async () => {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -15,6 +15,12 @@ const router = createRouter({
       meta: { requiresGuest: true },
     },
     {
+      path: '/signup',
+      name: 'signup',
+      component: () => import('@/views/SignupView.vue'),
+      meta: { requiresGuest: true },
+    },
+    {
       path: '/auth/callback',
       name: 'auth-callback',
       component: () => import('@/views/AuthCallbackView.vue'),

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -69,13 +69,25 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
-  const signUp = async (email: string, password: string) => {
+  // Invite-only onboarding (SB-188): redeem a token → backend creates the
+  // account + returns a session, which we adopt into the Supabase client so
+  // the app is logged straight in. Open signup is intentionally gone.
+  const redeemInvite = async (token: string, password: string) => {
     loading.value = true
     clearError()
     try {
-      const { error: err } = await supabase.auth.signUp({ email, password })
+      const data = await apiCall<{ access_token: string; refresh_token: string }>(
+        '/invites/redeem',
+        { method: 'POST', body: JSON.stringify({ token, password }) },
+      )
+      const { data: sess, error: err } = await supabase.auth.setSession({
+        access_token: data.access_token,
+        refresh_token: data.refresh_token,
+      })
       if (err) throw err
-      return { success: true, message: 'Check your email to confirm your account.' }
+      session.value = sess.session
+      user.value = sess.user
+      return { success: true }
     } catch (err: any) {
       setError(err.message)
       return { success: false, error: err.message }
@@ -144,7 +156,7 @@ export const useAuthStore = defineStore('auth', () => {
     initialize,
     signIn,
     signInWithGoogle,
-    signUp,
+    redeemInvite,
     signOut,
     requestPasswordReset,
     applyPasswordReset,

--- a/frontend/src/views/SignupView.vue
+++ b/frontend/src/views/SignupView.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-brand-50 to-white px-4">
+    <div class="w-full max-w-sm mx-auto">
+      <div class="text-center mb-8">
+        <span class="text-5xl">🏃</span>
+        <h1 class="mt-3 text-2xl font-bold text-gray-900">MyRunStreak</h1>
+        <p class="mt-1 text-sm text-gray-500">Invite-only — claim your account</p>
+      </div>
+
+      <!-- No invite token in the link -->
+      <div v-if="!token" class="text-center space-y-4">
+        <div class="bg-amber-50 border border-amber-200 text-amber-800 text-sm rounded-lg px-4 py-3">
+          MyRunStreak is currently invite-only. You need an invite link to create an account.
+        </div>
+        <p class="text-sm text-gray-500">
+          Already have an account?
+          <router-link to="/login" class="text-brand-600 hover:underline font-medium">Sign in</router-link>
+        </p>
+      </div>
+
+      <!-- Redeem form -->
+      <form v-else @submit.prevent="handleRedeem" class="space-y-4">
+        <div>
+          <label for="password" class="form-label">Choose a password</label>
+          <input id="password" v-model="password" type="password" required autocomplete="new-password"
+            class="form-input" placeholder="••••••••" minlength="6" :disabled="auth.loading" />
+        </div>
+        <div>
+          <label for="confirm" class="form-label">Confirm password</label>
+          <input id="confirm" v-model="confirm" type="password" required autocomplete="new-password"
+            class="form-input" placeholder="••••••••" minlength="6" :disabled="auth.loading" />
+        </div>
+
+        <div v-if="mismatch" class="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-3 py-2">
+          Passwords don't match.
+        </div>
+        <div v-if="auth.error" class="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-3 py-2">
+          {{ auth.error }}
+        </div>
+
+        <button type="submit" class="btn-primary w-full py-2.5" :disabled="auth.loading">
+          {{ auth.loading ? 'Creating account…' : 'Create account' }}
+        </button>
+
+        <p class="text-center text-sm text-gray-500">
+          Already have an account?
+          <router-link to="/login" class="text-brand-600 hover:underline font-medium">Sign in</router-link>
+        </p>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+
+const auth = useAuthStore()
+const route = useRoute()
+const router = useRouter()
+
+const token = (route.query.invite as string) || ''
+const password = ref('')
+const confirm = ref('')
+
+const mismatch = computed(() => confirm.value.length > 0 && password.value !== confirm.value)
+
+const handleRedeem = async () => {
+  if (password.value !== confirm.value) return
+  const result = await auth.redeemInvite(token, password.value)
+  if (result.success) router.push('/dashboard')
+}
+</script>

--- a/frontend/src/views/__tests__/SignupView.test.ts
+++ b/frontend/src/views/__tests__/SignupView.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import SignupView from '../SignupView.vue'
+import { useAuthStore } from '@/stores/auth'
+
+const buildRouter = () =>
+  createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: { template: '<div>home</div>' } },
+      { path: '/login', component: { template: '<div>login</div>' } },
+      { path: '/signup', component: SignupView },
+      { path: '/dashboard', component: { template: '<div>dash</div>' } },
+    ],
+  })
+
+const mountAt = async (query: string) => {
+  const router = buildRouter()
+  await router.push(`/signup${query}`)
+  await router.isReady()
+  const w = mount(SignupView, { global: { plugins: [createPinia(), router] } })
+  await flushPromises()
+  return { w, router }
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+describe('SignupView', () => {
+  it('shows invite-only notice when no token in the link', async () => {
+    const { w } = await mountAt('')
+    expect(w.text()).toContain('invite-only')
+    expect(w.find('input[type="password"]').exists()).toBe(false)
+  })
+
+  it('renders the redeem form when an invite token is present', async () => {
+    const { w } = await mountAt('?invite=tok-abcdef')
+    expect(w.findAll('input[type="password"]').length).toBe(2)
+  })
+
+  it('redeems and routes to dashboard on success', async () => {
+    const { w, router } = await mountAt('?invite=tok-abcdef')
+    const auth = useAuthStore()
+    const spy = vi.spyOn(auth, 'redeemInvite').mockResolvedValue({ success: true })
+    const push = vi.spyOn(router, 'push')
+
+    const pwds = w.findAll('input[type="password"]')
+    await pwds[0].setValue('secret1')
+    await pwds[1].setValue('secret1')
+    await w.find('form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(spy).toHaveBeenCalledWith('tok-abcdef', 'secret1')
+    expect(push).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('does not redeem when passwords mismatch', async () => {
+    const { w } = await mountAt('?invite=tok-abcdef')
+    const auth = useAuthStore()
+    const spy = vi.spyOn(auth, 'redeemInvite').mockResolvedValue({ success: true })
+
+    const pwds = w.findAll('input[type="password"]')
+    await pwds[0].setValue('secret1')
+    await pwds[1].setValue('secret2')
+    await w.find('form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(spy).not.toHaveBeenCalled()
+    expect(w.text()).toContain("Passwords don't match")
+  })
+})


### PR DESCRIPTION
Frontend half of invite-only onboarding. **Closes the open-signup hole on the web** — the public email/password signup form is gone.

## Changes
- **auth store**: `signUp` → `redeemInvite(token, password)` — calls `POST /invites/redeem`, then adopts the returned session via `supabase.auth.setSession` so the invitee is logged straight in.
- **new `/signup?invite=<token>` route + `SignupView`**: no token → invite-only notice; with token → password + confirm → redeem. Email is server-side (bound to the invite), never entered here.
- **LoginForm**: removed the open "Sign up" mode; footer now states the site is invite-only. Google + forgot-password unchanged (login paths).
- **tests**: `SignupView` (4) — invite-only notice, form render, redeem→dashboard, password-mismatch guard.

## Verified
Frontend **82 tests pass**, `type-check` + `build` green.

## Merge order / deps
- **Depends on #109** (the `/invites/redeem` endpoint) — merge that first.
- **Owner step still required:** disable open signups in the Supabase dashboard (closes the Google self-signup path, which bypasses our backend entirely).

After both merge + deploy: `stk invite create --email <x>` → text the link → invitee sets a password → in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)