### PR TITLE
feat: coach onboarding — coach invites + assign-by-email + demo (SB-204)

### DIFF
--- a/backend/routes/athletes.py
+++ b/backend/routes/athletes.py
@@ -12,14 +12,15 @@ from uuid import UUID
 
 from backend.admin import is_admin, require_athlete_access, require_coach
 from backend.auth import authenticate_request
-from fastapi import APIRouter, Depends, status
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, model_validator
 from src.shared.models import Athlete, AthleteCreate, CoachAthlete
 from src.shared.supabase_client import get_supabase_client
 from src.shared.supabase_ops import (
     AthletesRepository,
     CoachAthletesRepository,
     UserRolesRepository,
+    UsersRepository,
 )
 
 router = APIRouter(prefix="/athletes", tags=["athletes"])
@@ -27,7 +28,16 @@ me_router = APIRouter(prefix="/me", tags=["me"])
 
 
 class AssignCoachRequest(BaseModel):
-    coach_id: UUID
+    """Assign a coach by user id or by email (one is required)."""
+
+    coach_id: UUID | None = None
+    coach_email: str | None = None
+
+    @model_validator(mode="after")
+    def _one_of(self) -> AssignCoachRequest:
+        if not self.coach_id and not self.coach_email:
+            raise ValueError("coach_id or coach_email is required")
+        return self
 
 
 @me_router.get("/roles")
@@ -83,13 +93,36 @@ def assign_coach(
     body: AssignCoachRequest,
     user_id: UUID = Depends(authenticate_request),
 ) -> CoachAthlete:
-    """Add a coach to an athlete. Caller must already have access; the new coach
-    is granted the coach role so they can act on the athlete."""
+    """Add a coach (by id or email) to an athlete. Caller must already have
+    access; the new coach is granted the coach role so they can act."""
     require_athlete_access(user_id, athlete_id)
     supabase = get_supabase_client()
-    UserRolesRepository(supabase).grant(body.coach_id, "coach")
-    link = CoachAthletesRepository(supabase).assign(body.coach_id, athlete_id)
+
+    coach_id = body.coach_id
+    if coach_id is None:
+        assert body.coach_email is not None
+        found = UsersRepository(supabase).get_user_by_email(body.coach_email)
+        if found is None:
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND,
+                "No user with that email — invite them first (stk invite create --role coach)",
+            )
+        coach_id = UUID(found["user_id"])
+
+    UserRolesRepository(supabase).grant(coach_id, "coach")
+    link = CoachAthletesRepository(supabase).assign(coach_id, athlete_id)
     return CoachAthlete(**link)
