### PR TITLE
feat: coach platform foundation — roles, athletes, coach links (SB-195)

### DIFF
--- a/backend/admin.py
+++ b/backend/admin.py
@@ -1,8 +1,9 @@
-"""Admin authorization for privileged actions (SB-188).
+"""Authorization for privileged + relationship-scoped actions (SB-195).
 
-Admin status is config-driven via ADMIN_USER_IDS — a small, auditable allowlist
-of user UUIDs. No role column on the users table yet; this keeps the surface
-minimal until a real role system lands.
+Roles now live in the `user_roles` table. `require_admin` checks the DB role
+first and still honors the legacy ADMIN_USER_IDS allowlist for one release, so
+nothing breaks during the migration. Athlete access flows through the
+coach<->athlete relationship.
 """
 
 from __future__ import annotations
@@ -11,12 +12,51 @@ from uuid import UUID
 
 from backend.config import get_settings
 from fastapi import HTTPException, status
+from src.shared.supabase_client import get_supabase_client
+from src.shared.supabase_ops import (
+    AthletesRepository,
+    CoachAthletesRepository,
+    UserRolesRepository,
+)
+
+_FORBIDDEN = status.HTTP_403_FORBIDDEN
+
+
+def _has_role(user_id: UUID, role: str) -> bool:
+    return UserRolesRepository(get_supabase_client()).has_role(user_id, role)
+
+
+def is_admin(user_id: UUID) -> bool:
+    # DB role OR the legacy config allowlist (transitional).
+    return _has_role(user_id, "admin") or str(user_id).lower() in get_settings().admin_ids()
 
 
 def require_admin(user_id: UUID) -> None:
-    """Raise 403 unless the user is in the ADMIN_USER_IDS allowlist."""
-    if str(user_id).lower() not in get_settings().admin_ids():
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Admin privileges required",
-        )
+    """Raise 403 unless the user is an admin."""
+    if not is_admin(user_id):
+        raise HTTPException(status_code=_FORBIDDEN, detail="Admin privileges required")
+
+
+def require_coach(user_id: UUID) -> None:
+    """Raise 403 unless the user is a coach (admins are coaches too)."""
+    if not (_has_role(user_id, "coach") or is_admin(user_id)):
+        raise HTTPException(status_code=_FORBIDDEN, detail="Coach privileges required")
+
+
+def can_access_athlete(user_id: UUID, athlete_id: UUID) -> bool:
+    """True if the user is the athlete, actively coaches them, or is admin."""
+    supabase = get_supabase_client()
+    athlete = AthletesRepository(supabase).get(athlete_id)
+    if athlete is None:
+        return False
+    if athlete.get("linked_user_id") and UUID(str(athlete["linked_user_id"])) == user_id:
+        return True
+    if CoachAthletesRepository(supabase).active_link_exists(user_id, athlete_id):
+        return True
+    return is_admin(user_id)
+
+
+def require_athlete_access(user_id: UUID, athlete_id: UUID) -> None:
+    """Raise 403 unless the user may act on this athlete."""
+    if not can_access_athlete(user_id, athlete_id):
+        raise HTTPException(status_code=_FORBIDDEN, detail="No access to this athlete")

--- a/backend/app.py
+++ b/backend/app.py
@@ -3,7 +3,17 @@
 import logging
 
 from backend.config import get_settings
-from backend.routes import auth_routes, invites, metrics, plan, runs, stats, sync, workouts
+from backend.routes import (
+    athletes,
+    auth_routes,
+    invites,
+    metrics,
+    plan,
+    runs,
+    stats,
+    sync,
+    workouts,
+)
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -47,6 +57,8 @@ def create_app() -> FastAPI:
     app.include_router(plan.router)
     app.include_router(workouts.router)
     app.include_router(invites.router)
+    app.include_router(athletes.router)
+    app.include_router(athletes.me_router)
 
     return app
 

--- a/backend/routes/athletes.py
+++ b/backend/routes/athletes.py
@@ -1,0 +1,104 @@
+"""/athletes — coach platform foundation (SB-195).
+
+A coach creates managed athletes and manages the coach<->athlete roster.
+Access to an athlete flows through an active coaching link (or being the
+athlete, or admin) — enforced by can_access_athlete.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from backend.admin import is_admin, require_athlete_access, require_coach
+from backend.auth import authenticate_request
+from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel
+from src.shared.models import Athlete, AthleteCreate, CoachAthlete
+from src.shared.supabase_client import get_supabase_client
+from src.shared.supabase_ops import (
+    AthletesRepository,
+    CoachAthletesRepository,
+    UserRolesRepository,
+)
+
+router = APIRouter(prefix="/athletes", tags=["athletes"])
+me_router = APIRouter(prefix="/me", tags=["me"])
+
+
+class AssignCoachRequest(BaseModel):
+    coach_id: UUID
+
+
+@me_router.get("/roles")
+def my_roles(user_id: UUID = Depends(authenticate_request)) -> dict[str, Any]:
+    """The caller's platform roles."""
+    roles = UserRolesRepository(get_supabase_client()).list_roles(user_id)
+    return {"roles": sorted(roles), "is_admin": "admin" in roles}
+
+
+@router.post("", response_model=Athlete, status_code=status.HTTP_201_CREATED)
+def create_athlete(
+    body: AthleteCreate,
+    user_id: UUID = Depends(authenticate_request),
+) -> Athlete:
+    """Create a managed athlete and make the caller their (first) coach."""
+    require_coach(user_id)
+    supabase = get_supabase_client()
+    row = AthletesRepository(supabase).create(
+        created_by=user_id,
+        display_name=body.display_name,
+        birth_year=body.birth_year,
+        notes=body.notes,
+    )
+    CoachAthletesRepository(supabase).assign(user_id, UUID(row["id"]))
+    return Athlete(**row)
+
+
+@router.get("", response_model=list[Athlete])
+def list_athletes(
+    user_id: UUID = Depends(authenticate_request),
+) -> list[Athlete]:
+    """Athletes the caller actively coaches."""
+    rows = AthletesRepository(get_supabase_client()).list_for_coach(user_id)
+    return [Athlete(**r) for r in rows]
+
+
+@router.get("/{athlete_id}", response_model=Athlete)
+def get_athlete(
+    athlete_id: UUID,
+    user_id: UUID = Depends(authenticate_request),
+) -> Athlete:
+    require_athlete_access(user_id, athlete_id)
+    row = AthletesRepository(get_supabase_client()).get(athlete_id)
+    assert row is not None  # require_athlete_access already proved existence + access
+    return Athlete(**row)
+
+
+@router.post(
+    "/{athlete_id}/coaches", response_model=CoachAthlete, status_code=status.HTTP_201_CREATED
+)
+def assign_coach(
+    athlete_id: UUID,
+    body: AssignCoachRequest,
+    user_id: UUID = Depends(authenticate_request),
+) -> CoachAthlete:
+    """Add a coach to an athlete. Caller must already have access; the new coach
+    is granted the coach role so they can act on the athlete."""
+    require_athlete_access(user_id, athlete_id)
+    supabase = get_supabase_client()
+    UserRolesRepository(supabase).grant(body.coach_id, "coach")
+    link = CoachAthletesRepository(supabase).assign(body.coach_id, athlete_id)
+    return CoachAthlete(**link)
+
+
+@router.delete("/{athlete_id}/coaches/{coach_id}", status_code=status.HTTP_204_NO_CONTENT)
+def end_coach(
+    athlete_id: UUID,
+    coach_id: UUID,
+    user_id: UUID = Depends(authenticate_request),
+) -> None:
+    """End a coaching link. The coach themselves or an admin may do this."""
+    if coach_id != user_id and not is_admin(user_id):
+        require_athlete_access(user_id, athlete_id)  # else must have access
+    CoachAthletesRepository(get_supabase_client()).end(coach_id, athlete_id)

