### PR TITLE
chore: enable invite issuance — set admin UUID (SB-188)

### DIFF
--- a/helm/myrunstreak/values.yaml
+++ b/helm/myrunstreak/values.yaml
@@ -80,7 +80,7 @@ backend:
     cacheDefaultTtlSeconds: 60
     # Comma-separated user UUIDs allowed to issue invites (SB-188). Set the
     # owner's UUID here to enable invite issuance; empty = disabled.
-    adminUserIds: ""
+    adminUserIds: "16eb502d-7fc0-4fce-9107-9931df747e28"
 
   resources:
     requests:


### PR DESCRIPTION
Sets the owner's Supabase auth UUID in `backend.env.adminUserIds` → `ADMIN_USER_IDS` env → `stk invite create` / `GET|POST /invites` are now authorized for the owner.

Open signups already disabled in the Supabase dashboard, so a redeemed invite is now the only way to create an account.

ArgoCD applies the env on merge (helm values change). After it rolls out:
```
stk invite create --email <co-builder>   # prints the redeem link
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)