+
+
+@router.get("/{athlete_id}/coaches", response_model=list[CoachAthlete])
+def list_coaches(
+    athlete_id: UUID,
+    user_id: UUID = Depends(authenticate_request),
+) -> list[CoachAthlete]:
+    """Active coaches of an athlete."""
+    require_athlete_access(user_id, athlete_id)
+    rows = CoachAthletesRepository(get_supabase_client()).list_active_for_athlete(athlete_id)
+    return [CoachAthlete(**r) for r in rows]
 
 
 @router.delete("/{athlete_id}/coaches/{coach_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/routes/invites.py
+++ b/backend/routes/invites.py
@@ -23,7 +23,11 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 from src.shared.models import Invite, InviteCreate
 from src.shared.supabase_client import get_supabase_client
-from src.shared.supabase_ops import InvitesRepository, UsersRepository
+from src.shared.supabase_ops import (
+    InvitesRepository,
+    UserRolesRepository,
+    UsersRepository,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +80,11 @@ def issue_invite(
     token = secrets.token_urlsafe(32)
     expires_at = datetime.now(UTC) + timedelta(days=body.expires_in_days)
     row = InvitesRepository(get_supabase_client()).create(
-        created_by=user_id, email=body.email, token=token, expires_at=expires_at
+        created_by=user_id,
+        email=body.email,
+        token=token,
+        expires_at=expires_at,
+        grant_role=body.grant_role.value if body.grant_role else None,
     )
     return Invite(**row)
 
@@ -116,6 +124,9 @@ def redeem_invite(body: RedeemRequest) -> dict[str, Any]:
 
     # users.user_id must equal the auth uid (RLS + invites FK invariant).
     UsersRepository(supabase).upsert_user_with_id(auth_uid, email=email)
+    # Grant the invite's role (e.g. coach) so they can act immediately (SB-204).
+    if invite.get("grant_role"):
+        UserRolesRepository(supabase).grant(auth_uid, str(invite["grant_role"]))
     invites.mark_redeemed(body.token, auth_uid, datetime.now(UTC))
 
     # Hand back a live session so the invitee is logged straight in.

--- a/backend/tests/test_coach_foundation.py
+++ b/backend/tests/test_coach_foundation.py
@@ -183,3 +183,62 @@ def test_assign_coach_grants_role_and_links() -> None:
 
     roles_repo.grant.assert_called_once_with(new_coach, "coach")
     assert str(out.coach_id) == str(new_coach)
+
+
+def test_assign_coach_by_email_resolves_user() -> None:
+    from backend.routes.athletes import AssignCoachRequest, assign_coach
+
+    aid = uuid4()
+    coach_uid = uuid4()
+    users_repo = MagicMock()
+    users_repo.get_user_by_email.return_value = {"user_id": str(coach_uid)}
+    roles_repo = MagicMock()
+    links_repo = MagicMock()
+    links_repo.assign.return_value = {
+        "id": str(uuid4()),
+        "coach_id": str(coach_uid),
+        "athlete_id": str(aid),
+        "status": "active",
+        "started_at": "2026-06-21T00:00:00+00:00",
+        "ended_at": None,
+        "created_at": "2026-06-21T00:00:00+00:00",
+    }
+
+    with (
+        _admin_env(roles={"admin"}, athlete={"id": str(aid), "linked_user_id": None}),
+        patch("backend.routes.athletes.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.athletes.UsersRepository", return_value=users_repo),
+        patch("backend.routes.athletes.UserRolesRepository", return_value=roles_repo),
+        patch("backend.routes.athletes.CoachAthletesRepository", return_value=links_repo),
+    ):
+        out = assign_coach(
+            aid, AssignCoachRequest(coach_email="matthew@example.com"), user_id=uuid4()
+        )
+
+    users_repo.get_user_by_email.assert_called_once_with("matthew@example.com")
+    roles_repo.grant.assert_called_once_with(coach_uid, "coach")
+    assert str(out.coach_id) == str(coach_uid)
+
+
+def test_assign_coach_by_email_unknown_404() -> None:
+    from backend.routes.athletes import AssignCoachRequest, assign_coach
+
+    aid = uuid4()
+    users_repo = MagicMock()
+    users_repo.get_user_by_email.return_value = None
+
+    with (
+        _admin_env(roles={"admin"}, athlete={"id": str(aid), "linked_user_id": None}),
+        patch("backend.routes.athletes.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.athletes.UsersRepository", return_value=users_repo),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            assign_coach(aid, AssignCoachRequest(coach_email="nobody@example.com"), user_id=uuid4())
+    assert exc.value.status_code == 404
+
+
+def test_assign_coach_request_requires_id_or_email() -> None:
+    from backend.routes.athletes import AssignCoachRequest
+
+    with pytest.raises(ValueError):
+        AssignCoachRequest()

--- a/backend/tests/test_invites.py
+++ b/backend/tests/test_invites.py
@@ -149,12 +149,13 @@ def test_issue_invite_route_admin_issues_token() -> None:
 
     admin = uuid4()
     repo = MagicMock()
-    repo.create.side_effect = lambda created_by, email, token, expires_at: {
+    repo.create.side_effect = lambda created_by, email, token, expires_at, grant_role=None: {
         "id": str(uuid4()),
         "token": token,
         "email": email,
         "created_by": str(created_by),
         "expires_at": expires_at.isoformat(),
+        "grant_role": grant_role,
         "redeemed_at": None,
         "redeemed_by": None,
         "created_at": "2026-06-20T00:00:00+00:00",
@@ -185,15 +186,17 @@ def _past() -> str:
 
 
 def _redeem(invite_row: dict[str, Any] | None) -> Any:
-    """Call redeem_invite with the repo + supabase stubbed; return (result, repo)."""
+    """Call redeem_invite with the deps stubbed; return (result, repo, roles_repo)."""
     from backend.routes.invites import RedeemRequest, redeem_invite
 
     repo = MagicMock()
     repo.get_by_token.return_value = invite_row
+    roles_repo = MagicMock()
     with (
         patch("backend.routes.invites.get_supabase_client", return_value=MagicMock()),
         patch("backend.routes.invites.InvitesRepository", return_value=repo),
         patch("backend.routes.invites.UsersRepository", return_value=MagicMock()),
+        patch("backend.routes.invites.UserRolesRepository", return_value=roles_repo),
         patch(
             "backend.routes.invites._admin_create_user",
             return_value={"id": str(uuid4())},
@@ -203,7 +206,11 @@ def _redeem(invite_row: dict[str, Any] | None) -> Any:
             return_value={"access_token": "at", "refresh_token": "rt", "expires_in": 3600},
         ),
     ):
-        return redeem_invite(RedeemRequest(token="tok-abcdef", password="secret1")), repo
+        return (
+            redeem_invite(RedeemRequest(token="tok-abcdef", password="secret1")),
+            repo,
+            roles_repo,
+        )
 
 
 def test_redeem_unknown_token_404() -> None:
@@ -228,9 +235,22 @@ def test_redeem_expired_410() -> None:
 
 def test_redeem_happy_path_creates_user_and_returns_session() -> None:
     row = {"email": "friend@example.com", "expires_at": _future(), "redeemed_at": None}
-    result, repo = _redeem(row)
+    result, repo, roles_repo = _redeem(row)
     assert result["access_token"] == "at"
     assert result["user"]["email"] == "friend@example.com"
     # invite consumed; account email comes from the invite, not the request
     repo.mark_redeemed.assert_called_once()
     assert repo.mark_redeemed.call_args[0][0] == "tok-abcdef"
+    roles_repo.grant.assert_not_called()  # no grant_role on this invite
+
+
+def test_redeem_grants_role_when_set() -> None:
+    row = {
+        "email": "matthew@example.com",
+        "expires_at": _future(),
+        "redeemed_at": None,
+        "grant_role": "coach",
+    }
+    _result, _repo, roles_repo = _redeem(row)
+    roles_repo.grant.assert_called_once()
+    assert roles_repo.grant.call_args[0][1] == "coach"

--- a/docs/coach-demo.md
+++ b/docs/coach-demo.md
@@ -1,0 +1,72 @@
+# Coach demo — Matthew builds + logs Gabe's workout
+
+End-to-end walkthrough of the coach platform (SB-189): invite a coach, give
+them an athlete, and have *them* build + log that athlete's training. Everything
+below is CLI-driven (`stk`); the same flows back the future web UI.
+
+## Roles in this demo
+- **You** — owner/admin (seeded `admin` + `coach`).
+- **Matthew** — the trainer; gets a `coach` account via an invite.
+- **Gabe** — a managed athlete (14yo, no login).
+
+## 1. Owner: invite Matthew as a coach
+```bash
+stk invite create --email matthew@example.com --role coach
+#   Invite issued for matthew@example.com as coach (expires …)
+#   link: https://myrunstreak.run/signup?invite=<token>
+```
+Text Matthew the link.
+
+## 2. Matthew: redeem → he's a coach
+Matthew opens the link, sets a password (web `/signup?invite=…`) — or, since
+he's CLI-savvy:
+```bash
+stk invite redeem --token <token>     # creates his account + logs in
+stk athlete whoami                     # roles: coach
+```
+The `--role coach` on the invite means he's a coach the moment he redeems — no
+extra admin step.
+
+## 3. Owner: create Gabe + hand him to Matthew
+```bash
+stk athlete add --name "Gabe" --birth-year 2011
+stk athlete add-coach Gabe --email matthew@example.com
+stk athlete coaches Gabe                # shows Matthew as an active coach
+```
+`add-coach` resolves Matthew by email, grants him `coach` (idempotent), and
+links him to Gabe.
+
+> Either the owner or Matthew can create Gabe; whoever does becomes a coach
+> automatically. Shown here owner-side so Gabe pre-exists for Matthew.
+
+## 4. Matthew: act as Gabe, build + log
+```bash
+stk athlete use Gabe                    # active athlete = Gabe
+stk athlete whoami                      # active athlete: Gabe
+
+# build Gabe's plan
+stk workout add-template --file gabe-circuit.json
+stk workout show <template-id>          # Gabe's card
+
+# after the session, log it
+stk workout log --file gabe-session.json
+stk workout sessions                    # Gabe's sessions, not Matthew's
+```
+While "using" Gabe, every `stk workout …` call carries `X-Act-As-Athlete: <gabe>`
+and is validated against Matthew's roster. Matthew's own workouts (if any) stay
+separate — `stk athlete use` with no athlete, or clearing it, returns to self.
+
+## 5. Changing coaches (history follows the athlete)
+```bash
+stk athlete add-coach Gabe --email newcoach@example.com   # add the new coach
+# end the old link (owner or Matthew):
+#   DELETE /athletes/<gabe>/coaches/<matthew-id>
+```
+Because workouts are **owned by the athlete**, the new coach immediately sees
+Gabe's full history. The ex-coach loses roster access going forward.
+
+## What's not here yet (roadmap)
+- Teams + seasons + "who on my team got faster" (SB-196/197/200/201)
+- Coach feedback on sessions (SB-199)
+- Web athlete-switcher + coach dashboard (SB-202)
+- Athlete/parent self-view via `linked_user_id` (SB-203)

--- a/src/shared/models/invite.py
+++ b/src/shared/models/invite.py
@@ -7,6 +7,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
+from .athlete import Role
+
 
 class InviteCreate(BaseModel):
     """Admin request to issue an invite."""
@@ -14,6 +16,9 @@ class InviteCreate(BaseModel):
     email: str = Field(min_length=3, description="Who the invite is for")
     expires_in_days: int = Field(
         default=14, ge=1, le=90, description="Days until the token expires"
+    )
+    grant_role: Role | None = Field(
+        default=None, description="Role granted on redemption (e.g. coach)"
     )
 
 
@@ -25,6 +30,7 @@ class Invite(BaseModel):
     email: str
     created_by: UUID
     expires_at: datetime
+    grant_role: Role | None = None
     redeemed_at: datetime | None = None
     redeemed_by: UUID | None = None
     created_at: datetime

--- a/src/shared/supabase_ops/athletes_repository.py
+++ b/src/shared/supabase_ops/athletes_repository.py
@@ -130,3 +130,14 @@ class CoachAthletesRepository:
             .execute()
         )
         return cast(list[dict[str, Any]], result.data)
+
+    def list_active_for_athlete(self, athlete_id: UUID) -> list[dict[str, Any]]:
+        """Active coach links for an athlete (caller resolves coach emails)."""
+        result = (
+            self.supabase.table("coach_athletes")
+            .select("*")
+            .eq("athlete_id", str(athlete_id))
+            .eq("status", "active")
+            .execute()
+        )
+        return cast(list[dict[str, Any]], result.data)

--- a/src/shared/supabase_ops/invites_repository.py
+++ b/src/shared/supabase_ops/invites_repository.py
@@ -20,7 +20,12 @@ class InvitesRepository:
         self.supabase = supabase
 
     def create(
-        self, created_by: UUID, email: str, token: str, expires_at: datetime
+        self,
+        created_by: UUID,
+        email: str,
+        token: str,
+        expires_at: datetime,
+        grant_role: str | None = None,
     ) -> dict[str, Any]:
         row = {
             "created_by": str(created_by),
@@ -28,6 +33,8 @@ class InvitesRepository:
             "token": token,
             "expires_at": expires_at.isoformat(),
         }
+        if grant_role is not None:
+            row["grant_role"] = grant_role
         result = self.supabase.table("invites").insert(row).execute()
         return cast(list[dict[str, Any]], result.data)[0]
 

--- a/stk/src/cli/commands/athlete.py
+++ b/stk/src/cli/commands/athlete.py
@@ -37,10 +37,8 @@ def list_athletes() -> None:
         display.console.print(f"{mark}{r['display_name']}{yr}  id={r['id'][:8]}")
 
 
-def use(
-    who: str = typer.Argument(..., help="Athlete name or 8-char id prefix"),
-) -> None:
-    """Set the active athlete (subsequent workout commands target them)."""
+def _resolve(who: str) -> dict[str, str]:
+    """Resolve a name/id-prefix to one athlete you coach, or exit."""
     rows = api.request("athletes")
     matches = [
         r for r in rows if r["id"].startswith(who) or who.lower() in r["display_name"].lower()
@@ -51,9 +49,39 @@ def use(
     if len(matches) > 1:
         display.console.print(f"[red]'{who}' is ambiguous — use the id prefix[/red]")
         raise typer.Exit(1)
-    a = matches[0]
+    return matches[0]
+
+
+def use(
+    who: str = typer.Argument(..., help="Athlete name or 8-char id prefix"),
+) -> None:
+    """Set the active athlete (subsequent workout commands target them)."""
+    a = _resolve(who)
     config.set_active_athlete(a["id"], a["display_name"])
     display.console.print(f"[green]Active athlete:[/green] {a['display_name']}")
+
+
+def add_coach(
+    who: str = typer.Argument(..., help="Athlete name or 8-char id prefix"),
+    email: str = typer.Option(..., "--email", "-e", help="Coach's account email"),
+) -> None:
+    """Add a coach (by email) to an athlete. They must have an account already."""
+    a = _resolve(who)
+    api.post_request(f"athletes/{a['id']}/coaches", {"coach_email": email})
+    display.console.print(f"[green]Coach added[/green] {email} → {a['display_name']}")
+
+
+def coaches(
+    who: str = typer.Argument(..., help="Athlete name or 8-char id prefix"),
+) -> None:
+    """List an athlete's active coaches."""
+    a = _resolve(who)
+    rows = api.request(f"athletes/{a['id']}/coaches")
+    if not rows:
+        display.console.print(f"{a['display_name']} has no coaches.")
+        return
+    for r in rows:
+        display.console.print(f"  coach_id={r['coach_id'][:8]}  since {r['started_at'][:10]}")
 
 
 def whoami() -> None:
@@ -70,4 +98,6 @@ def whoami() -> None:
 athlete_app.command(name="add")(add)
 athlete_app.command(name="list")(list_athletes)
 athlete_app.command(name="use")(use)
+athlete_app.command(name="add-coach")(add_coach)
+athlete_app.command(name="coaches")(coaches)
 athlete_app.command(name="whoami")(whoami)

--- a/stk/src/cli/commands/invite.py
+++ b/stk/src/cli/commands/invite.py
@@ -16,12 +16,18 @@ invite_app = typer.Typer(help="Issue, list, and redeem onboarding invites.")
 def create(
     email: str = typer.Option(..., "--email", "-e", help="Who the invite is for"),
     days: int = typer.Option(14, "--days", "-d", help="Days until the token expires"),
+    role: str = typer.Option(None, "--role", "-r", help="Role to grant on redeem (e.g. coach)"),
 ) -> None:
     """Issue an invite. Prints a redeem link to text the invitee."""
-    result = api.post_request("invites", {"email": email, "expires_in_days": days})
+    body: dict[str, object] = {"email": email, "expires_in_days": days}
+    if role is not None:
+        body["grant_role"] = role
+    result = api.post_request("invites", body)
     link = f"https://myrunstreak.run/signup?invite={result['token']}"
+    role_note = f" as [bold]{result['grant_role']}[/bold]" if result.get("grant_role") else ""
     display.console.print(
-        f"[green]Invite issued[/green] for {result['email']} (expires {result['expires_at'][:10]})"
+        f"[green]Invite issued[/green] for {result['email']}{role_note} "
+        f"(expires {result['expires_at'][:10]})"
     )
     display.console.print(f"  link: [bold]{link}[/bold]")
     display.console.print("  [dim](text this to the invitee)[/dim]")

--- a/supabase/migrations/20260621020000_invite_grant_role.sql
+++ b/supabase/migrations/20260621020000_invite_grant_role.sql
@@ -1,0 +1,8 @@
+-- =====================================================
+-- Coach onboarding (SB-204): an invite can carry a role to grant on redemption.
+-- Invite a coach with grant_role = 'coach' → when they redeem, they're a coach
+-- immediately (no separate admin step).
+-- =====================================================
+ALTER TABLE invites ADD COLUMN grant_role user_role;
+
+COMMENT ON COLUMN invites.grant_role IS 'Role granted to the user on redemption (SB-204), e.g. coach';


### PR DESCRIPTION
Wires the trainer **end-to-end**: invite a coach, give them an athlete, and they build/log for that athlete. Completes the Matthew+Gabe demo path (SB-189).

## What's new
- **migration** `invites.grant_role` — an invite can carry a role to grant on redemption.
- **invites**: `stk invite create --role coach` issues a coach invite; **redeem grants the role**, so the invitee is a coach the moment they sign up (no separate admin step).
- **`/athletes/{id}/coaches`**: assign a coach **by email** (resolved to user_id; `404` + "invite them first" hint if they haven't signed up) or by id; grants the coach role on assign. New `GET` lists an athlete's active coaches.
- **stk**: `invite create --role`, `athlete add-coach --email`, `athlete coaches`.
- **`docs/coach-demo.md`** — the full owner → invite → redeem → roster → act-as runbook.

## Tests
role-grant on redeem, assign-by-email (+ unknown→404), request validation (id-or-email required). backend **165@85%**, root 52@63%, lint+format clean.

## The loop it unlocks
```
# owner
stk invite create --email matthew@x --role coach        # text the link
stk athlete add --name Gabe --birth-year 2011
stk athlete add-coach Gabe --email matthew@x
# matthew (after redeem)
stk athlete use Gabe
stk workout add-template --file gabe-circuit.json        # built under Gabe
stk workout log --file gabe-session.json                 # logged under Gabe
```

Closes SB-204. With SB-195 + SB-198 + this, the coach platform's core loop is usable end to end. Roadmap next: teams, seasons, "who got faster" (SB-196/197/200/201), feedback (SB-199), web UI (SB-202).

🤖 Generated with [Claude Code](https://claude.com/claude-code)