--- a/backend/tests/test_coach_foundation.py
+++ b/backend/tests/test_coach_foundation.py
@@ -1,0 +1,185 @@
+"""SB-195: coach platform foundation — roles, athlete access, routes."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+
+@contextmanager
+def _admin_env(
+    *,
+    roles: set[str] | None = None,
+    athlete: dict[str, Any] | None = None,
+    active_link: bool = False,
+    admin_ids: set[str] | None = None,
+) -> Any:
+    """Patch backend.admin's dependencies for access-logic tests."""
+    roles_repo = MagicMock()
+    roles_repo.has_role.side_effect = lambda _uid, role: role in (roles or set())
+    athletes_repo = MagicMock()
+    athletes_repo.get.return_value = athlete
+    links_repo = MagicMock()
+    links_repo.active_link_exists.return_value = active_link
+    settings = SimpleNamespace(admin_ids=lambda: admin_ids or set())
+
+    with (
+        patch("backend.admin.get_supabase_client", return_value=MagicMock()),
+        patch("backend.admin.UserRolesRepository", return_value=roles_repo),
+        patch("backend.admin.AthletesRepository", return_value=athletes_repo),
+        patch("backend.admin.CoachAthletesRepository", return_value=links_repo),
+        patch("backend.admin.get_settings", return_value=settings),
+    ):
+        yield
+
+
+def test_require_admin_db_role() -> None:
+    from backend.admin import require_admin
+
+    with _admin_env(roles={"admin"}):
+        require_admin(uuid4())  # no raise
+
+
+def test_require_admin_config_fallback() -> None:
+    from backend.admin import require_admin
+
+    uid = uuid4()
+    with _admin_env(admin_ids={str(uid).lower()}):
+        require_admin(uid)  # legacy allowlist still works
+
+
+def test_require_admin_denies() -> None:
+    from backend.admin import require_admin
+
+    with _admin_env():
+        with pytest.raises(HTTPException) as exc:
+            require_admin(uuid4())
+    assert exc.value.status_code == 403
+
+
+def test_require_coach_allows_admin_and_coach() -> None:
+    from backend.admin import require_coach
+
+    with _admin_env(roles={"coach"}):
+        require_coach(uuid4())
+    with _admin_env(roles={"admin"}):
+        require_coach(uuid4())  # admins are coaches too
+    with _admin_env():
+        with pytest.raises(HTTPException):
+            require_coach(uuid4())
+
+
+def test_can_access_athlete_self() -> None:
+    from backend.admin import can_access_athlete
+
+    uid = uuid4()
+    athlete = {"id": str(uuid4()), "linked_user_id": str(uid)}
+    with _admin_env(athlete=athlete):
+        assert can_access_athlete(uid, uuid4()) is True
+
+
+def test_can_access_athlete_active_coach() -> None:
+    from backend.admin import can_access_athlete
+
+    athlete = {"id": str(uuid4()), "linked_user_id": None}
+    with _admin_env(athlete=athlete, active_link=True):
+        assert can_access_athlete(uuid4(), uuid4()) is True
+
+
+def test_can_access_athlete_admin() -> None:
+    from backend.admin import can_access_athlete
+
+    athlete = {"id": str(uuid4()), "linked_user_id": None}
+    with _admin_env(athlete=athlete, active_link=False, roles={"admin"}):
+        assert can_access_athlete(uuid4(), uuid4()) is True
+
+
+def test_can_access_athlete_denied() -> None:
+    from backend.admin import can_access_athlete
+
+    athlete = {"id": str(uuid4()), "linked_user_id": None}
+    with _admin_env(athlete=athlete, active_link=False):
+        assert can_access_athlete(uuid4(), uuid4()) is False
+
+
+def test_can_access_athlete_missing_is_false() -> None:
+    from backend.admin import can_access_athlete
+
+    with _admin_env(athlete=None):
+        assert can_access_athlete(uuid4(), uuid4()) is False
+
+
+def test_create_athlete_requires_coach() -> None:
+    from backend.routes.athletes import create_athlete
+    from src.shared.models import AthleteCreate
+
+    with _admin_env():  # not a coach
+        with pytest.raises(HTTPException) as exc:
+            create_athlete(AthleteCreate(display_name="Gabe"), user_id=uuid4())
+    assert exc.value.status_code == 403
+
+
+def test_create_athlete_creates_and_self_assigns() -> None:
+    from backend.routes.athletes import create_athlete
+    from src.shared.models import AthleteCreate
+
+    coach = uuid4()
+    aid = uuid4()
+    athletes_repo = MagicMock()
+    athletes_repo.create.return_value = {
+        "id": str(aid),
+        "display_name": "Gabe",
+        "birth_year": 2011,
+        "linked_user_id": None,
+        "created_by": str(coach),
+        "notes": None,
+        "created_at": "2026-06-21T00:00:00+00:00",
+    }
+    links_repo = MagicMock()
+
+    with (
+        _admin_env(roles={"coach"}),
+        patch("backend.routes.athletes.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.athletes.AthletesRepository", return_value=athletes_repo),
+        patch("backend.routes.athletes.CoachAthletesRepository", return_value=links_repo),
+    ):
+        out = create_athlete(AthleteCreate(display_name="Gabe", birth_year=2011), user_id=coach)
+
+    assert out.display_name == "Gabe"
+    links_repo.assign.assert_called_once_with(coach, aid)
+
+
+def test_assign_coach_grants_role_and_links() -> None:
+    from backend.routes.athletes import AssignCoachRequest, assign_coach
+
+    caller = uuid4()
+    new_coach = uuid4()
+    aid = uuid4()
+    roles_repo = MagicMock()
+    links_repo = MagicMock()
+    links_repo.assign.return_value = {
+        "id": str(uuid4()),
+        "coach_id": str(new_coach),
+        "athlete_id": str(aid),
+        "status": "active",
+        "started_at": "2026-06-21T00:00:00+00:00",
+        "ended_at": None,
+        "created_at": "2026-06-21T00:00:00+00:00",
+    }
+
+    with (
+        _admin_env(roles={"admin"}, athlete={"id": str(aid), "linked_user_id": None}),
+        patch("backend.routes.athletes.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.athletes.UserRolesRepository", return_value=roles_repo),
+        patch("backend.routes.athletes.CoachAthletesRepository", return_value=links_repo),
+    ):
+        out = assign_coach(aid, AssignCoachRequest(coach_id=new_coach), user_id=caller)
+
+    roles_repo.grant.assert_called_once_with(new_coach, "coach")
+    assert str(out.coach_id) == str(new_coach)

