### PR TITLE
feat: act-as scoping for workouts — coach builds/logs athlete training (SB-198)

### DIFF
--- a/backend/routes/workouts.py
+++ b/backend/routes/workouts.py
@@ -11,9 +11,10 @@ from __future__ import annotations
 from datetime import date
 from uuid import UUID
 
+from backend.admin import require_athlete_access
 from backend.auth import authenticate_request
 from backend.cache import invalidate_user
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
 from src.shared.models.workout import (
     Exercise,
     WorkoutSession,
@@ -29,6 +30,21 @@ from src.shared.supabase_ops import (
 )
 
 router = APIRouter(prefix="/workouts", tags=["workouts"])
+
+
+def acting_athlete(
+    user_id: UUID = Depends(authenticate_request),
+    x_act_as_athlete: UUID | None = Header(default=None, alias="X-Act-As-Athlete"),
+) -> UUID | None:
+    """The athlete the caller is acting as (SB-198), or None for self.
+
+    When set, the caller must have access to that athlete — so every workout
+    operation below is scoped to an athlete the coach actually coaches.
+    """
+    if x_act_as_athlete is None:
+        return None
+    require_athlete_access(user_id, x_act_as_athlete)
+    return x_act_as_athlete
 
 
 # ---------------------------------------------------------------- catalog
@@ -49,6 +65,7 @@ def list_exercises(
 async def create_template(
     body: WorkoutTemplateCreate,
     user_id: UUID = Depends(authenticate_request),
+    athlete_id: UUID | None = Depends(acting_athlete),
 ) -> WorkoutTemplate:
     supabase = get_supabase_client()
     valid = ExercisesRepository(supabase).keys()
@@ -57,7 +74,7 @@ async def create_template(
         raise HTTPException(status.HTTP_400_BAD_REQUEST, f"Unknown exercise(s): {sorted(unknown)}")
 
     row = WorkoutTemplatesRepository(supabase).create(
-        user_id, body.model_dump(mode="json", exclude_none=True)
+        user_id, body.model_dump(mode="json", exclude_none=True), athlete_id=athlete_id
     )
     await invalidate_user(user_id)
     return WorkoutTemplate(**row)
@@ -66,8 +83,9 @@ async def create_template(
 @router.get("/templates", response_model=list[WorkoutTemplate])
 def list_templates(
     user_id: UUID = Depends(authenticate_request),
+    athlete_id: UUID | None = Depends(acting_athlete),
 ) -> list[WorkoutTemplate]:
-    rows = WorkoutTemplatesRepository(get_supabase_client()).list(user_id)
+    rows = WorkoutTemplatesRepository(get_supabase_client()).list(user_id, athlete_id=athlete_id)
     return [WorkoutTemplate(**r) for r in rows]
 
 
@@ -75,8 +93,11 @@ def list_templates(
 def get_template(
     template_id: UUID,
     user_id: UUID = Depends(authenticate_request),
+    athlete_id: UUID | None = Depends(acting_athlete),
 ) -> WorkoutTemplate:
-    row = WorkoutTemplatesRepository(get_supabase_client()).get(user_id, template_id)
+    row = WorkoutTemplatesRepository(get_supabase_client()).get(
+        user_id, template_id, athlete_id=athlete_id
+    )
     if row is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Template not found")
     return WorkoutTemplate(**row)
@@ -86,8 +107,11 @@ def get_template(
 async def delete_template(
     template_id: UUID,
     user_id: UUID = Depends(authenticate_request),
+    athlete_id: UUID | None = Depends(acting_athlete),
 ) -> None:
-    if not WorkoutTemplatesRepository(get_supabase_client()).delete(user_id, template_id):
+    if not WorkoutTemplatesRepository(get_supabase_client()).delete(
+        user_id, template_id, athlete_id=athlete_id
+    ):
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Template not found")
     await invalidate_user(user_id)
 
@@ -99,6 +123,7 @@ async def delete_template(
 async def create_session(
     body: WorkoutSessionCreate,
     user_id: UUID = Depends(authenticate_request),
+    athlete_id: UUID | None = Depends(acting_athlete),
 ) -> WorkoutSession:
     supabase = get_supabase_client()
     valid = ExercisesRepository(supabase).keys()
@@ -107,7 +132,7 @@ async def create_session(
         raise HTTPException(status.HTTP_400_BAD_REQUEST, f"Unknown exercise(s): {sorted(unknown)}")
 
     row = WorkoutSessionsRepository(supabase).create(
-        user_id, body.model_dump(mode="json", exclude_none=True)
+        user_id, body.model_dump(mode="json", exclude_none=True), athlete_id=athlete_id
     )
     await invalidate_user(user_id)
     return WorkoutSession(**row)
@@ -116,12 +141,13 @@ async def create_session(
 @router.get("/sessions", response_model=list[WorkoutSession])
 def list_sessions(
     user_id: UUID = Depends(authenticate_request),
+    athlete_id: UUID | None = Depends(acting_athlete),
     date_from: date | None = Query(default=None),
     date_to: date | None = Query(default=None),
     limit: int = Query(default=100, ge=1, le=500),
 ) -> list[WorkoutSession]:
     rows = WorkoutSessionsRepository(get_supabase_client()).list(
-        user_id, date_from=date_from, date_to=date_to, limit=limit
+        user_id, date_from=date_from, date_to=date_to, limit=limit, athlete_id=athlete_id
     )
     return [WorkoutSession(**r) for r in rows]
 
@@ -130,8 +156,11 @@ def list_sessions(
 def get_session(
     session_id: UUID,
     user_id: UUID = Depends(authenticate_request),
+    athlete_id: UUID | None = Depends(acting_athlete),
 ) -> WorkoutSession:
-    row = WorkoutSessionsRepository(get_supabase_client()).get(user_id, session_id)
+    row = WorkoutSessionsRepository(get_supabase_client()).get(
+        user_id, session_id, athlete_id=athlete_id
+    )
     if row is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
     return WorkoutSession(**row)
@@ -141,7 +170,10 @@ def get_session(
 async def delete_session(
     session_id: UUID,
     user_id: UUID = Depends(authenticate_request),
+    athlete_id: UUID | None = Depends(acting_athlete),
 ) -> None:
-    if not WorkoutSessionsRepository(get_supabase_client()).delete(user_id, session_id):
+    if not WorkoutSessionsRepository(get_supabase_client()).delete(
+        user_id, session_id, athlete_id=athlete_id
+    ):
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
     await invalidate_user(user_id)

--- a/backend/tests/test_workout_actas.py
+++ b/backend/tests/test_workout_actas.py
@@ -1,0 +1,112 @@
+"""SB-198: act-as scoping — acting_athlete dependency + athlete-owned rows."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from src.shared.supabase_ops.workout_repository import WorkoutTemplatesRepository
+
+
+class _Q:
+    def __init__(self, table: str, store: dict[str, list[dict[str, Any]]]) -> None:
+        self.table, self.store = table, store
+        self._mode, self._payload = "select", None
+
+    def select(self, *a: Any, **k: Any) -> _Q:
+        return self
+
+    def eq(self, *a: Any, **k: Any) -> _Q:
+        return self
+
+    def is_(self, *a: Any, **k: Any) -> _Q:
+        return self
+
+    def order(self, *a: Any, **k: Any) -> _Q:
+        return self
+
+    def insert(self, payload: Any) -> _Q:
+        self._mode, self._payload = "insert", payload
+        return self
+
+    def execute(self) -> Any:
+        from types import SimpleNamespace
+
+        if self._mode == "insert":
+            rows = self._payload if isinstance(self._payload, list) else [self._payload]
+            out = []
+            for r in rows:
+                row = dict(r) if "id" in r else {"id": str(uuid4()), **r}
+                self.store.setdefault(self.table, []).append(row)
+                out.append(row)
+            return SimpleNamespace(data=out)
+        return SimpleNamespace(data=self.store.get(self.table, []))
+
+
+class _Client:
+    def __init__(self) -> None:
+        self.store: dict[str, list[dict[str, Any]]] = {}
+
+    def table(self, name: str) -> _Q:
+        return _Q(name, self.store)
+
+
+def test_acting_athlete_none_when_no_header() -> None:
+    from backend.routes.workouts import acting_athlete
+
+    assert acting_athlete(user_id=uuid4(), x_act_as_athlete=None) is None
+
+
+def test_acting_athlete_validates_and_returns() -> None:
+    from backend.routes.workouts import acting_athlete
+
+    coach, aid = uuid4(), uuid4()
+    with patch("backend.routes.workouts.require_athlete_access") as guard:
+        out = acting_athlete(user_id=coach, x_act_as_athlete=aid)
+    assert out == aid
+    guard.assert_called_once_with(coach, aid)
+
+
+def test_acting_athlete_propagates_denial() -> None:
+    from backend.routes.workouts import acting_athlete
+
+    with patch(
+        "backend.routes.workouts.require_athlete_access",
+        side_effect=HTTPException(status_code=403, detail="no"),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            acting_athlete(user_id=uuid4(), x_act_as_athlete=uuid4())
+    assert exc.value.status_code == 403
+
+
+def test_template_create_with_athlete_sets_owner_fields() -> None:
+    client = _Client()
+    repo = WorkoutTemplatesRepository(client)  # type: ignore[arg-type]
+    coach, aid = uuid4(), uuid4()
+
+    repo.create(
+        coach,
+        {"name": "Saturday Circuit", "type": "circuit", "rounds": 3, "items": []},
+        athlete_id=aid,
+    )
+
+    row = client.store["workout_templates"][0]
+    assert row["athlete_id"] == str(aid)
+    assert row["created_by"] == str(coach)
+    assert row["user_id"] == str(coach)
+
+
+def test_template_create_self_has_no_athlete() -> None:
+    client = _Client()
+    repo = WorkoutTemplatesRepository(client)  # type: ignore[arg-type]
+    user = uuid4()
+
+    repo.create(user, {"name": "My circuit", "type": "circuit", "rounds": 1, "items": []})
+
+    row = client.store["workout_templates"][0]
+    assert "athlete_id" not in row
+    assert "created_by" not in row
+    assert row["user_id"] == str(user)

--- a/backend/tests/test_workout_repository.py
+++ b/backend/tests/test_workout_repository.py
@@ -25,6 +25,9 @@ class _FakeQuery:
     def eq(self, *a: Any, **k: Any) -> _FakeQuery:
         return self
 
+    def is_(self, *a: Any, **k: Any) -> _FakeQuery:
+        return self
+
     def gte(self, *a: Any, **k: Any) -> _FakeQuery:
         return self
 

--- a/src/shared/models/workout.py
+++ b/src/shared/models/workout.py
@@ -85,6 +85,8 @@ class WorkoutTemplate(BaseModel):
 
     id: UUID
     user_id: UUID
+    athlete_id: UUID | None = None
+    created_by: UUID | None = None
     name: str
     type: WorkoutType
     rounds: int
@@ -139,6 +141,8 @@ class WorkoutSession(BaseModel):
 
     id: UUID
     user_id: UUID
+    athlete_id: UUID | None = None
+    created_by: UUID | None = None
     session_date: date
     template_id: UUID | None = None
     type: WorkoutType

--- a/src/shared/supabase_ops/workout_repository.py
+++ b/src/shared/supabase_ops/workout_repository.py
@@ -18,6 +18,24 @@ from uuid import UUID
 from supabase import Client
 
 
+def _owner_fields(user_id: UUID, athlete_id: UUID | None) -> dict[str, str]:
+    """Owner columns for a row. Self → user_id only. Athlete (act-as) → also
+    athlete_id (the subject) + created_by (the acting coach, for audit)."""
+    fields = {"user_id": str(user_id)}
+    if athlete_id is not None:
+        fields["athlete_id"] = str(athlete_id)
+        fields["created_by"] = str(user_id)
+    return fields
+
+
+def _scope(query: Any, user_id: UUID, athlete_id: UUID | None) -> Any:
+    """Limit a query to the owner. Athlete rows by athlete_id; self rows by
+    user_id AND athlete_id IS NULL (so a coach's own rows never leak athletes')."""
+    if athlete_id is not None:
+        return query.eq("athlete_id", str(athlete_id))
+    return query.eq("user_id", str(user_id)).is_("athlete_id", "null")
+
+
 class ExercisesRepository:
     """Read-only global movement catalog."""
 
@@ -41,42 +59,34 @@ class WorkoutTemplatesRepository:
     def __init__(self, supabase: Client):
         self.supabase = supabase
 
-    def create(self, user_id: UUID, payload: dict[str, Any]) -> dict[str, Any]:
+    def create(
+        self, user_id: UUID, payload: dict[str, Any], athlete_id: UUID | None = None
+    ) -> dict[str, Any]:
         items: Sequence[dict[str, Any]] = payload.pop("items", []) or []
-        row = (
-            self.supabase.table("workout_templates")
-            .insert({**payload, "user_id": str(user_id)})
-            .execute()
-        )
+        owner = _owner_fields(user_id, athlete_id)
+        row = self.supabase.table("workout_templates").insert({**payload, **owner}).execute()
         template = cast(list[dict[str, Any]], row.data)[0]
         if items:
-            item_rows = [
-                {**it, "user_id": str(user_id), "template_id": template["id"]} for it in items
-            ]
+            item_rows = [{**it, **owner, "template_id": template["id"]} for it in items]
             self.supabase.table("template_items").insert(item_rows).execute()
-        got = self.get(user_id, UUID(template["id"]))
+        got = self.get(user_id, UUID(template["id"]), athlete_id)
         assert got is not None
         return got
 
-    def list(self, user_id: UUID) -> list[dict[str, Any]]:
-        result = (
-            self.supabase.table("workout_templates")
-            .select("*")
-            .eq("user_id", str(user_id))
-            .order("created_at", desc=True)
-            .execute()
-        )
+    def list(self, user_id: UUID, athlete_id: UUID | None = None) -> list[dict[str, Any]]:
+        query = _scope(self.supabase.table("workout_templates").select("*"), user_id, athlete_id)
+        result = query.order("created_at", desc=True).execute()
         return cast(list[dict[str, Any]], result.data)
 
-    def get(self, user_id: UUID, template_id: UUID) -> dict[str, Any] | None:
-        result = (
-            self.supabase.table("workout_templates")
-            .select("*")
-            .eq("id", str(template_id))
-            .eq("user_id", str(user_id))
-            .execute()
+    def get(
+        self, user_id: UUID, template_id: UUID, athlete_id: UUID | None = None
+    ) -> dict[str, Any] | None:
+        query = _scope(
+            self.supabase.table("workout_templates").select("*").eq("id", str(template_id)),
+            user_id,
+            athlete_id,
         )
-        rows = cast(list[dict[str, Any]], result.data)
+        rows = cast(list[dict[str, Any]], query.execute().data)
         if not rows:
             return None
         template = rows[0]
@@ -90,15 +100,13 @@ class WorkoutTemplatesRepository:
         template["items"] = cast(list[dict[str, Any]], items.data)
         return template
 
-    def delete(self, user_id: UUID, template_id: UUID) -> bool:
-        result = (
-            self.supabase.table("workout_templates")
-            .delete()
-            .eq("id", str(template_id))
-            .eq("user_id", str(user_id))
-            .execute()
+    def delete(self, user_id: UUID, template_id: UUID, athlete_id: UUID | None = None) -> bool:
+        query = _scope(
+            self.supabase.table("workout_templates").delete().eq("id", str(template_id)),
+            user_id,
+            athlete_id,
         )
-        return bool(cast(list[dict[str, Any]], result.data))
+        return bool(cast(list[dict[str, Any]], query.execute().data))
 
 
 class WorkoutSessionsRepository:
@@ -107,18 +115,17 @@ class WorkoutSessionsRepository:
     def __init__(self, supabase: Client):
         self.supabase = supabase
 
-    def create(self, user_id: UUID, payload: dict[str, Any]) -> dict[str, Any]:
+    def create(
+        self, user_id: UUID, payload: dict[str, Any], athlete_id: UUID | None = None
+    ) -> dict[str, Any]:
         sets: Sequence[dict[str, Any]] = payload.pop("sets", []) or []
-        row = (
-            self.supabase.table("workout_sessions")
-            .insert({**payload, "user_id": str(user_id)})
-            .execute()
-        )
+        owner = _owner_fields(user_id, athlete_id)
+        row = self.supabase.table("workout_sessions").insert({**payload, **owner}).execute()
         session = cast(list[dict[str, Any]], row.data)[0]
         if sets:
-            set_rows = [{**s, "user_id": str(user_id), "session_id": session["id"]} for s in sets]
+            set_rows = [{**s, **owner, "session_id": session["id"]} for s in sets]
             self.supabase.table("exercise_sets").insert(set_rows).execute()
-        got = self.get(user_id, UUID(session["id"]))
+        got = self.get(user_id, UUID(session["id"]), athlete_id)
         assert got is not None
         return got
 
@@ -128,8 +135,9 @@ class WorkoutSessionsRepository:
         date_from: date | None = None,
         date_to: date | None = None,
         limit: int = 100,
+        athlete_id: UUID | None = None,
     ) -> list[dict[str, Any]]:
-        query = self.supabase.table("workout_sessions").select("*").eq("user_id", str(user_id))
+        query = _scope(self.supabase.table("workout_sessions").select("*"), user_id, athlete_id)
         if date_from is not None:
             query = query.gte("session_date", date_from.isoformat())
         if date_to is not None:
@@ -137,15 +145,15 @@ class WorkoutSessionsRepository:
         result = query.order("session_date", desc=True).limit(limit).execute()
         return cast(list[dict[str, Any]], result.data)
 
-    def get(self, user_id: UUID, session_id: UUID) -> dict[str, Any] | None:
-        result = (
-            self.supabase.table("workout_sessions")
-            .select("*")
-            .eq("id", str(session_id))
-            .eq("user_id", str(user_id))
-            .execute()
+    def get(
+        self, user_id: UUID, session_id: UUID, athlete_id: UUID | None = None
+    ) -> dict[str, Any] | None:
+        query = _scope(
+            self.supabase.table("workout_sessions").select("*").eq("id", str(session_id)),
+            user_id,
+            athlete_id,
         )
-        rows = cast(list[dict[str, Any]], result.data)
+        rows = cast(list[dict[str, Any]], query.execute().data)
         if not rows:
             return None
         session = rows[0]
@@ -160,12 +168,10 @@ class WorkoutSessionsRepository:
         session["sets"] = cast(list[dict[str, Any]], sets.data)
         return session
 
-    def delete(self, user_id: UUID, session_id: UUID) -> bool:
-        result = (
-            self.supabase.table("workout_sessions")
-            .delete()
-            .eq("id", str(session_id))
-            .eq("user_id", str(user_id))
-            .execute()
+    def delete(self, user_id: UUID, session_id: UUID, athlete_id: UUID | None = None) -> bool:
+        query = _scope(
+            self.supabase.table("workout_sessions").delete().eq("id", str(session_id)),
+            user_id,
+            athlete_id,
         )
-        return bool(cast(list[dict[str, Any]], result.data))
+        return bool(cast(list[dict[str, Any]], query.execute().data))

--- a/stk/src/cli/api.py
+++ b/stk/src/cli/api.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import httpx
 
+from cli import config as config_mod
 from cli import session as session_mod
 from cli.display import display_error, display_info
 
@@ -91,7 +92,13 @@ def _ensure_fresh(s: session_mod.Session) -> session_mod.Session:
 
 
 def _auth_headers(s: session_mod.Session) -> dict[str, str]:
-    return {"Authorization": f"Bearer {s.access_token}"}
+    headers = {"Authorization": f"Bearer {s.access_token}"}
+    # Act-as: when an active athlete is set, workout calls target them (SB-198).
+    # Other endpoints ignore the header.
+    active = config_mod.get_active_athlete()
+    if active:
+        headers["X-Act-As-Athlete"] = active["id"]
+    return headers
 
 
 def _exit_with_error(response: httpx.Response) -> None:

--- a/supabase/migrations/20260621010000_workouts_athlete_scope.sql
+++ b/supabase/migrations/20260621010000_workouts_athlete_scope.sql
@@ -1,0 +1,75 @@
+-- =====================================================
+-- Scope workouts to an athlete (SB-198). A coach acting-as an athlete creates
+-- templates/sessions owned by that athlete (athlete_id) with created_by = the
+-- coach. Self workouts keep athlete_id NULL (existing rows unaffected).
+--
+-- Access stays additive: the existing "own" policies (user_id = auth.uid())
+-- are untouched; we ADD coach policies via can_coach_athlete so a current coach
+-- (or the linked athlete) reaches athlete-owned rows — which is what lets a NEW
+-- coach see the full history. The backend (service-role) enforces act-as in
+-- code; these policies are the second line of defence.
+-- =====================================================
+
+-- True if the caller actively coaches the athlete, or is the linked athlete.
+CREATE FUNCTION can_coach_athlete(aid UUID) RETURNS BOOLEAN
+LANGUAGE sql STABLE AS $$
+    SELECT aid IS NOT NULL AND (
+        EXISTS (
+            SELECT 1 FROM coach_athletes
+            WHERE athlete_id = aid AND coach_id = auth.uid() AND status = 'active'
+        )
+        OR EXISTS (SELECT 1 FROM athletes WHERE id = aid AND linked_user_id = auth.uid())
+    );
+$$;
+
+-- workout_templates
+ALTER TABLE workout_templates ADD COLUMN athlete_id UUID REFERENCES athletes(id) ON DELETE CASCADE;
+ALTER TABLE workout_templates ADD COLUMN created_by UUID REFERENCES users(user_id) ON DELETE SET NULL;
+CREATE INDEX idx_workout_templates_athlete ON workout_templates (athlete_id);
+CREATE POLICY "coach workout_templates select" ON workout_templates FOR SELECT
+    USING (can_coach_athlete(athlete_id));
+CREATE POLICY "coach workout_templates insert" ON workout_templates FOR INSERT
+    WITH CHECK (can_coach_athlete(athlete_id));
+CREATE POLICY "coach workout_templates update" ON workout_templates FOR UPDATE
+    USING (can_coach_athlete(athlete_id));
+CREATE POLICY "coach workout_templates delete" ON workout_templates FOR DELETE
+    USING (can_coach_athlete(athlete_id));
+
+-- template_items
+ALTER TABLE template_items ADD COLUMN athlete_id UUID REFERENCES athletes(id) ON DELETE CASCADE;
+ALTER TABLE template_items ADD COLUMN created_by UUID REFERENCES users(user_id) ON DELETE SET NULL;
+CREATE INDEX idx_template_items_athlete ON template_items (athlete_id);
+CREATE POLICY "coach template_items select" ON template_items FOR SELECT
+    USING (can_coach_athlete(athlete_id));
+CREATE POLICY "coach template_items insert" ON template_items FOR INSERT
+    WITH CHECK (can_coach_athlete(athlete_id));
+CREATE POLICY "coach template_items update" ON template_items FOR UPDATE
+    USING (can_coach_athlete(athlete_id));
+CREATE POLICY "coach template_items delete" ON template_items FOR DELETE
+    USING (can_coach_athlete(athlete_id));
+
+-- workout_sessions
+ALTER TABLE workout_sessions ADD COLUMN athlete_id UUID REFERENCES athletes(id) ON DELETE CASCADE;
+ALTER TABLE workout_sessions ADD COLUMN created_by UUID REFERENCES users(user_id) ON DELETE SET NULL;
+CREATE INDEX idx_workout_sessions_athlete ON workout_sessions (athlete_id, session_date DESC);
+CREATE POLICY "coach workout_sessions select" ON workout_sessions FOR SELECT
+    USING (can_coach_athlete(athlete_id));
+CREATE POLICY "coach workout_sessions insert" ON workout_sessions FOR INSERT
+    WITH CHECK (can_coach_athlete(athlete_id));
+CREATE POLICY "coach workout_sessions update" ON workout_sessions FOR UPDATE
+    USING (can_coach_athlete(athlete_id));
+CREATE POLICY "coach workout_sessions delete" ON workout_sessions FOR DELETE
+    USING (can_coach_athlete(athlete_id));
+
+-- exercise_sets
+ALTER TABLE exercise_sets ADD COLUMN athlete_id UUID REFERENCES athletes(id) ON DELETE CASCADE;
+ALTER TABLE exercise_sets ADD COLUMN created_by UUID REFERENCES users(user_id) ON DELETE SET NULL;
+CREATE INDEX idx_exercise_sets_athlete ON exercise_sets (athlete_id, exercise_key);
+CREATE POLICY "coach exercise_sets select" ON exercise_sets FOR SELECT
+    USING (can_coach_athlete(athlete_id));
+CREATE POLICY "coach exercise_sets insert" ON exercise_sets FOR INSERT
+    WITH CHECK (can_coach_athlete(athlete_id));
+CREATE POLICY "coach exercise_sets update" ON exercise_sets FOR UPDATE
+    USING (can_coach_athlete(athlete_id));
+CREATE POLICY "coach exercise_sets delete" ON exercise_sets FOR DELETE
+    USING (can_coach_athlete(athlete_id));


### PR DESCRIPTION
**The piece that makes "Matthew builds + logs Gabe's workout" work.** A coach acting-as a roster athlete now creates + reads that athlete's templates/sessions.

## Migration
- `athlete_id` + `created_by` on all 4 workout tables (`workout_templates`, `template_items`, `workout_sessions`, `exercise_sets`)
- `can_coach_athlete()` SQL helper (active coach link OR linked athlete)
- **Additive** coach RLS policies — existing `own` (self) policies untouched. Self workouts keep `athlete_id NULL`; existing rows unaffected. A new coach reaches athlete-owned history via the relationship.

## Backend
- **`acting_athlete` dependency** reads `X-Act-As-Athlete`, validates `require_athlete_access`, scopes every `/workouts` op to that athlete.
- Repo `create/list/get/delete` take `athlete_id`. Athlete rows → `athlete_id` + `created_by=coach`. Self rows scoped by `user_id AND athlete_id IS NULL` (a coach's own rows never mix with athletes').

## stk
`api` auto-sends `X-Act-As-Athlete` when an active athlete is set → `stk athlete use gabe` then `stk workout add-template|log|templates|sessions` all target Gabe.

## Verified
backend **161@85%**, root 52@63%, lint+format clean. Migration: 8 columns, 16 policies, helper fn.

## Known limit (follow-up)
The creating coach retains `user_id` self-access to rows they created even after their link ends. Fine for the demo (single admin coach); true athlete-only ownership is a later privacy hardening.

Part of SB-198. **Next (SB-204):** invite Matthew → add Gabe to his roster → the live coach demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)