--- a/backend/tests/test_invites.py
+++ b/backend/tests/test_invites.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Any
@@ -91,6 +92,19 @@ def test_invite_create_list_get_redeem_roundtrip() -> None:
     assert repo.get_by_token("tok-abc")["redeemed_at"] is not None  # type: ignore[index]
 
 
+@contextmanager
+def _admin_via_config(settings: Any) -> Any:
+    """Admin resolves via the config allowlist; DB-role check is a no-op."""
+    roles_repo = MagicMock()
+    roles_repo.has_role.return_value = False
+    with (
+        patch("backend.admin.get_settings", return_value=settings),
+        patch("backend.admin.get_supabase_client", return_value=MagicMock()),
+        patch("backend.admin.UserRolesRepository", return_value=roles_repo),
+    ):
+        yield
+
+
 def test_require_admin_allows_listed_denies_others() -> None:
     from backend.admin import require_admin
 
@@ -98,7 +112,7 @@ def test_require_admin_allows_listed_denies_others() -> None:
     other = uuid4()
     settings = SimpleNamespace(admin_ids=lambda: {str(admin).lower()})
 
-    with patch("backend.admin.get_settings", return_value=settings):
+    with _admin_via_config(settings):
         require_admin(admin)  # no raise
         with pytest.raises(HTTPException) as exc:
             require_admin(other)
@@ -123,7 +137,7 @@ def test_issue_invite_route_denies_non_admin() -> None:
     from src.shared.models import InviteCreate
 
     empty = SimpleNamespace(admin_ids=lambda: set())
-    with patch("backend.admin.get_settings", return_value=empty):
+    with _admin_via_config(empty):
         with pytest.raises(HTTPException) as exc:
             issue_invite(InviteCreate(email="x@example.com"), user_id=uuid4())
     assert exc.value.status_code == 403

--- a/src/shared/models/__init__.py
+++ b/src/shared/models/__init__.py
@@ -1,6 +1,7 @@
 """Data models for MyRunStreak.com."""
 
 from .activity import Activity
+from .athlete import Athlete, AthleteCreate, CoachAthlete, CoachAthleteStatus, Role
 from .enums import (
     ActivityType,
     DeviceType,
@@ -66,6 +67,12 @@ __all__ = [
     "Activity",
     "Goal",
     "Split",
+    # Coach platform (SB-195)
+    "Athlete",
+    "AthleteCreate",
+    "CoachAthlete",
+    "CoachAthleteStatus",
+    "Role",
     # Invites
     "Invite",
     "InviteCreate",

--- a/src/shared/models/athlete.py
+++ b/src/shared/models/athlete.py
@@ -1,0 +1,47 @@
+"""Coach platform foundation models (SB-195): roles, athletes, coach links."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class Role(StrEnum):
+    ADMIN = "admin"
+    COACH = "coach"
+
+
+class CoachAthleteStatus(StrEnum):
+    ACTIVE = "active"
+    ENDED = "ended"
+
+
+class AthleteCreate(BaseModel):
+    """Create a managed athlete (the coach owns it; no login needed)."""
+
+    display_name: str = Field(min_length=1)
+    birth_year: int | None = Field(default=None, ge=1900, le=2100)
+    notes: str | None = None
+
+
+class Athlete(BaseModel):
+    id: UUID
+    display_name: str
+    birth_year: int | None = None
+    linked_user_id: UUID | None = None
+    created_by: UUID | None = None
+    notes: str | None = None
+    created_at: datetime
+
+
+class CoachAthlete(BaseModel):
+    id: UUID
+    coach_id: UUID
+    athlete_id: UUID
+    status: CoachAthleteStatus
+    started_at: datetime
+    ended_at: datetime | None = None
+    created_at: datetime

--- a/src/shared/supabase_ops/__init__.py
+++ b/src/shared/supabase_ops/__init__.py
@@ -1,5 +1,10 @@
 """Supabase database operations for MyRunStreak.com."""
 
+from .athletes_repository import (
+    AthletesRepository,
+    CoachAthletesRepository,
+    UserRolesRepository,
+)
 from .goals_repository import GoalsRepository
 from .invites_repository import InvitesRepository
 from .mappers import activity_to_run_dict, split_to_dict
@@ -23,6 +28,9 @@ from .workout_repository import (
 )
 
 __all__ = [
+    "AthletesRepository",
+    "CoachAthletesRepository",
+    "UserRolesRepository",
     "GoalsRepository",
     "InvitesRepository",
     "MetricEntriesRepository",

--- a/src/shared/supabase_ops/athletes_repository.py
+++ b/src/shared/supabase_ops/athletes_repository.py
@@ -1,0 +1,132 @@
+"""Repositories for the coach platform foundation (SB-195).
+
+The backend connects with the service-role key (bypasses RLS), so every method
+scopes by the relevant id in code. Access decisions live in the backend's
+can_access_athlete; these repos are the plain data layer.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, cast
+from uuid import UUID
+
+from supabase import Client
+
+
+class UserRolesRepository:
+    """Who is an admin / coach."""
+
+    def __init__(self, supabase: Client):
+        self.supabase = supabase
+
+    def list_roles(self, user_id: UUID) -> set[str]:
+        result = (
+            self.supabase.table("user_roles").select("role").eq("user_id", str(user_id)).execute()
+        )
+        return {r["role"] for r in cast(list[dict[str, Any]], result.data)}
+
+    def has_role(self, user_id: UUID, role: str) -> bool:
+        return role in self.list_roles(user_id)
+
+    def grant(self, user_id: UUID, role: str) -> None:
+        self.supabase.table("user_roles").upsert(
+            {"user_id": str(user_id), "role": role}, on_conflict="user_id,role"
+        ).execute()
+
+
+class AthletesRepository:
+    """Managed/linked athlete profiles."""
+
+    def __init__(self, supabase: Client):
+        self.supabase = supabase
+
+    def create(
+        self,
+        created_by: UUID,
+        display_name: str,
+        birth_year: int | None = None,
+        notes: str | None = None,
+    ) -> dict[str, Any]:
+        row = {"created_by": str(created_by), "display_name": display_name}
+        if birth_year is not None:
+            row["birth_year"] = birth_year  # type: ignore[assignment]
+        if notes is not None:
+            row["notes"] = notes
+        result = self.supabase.table("athletes").insert(row).execute()
+        return cast(list[dict[str, Any]], result.data)[0]
+
+    def get(self, athlete_id: UUID) -> dict[str, Any] | None:
+        result = self.supabase.table("athletes").select("*").eq("id", str(athlete_id)).execute()
+        data = cast(list[dict[str, Any]], result.data)
+        return data[0] if data else None
+
+    def list_for_coach(self, coach_id: UUID) -> list[dict[str, Any]]:
+        """Athletes the coach actively coaches (joined via coach_athletes)."""
+        links = (
+            self.supabase.table("coach_athletes")
+            .select("athlete_id")
+            .eq("coach_id", str(coach_id))
+            .eq("status", "active")
+            .execute()
+        )
+        ids = [r["athlete_id"] for r in cast(list[dict[str, Any]], links.data)]
+        if not ids:
+            return []
+        result = (
+            self.supabase.table("athletes")
+            .select("*")
+            .in_("id", ids)
+            .order("display_name")
+            .execute()
+        )
+        return cast(list[dict[str, Any]], result.data)
+
+
+class CoachAthletesRepository:
+    """The coach<->athlete relationship over time."""
+
+    def __init__(self, supabase: Client):
+        self.supabase = supabase
+
+    def active_link_exists(self, coach_id: UUID, athlete_id: UUID) -> bool:
+        result = (
+            self.supabase.table("coach_athletes")
+            .select("id")
+            .eq("coach_id", str(coach_id))
+            .eq("athlete_id", str(athlete_id))
+            .eq("status", "active")
+            .execute()
+        )
+        return bool(cast(list[dict[str, Any]], result.data))
+
+    def assign(self, coach_id: UUID, athlete_id: UUID) -> dict[str, Any]:
+        """Start an active coaching link (idempotent on the active uniqueness)."""
+        result = (
+            self.supabase.table("coach_athletes")
+            .insert({"coach_id": str(coach_id), "athlete_id": str(athlete_id)})
+            .execute()
+        )
+        return cast(list[dict[str, Any]], result.data)[0]
+
+    def end(self, coach_id: UUID, athlete_id: UUID) -> int:
+        """End the active link; returns rows affected."""
+        result = (
+            self.supabase.table("coach_athletes")
+            .update({"status": "ended", "ended_at": datetime.now(UTC).isoformat()})
+            .eq("coach_id", str(coach_id))
+            .eq("athlete_id", str(athlete_id))
+            .eq("status", "active")
+            .execute()
+        )
+        return len(cast(list[dict[str, Any]], result.data))
+
+    def list_active_for_coach(self, coach_id: UUID) -> list[dict[str, Any]]:
+        result = (
+            self.supabase.table("coach_athletes")
+            .select("*")
+            .eq("coach_id", str(coach_id))
+            .eq("status", "active")
+            .execute()
+        )
+        return cast(list[dict[str, Any]], result.data)

--- a/stk/src/cli/commands/athlete.py
+++ b/stk/src/cli/commands/athlete.py
@@ -1,0 +1,73 @@
+"""Athlete commands for stk CLI — coach platform foundation (SB-195)."""
+
+from __future__ import annotations
+
+import typer
+
+from cli import api, config, display
+
+athlete_app = typer.Typer(help="Manage athletes you coach + set the active athlete.")
+
+
+def add(
+    name: str = typer.Option(..., "--name", "-n", help="Athlete display name"),
+    birth_year: int = typer.Option(None, "--birth-year", "-y", help="Birth year"),
+) -> None:
+    """Create a managed athlete (you become their coach)."""
+    body: dict[str, object] = {"display_name": name}
+    if birth_year is not None:
+        body["birth_year"] = birth_year
+    result = api.post_request("athletes", body)
+    display.console.print(
+        f"[green]Athlete added[/green] {result['display_name']}  id={result['id']}"
+    )
+
+
+def list_athletes() -> None:
+    """List athletes you actively coach."""
+    rows = api.request("athletes")
+    if not rows:
+        display.console.print("No athletes yet. Add one with 'stk athlete add --name <name>'.")
+        return
+    active = config.get_active_athlete()
+    active_id = active["id"] if active else None
+    for r in rows:
+        mark = "→ " if r["id"] == active_id else "  "
+        yr = f" (b. {r['birth_year']})" if r.get("birth_year") else ""
+        display.console.print(f"{mark}{r['display_name']}{yr}  id={r['id'][:8]}")
+
+
+def use(
+    who: str = typer.Argument(..., help="Athlete name or 8-char id prefix"),
+) -> None:
+    """Set the active athlete (subsequent workout commands target them)."""
+    rows = api.request("athletes")
+    matches = [
+        r for r in rows if r["id"].startswith(who) or who.lower() in r["display_name"].lower()
+    ]
+    if not matches:
+        display.console.print(f"[red]No athlete matching '{who}'[/red]")
+        raise typer.Exit(1)
+    if len(matches) > 1:
+        display.console.print(f"[red]'{who}' is ambiguous — use the id prefix[/red]")
+        raise typer.Exit(1)
+    a = matches[0]
+    config.set_active_athlete(a["id"], a["display_name"])
+    display.console.print(f"[green]Active athlete:[/green] {a['display_name']}")
+
+
+def whoami() -> None:
+    """Show your roles and the active athlete."""
+    roles = api.request("me/roles")
+    display.console.print(f"  roles: {', '.join(roles.get('roles', [])) or '(none)'}")
+    active = config.get_active_athlete()
+    if active:
+        display.console.print(f"  active athlete: {active['name']}  id={active['id'][:8]}")
+    else:
+        display.console.print("  active athlete: (none) — set with 'stk athlete use <name>'")
+
+
+athlete_app.command(name="add")(add)
+athlete_app.command(name="list")(list_athletes)
+athlete_app.command(name="use")(use)
+athlete_app.command(name="whoami")(whoami)

--- a/stk/src/cli/config.py
+++ b/stk/src/cli/config.py
@@ -1,0 +1,45 @@
+"""Local stk config (non-secret) — currently the active athlete context.
+
+Stored at ``~/.config/stk/config.json``, separate from the auth session.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+CONFIG_DIR = Path.home() / ".config" / "stk"
+CONFIG_FILE = CONFIG_DIR / "config.json"
+
+
+def _load() -> dict[str, Any]:
+    if not CONFIG_FILE.exists():
+        return {}
+    try:
+        data: dict[str, Any] = json.loads(CONFIG_FILE.read_text())
+        return data
+    except (ValueError, OSError):
+        return {}
+
+
+def _save(data: dict[str, Any]) -> None:
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    CONFIG_FILE.write_text(json.dumps(data, indent=2))
+
+
+def get_active_athlete() -> dict[str, str] | None:
+    """Returns {'id':..., 'name':...} or None."""
+    return _load().get("active_athlete")
+
+
+def set_active_athlete(athlete_id: str, name: str) -> None:
+    data = _load()
+    data["active_athlete"] = {"id": athlete_id, "name": name}
+    _save(data)
+
+
+def clear_active_athlete() -> None:
+    data = _load()
+    data.pop("active_athlete", None)
+    _save(data)

--- a/stk/src/cli/main.py
+++ b/stk/src/cli/main.py
@@ -17,7 +17,7 @@ import typer
 from rich.console import Console
 
 from cli import __version__
-from cli.commands import auth, invite, plan, runs, splits, stats, sync, workout
+from cli.commands import athlete, auth, invite, plan, runs, splits, stats, sync, workout
 
 # Create the main app
 app = typer.Typer(
@@ -35,6 +35,7 @@ app.add_typer(plan.readiness_app, name="readiness", help="Daily readiness check-
 app.add_typer(splits.splits_app, name="splits", help="Per-mile splits")
 app.add_typer(workout.workout_app, name="workout", help="Athlete workout tracker")
 app.add_typer(invite.invite_app, name="invite", help="Invite-only onboarding (admin)")
+app.add_typer(athlete.athlete_app, name="athlete", help="Athletes you coach")
 
 # Console for output
 console = Console()

--- a/supabase/migrations/20260621000000_coach_foundation.sql
+++ b/supabase/migrations/20260621000000_coach_foundation.sql
@@ -1,0 +1,106 @@
+-- =====================================================
+-- Coach platform foundation (SB-195): identity + relationships.
+--
+--   user_roles      who is an admin / coach (retires the ADMIN_USER_IDS hack)
+--   athletes        a trackable person — managed (no login) or linked to a user
+--   coach_athletes  the coach<->athlete relationship over time (active|ended)
+--
+-- Data is owned by the ATHLETE (later: workouts reference athlete_id), so a new
+-- coach sees the full history and reassigning coaches re-homes nothing. Access
+-- is granted by an ACTIVE coach link (or being the linked user, or admin).
+--
+-- The backend uses the service-role key (bypasses RLS) and enforces access in
+-- code (can_access_athlete). RLS here is the second line of defence for direct
+-- anon-key access.
+-- =====================================================
+
+CREATE TYPE user_role AS ENUM ('admin', 'coach');
+CREATE TYPE coach_athlete_status AS ENUM ('active', 'ended');
+
+-- ---- tables -----------------------------------------
+
+-- user_roles — replaces the ADMIN_USER_IDS env allowlist
+CREATE TABLE user_roles (
+    user_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    role user_role NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, role)
+);
+COMMENT ON TABLE user_roles IS 'Per-user platform roles (SB-195); admin/coach grants';
+
+-- athletes — the training subject (managed or linked to a login)
+CREATE TABLE athletes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    display_name TEXT NOT NULL,
+    birth_year INT,                                   -- minor-aware; age-norms later
+    linked_user_id UUID REFERENCES users(user_id) ON DELETE SET NULL,  -- self/parent login (future)
+    created_by UUID NOT NULL REFERENCES users(user_id) ON DELETE SET NULL,
+    notes TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_athletes_linked_user ON athletes (linked_user_id);
+CREATE INDEX idx_athletes_created_by ON athletes (created_by);
+COMMENT ON TABLE athletes IS 'A trackable athlete (SB-195); managed (no login) or linked to a user';
+COMMENT ON COLUMN athletes.linked_user_id IS 'If set, that user IS this athlete (self/parent access)';
+
+-- coach_athletes — the relationship over time
+CREATE TABLE coach_athletes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    coach_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    athlete_id UUID NOT NULL REFERENCES athletes(id) ON DELETE CASCADE,
+    status coach_athlete_status NOT NULL DEFAULT 'active',
+    started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ended_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+-- At most one active link per (coach, athlete); re-coaching after an end is fine.
+CREATE UNIQUE INDEX idx_coach_athletes_active
+    ON coach_athletes (coach_id, athlete_id)
+    WHERE status = 'active';
+CREATE INDEX idx_coach_athletes_coach ON coach_athletes (coach_id, status);
+CREATE INDEX idx_coach_athletes_athlete ON coach_athletes (athlete_id, status);
+COMMENT ON TABLE coach_athletes IS 'Coach<->athlete relationship history (SB-195); active row = current coach';
+
+-- ---- RLS (after all tables exist, since policies cross-reference) ----
+
+ALTER TABLE user_roles ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "own roles select" ON user_roles FOR SELECT USING (user_id = auth.uid());
+
+ALTER TABLE athletes ENABLE ROW LEVEL SECURITY;
+-- See/edit an athlete if you ARE them, or you actively coach them.
+CREATE POLICY "athletes select" ON athletes FOR SELECT
+    USING (
+        linked_user_id = auth.uid()
+        OR id IN (
+            SELECT athlete_id FROM coach_athletes
+            WHERE coach_id = auth.uid() AND status = 'active'
+        )
+    );
+CREATE POLICY "athletes insert" ON athletes FOR INSERT
+    WITH CHECK (created_by = auth.uid());
+CREATE POLICY "athletes update" ON athletes FOR UPDATE
+    USING (
+        linked_user_id = auth.uid()
+        OR id IN (
+            SELECT athlete_id FROM coach_athletes
+            WHERE coach_id = auth.uid() AND status = 'active'
+        )
+    );
+
+ALTER TABLE coach_athletes ENABLE ROW LEVEL SECURITY;
+-- A coach manages + sees their own links; an athlete sees who coaches them.
+CREATE POLICY "coach_athletes select" ON coach_athletes FOR SELECT
+    USING (
+        coach_id = auth.uid()
+        OR athlete_id IN (SELECT id FROM athletes WHERE linked_user_id = auth.uid())
+    );
+CREATE POLICY "coach_athletes insert" ON coach_athletes FOR INSERT
+    WITH CHECK (coach_id = auth.uid());
+CREATE POLICY "coach_athletes update" ON coach_athletes FOR UPDATE
+    USING (coach_id = auth.uid());
+
+-- ---- seed: owner is admin + coach (usable immediately; keeps invites working) ----
+INSERT INTO user_roles (user_id, role) VALUES
+    ('16eb502d-7fc0-4fce-9107-9931df747e28', 'admin'),
+    ('16eb502d-7fc0-4fce-9107-9931df747e28', 'coach')
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
**Build-small first slice** of the Coach Platform (SB-189 epic). The identity + relationships backbone every coach feature sits on. **No workout changes yet** (that's Phase 2 / SB-198).

## Migration
- **`user_roles`** (`admin` | `coach`) — retires the `ADMIN_USER_IDS` config hack; seeds the owner as both.
- **`athletes`** — managed (no login) or linked profiles; `birth_year` (minor-aware), `created_by`, `linked_user_id?` (future self/parent access).
- **`coach_athletes`** — the relationship over time (`active` | `ended`). End one, start another = changed coach, **full history preserved**. Unique active link per pair.
- Strict RLS on all three.

## Access (the reusable bit)
Data is **athlete-owned**, so a new coach sees the entire history — nothing re-homes. `can_access_athlete = you are the athlete (linked) OR you actively coach them OR admin`.
- `require_admin` now checks the **DB role** (config allowlist kept as a one-release fallback — no flip-day break)
- `require_coach`, `require_athlete_access`

## API + CLI
- `/athletes` CRUD (coach-gated; create self-assigns you as coach), `/athletes/{id}/coaches` assign (grants the coach role) + end, `/me/roles`
- `stk athlete add | list | use | whoami` (active athlete stored locally)

## Decisions baked in
Ex-coach access revoked on end · multiple concurrent coaches allowed · act-as = coach uses **their own identity** scoped to a roster athlete (auditable, not a separate login).

## Verified
backend **156@85%**, root 52@63%, lint+format clean, migration parses (3 tables, 7 policies), `stk athlete` registered.

Part of SB-195. **Next:** Phase 2 — retrofit `athlete_id` onto workouts so a coach builds + logs an athlete's training (SB-198).

🤖 Generated with [Claude Code](https://claude.com/claude-code)