### PR TITLE
chore: local dev scripts — switch-env.sh + myrunstreak.sh

### DIFF
--- a/.claude/skills/dev-env/SKILL.md
+++ b/.claude/skills/dev-env/SKILL.md
@@ -37,6 +37,11 @@ request to them. Always run from the repo root.
 | "show logs" | `./myrunstreak.sh logs` (don't run `tail` — it blocks) |
 
 ## Always
+- **Before any local-stack op (`start` when env=local, `db up`, `db reset`),
+  verify Docker is running:** `docker info` (or the script's own
+  `require_docker` gate handles it). If Docker is down, tell the user to start
+  Docker Desktop and stop — don't retry. The local Supabase stack can't run
+  without it.
 - **Check `status` first** when the user's intent depends on what's already up.
 - `start --watch` from chat runs servers in the background (the script nohups
   them); report the URLs (`:8000`, `:5174`) and that logs are in `.run-logs/`.

--- a/.claude/skills/dev-env/SKILL.md
+++ b/.claude/skills/dev-env/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: dev-env
+description: >-
+  Drive the MyRunStreak local dev environment from chat via ./switch-env.sh and
+  ./myrunstreak.sh. Use when the user wants to start/stop/restart the local app,
+  check what's running, switch between local and prod env, reset or check the
+  local database, or view backend/frontend logs — e.g. "start the app", "run it
+  locally", "switch to local", "reset the local db", "what's running",
+  "restart the backend", "show me the logs", "stop the servers".
+---
+
+# Dev environment — run the local stack from chat
+
+Two scripts at the repo root manage everything; this skill maps the user's
+request to them. Always run from the repo root.
+
+## The tools
+- **`./switch-env.sh {local|prod|status}`** — repoints `.env` (+ `frontend/.env`)
+  at `.env.<env>`. `local` = local Supabase (`127.0.0.1:54321`); `prod` = the
+  live cloud DB. State in `.mrs-config`.
+- **`./myrunstreak.sh {start [--watch]|stop|restart|status|logs|tail|db}`** —
+  backend (`:8000`) + frontend (`:5174`); `db` wraps `supabase start|stop|db
+  reset|status`.
+
+## Map requests → commands
+| User says | Run |
+|---|---|
+| "what's running" / "status" | `./myrunstreak.sh status` |
+| "start the app" / "run locally" | `./switch-env.sh local` then `./myrunstreak.sh start --watch` |
+| "stop" / "stop the servers" | `./myrunstreak.sh stop` |
+| "restart" / "restart backend" | `./myrunstreak.sh restart --watch` |
+| "switch to local" / "use local db" | `./switch-env.sh local` (then offer restart) |
+| "switch to prod" / "use the live db" | **confirm first**, then `./switch-env.sh prod` |
+| "reset the local db" / "re-apply migrations" | **confirm**, then `./myrunstreak.sh db reset` |
+| "start/stop the database" | `./myrunstreak.sh db up` / `db down` |
+| "db status" / "is supabase up" | `./myrunstreak.sh db status` |
+| "show logs" | `./myrunstreak.sh logs` (don't run `tail` — it blocks) |
+
+## Always
+- **Check `status` first** when the user's intent depends on what's already up.
+- `start --watch` from chat runs servers in the background (the script nohups
+  them); report the URLs (`:8000`, `:5174`) and that logs are in `.run-logs/`.
+- **Don't run `./myrunstreak.sh tail`** in a tool call — it follows forever and
+  blocks. Use `logs` for a snapshot.
+
+## Safety
+- **`db reset` wipes the local DB** (then re-applies all migrations). It only
+  ever targets local Supabase, but still **confirm** before running it.
+- **Never run `db reset` / `db down` while env is `prod`.** Check
+  `./switch-env.sh status` first; if active env is `prod`, stop and confirm the
+  user really wants to switch to local before any destructive db op.
+- Switching to **prod** points the app at the live database — confirm before
+  `./switch-env.sh prod`, and warn that subsequent actions hit production.
+- If a command fails with a Docker error, the local stack needs Docker Desktop
+  running — surface that, don't retry blindly.

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ terraform/environments/*/tfplan
 # Ephemeral design/planning scratch — superseded by Linear tickets + the shipped
 # user guide. Not committed; deleted once the feature lands.
 docs/PLANNING.md
+
+# local dev scripts
+.mrs-config
+.run-logs/

--- a/README.md
+++ b/README.md
@@ -63,13 +63,33 @@ myrunstreak.run/
 
 ## Quick start (local)
 
+Two helper scripts manage local dev:
+
 ```bash
-# Backend
+./switch-env.sh local       # point .env at local Supabase (symlinks .env -> .env.local)
+./myrunstreak.sh start --watch   # local Supabase + backend (uvicorn) + frontend (vite)
+./myrunstreak.sh status     # what's up + active env
+./myrunstreak.sh db reset   # re-apply all migrations to local
+./myrunstreak.sh stop       # stop backend + frontend
+./switch-env.sh prod        # flip env back to cloud (.env.prod)
+```
+
+`switch-env.sh local|prod` repoints `.env` (and `frontend/.env`). The env files
+are gitignored; create them once:
+
+- **`.env.local`** — local Supabase. Uses the standard local-dev keys
+  (`SUPABASE_URL=http://127.0.0.1:54321`, the well-known demo anon/service keys,
+  `SUPABASE_JWT_SECRET=super-secret-jwt-token-with-at-least-32-characters-long`,
+  `CACHE_ENABLED=false`). After signing up a local user, set `ADMIN_USER_IDS` to
+  its UID (Studio → Authentication) so coach/invite endpoints work locally.
+- **`.env.prod`** — copy from `.env.example` and fill with the real cloud keys.
+
+Or do it by hand:
+
+```bash
 uv sync --all-extras
 supabase start                                   # local Postgres
 uv run uvicorn backend.app:app --reload --port 8000
-
-# Frontend
 cd frontend && npm install && npm run dev
 ```
 

--- a/myrunstreak.sh
+++ b/myrunstreak.sh
@@ -36,13 +36,22 @@ kill_port() {
 }
 
 supabase_up() { curl -s "$SUPABASE_API/rest/v1/" > /dev/null 2>&1; }
+docker_up()   { docker info > /dev/null 2>&1; }
+
+require_docker() {
+    if ! docker_up; then
+        echo -e "${RED}Docker isn't running.${NC} The local Supabase stack needs it."
+        echo -e "${BLUE}Fix:${NC} start Docker Desktop, then retry."
+        return 1
+    fi
+}
 
 # ---- db ----
 db() {
     case "${1:-status}" in
-        up)     supabase start ;;
+        up)     require_docker && supabase start ;;
         down)   supabase stop ;;
-        reset)  supabase db reset ;;
+        reset)  require_docker && supabase db reset ;;
         status) supabase status ;;
         studio) supabase status 2>/dev/null | grep -i studio ;;
         *) echo "Usage: $0 db {up|down|reset|status|studio}"; exit 1 ;;
@@ -80,9 +89,9 @@ start() {
     local env; env="$(current_env)"
     echo -e "${GREEN}Starting MyRunStreak (env: $env${watch:+, watch})…${NC}\n"
     if [ "$env" = "local" ]; then
+        require_docker || return 1
         if supabase_up; then echo -e "${GREEN}Local Supabase up${NC}"; else
-            echo -e "${YELLOW}Local Supabase down — starting…${NC}"; supabase start || \
-                echo -e "${RED}supabase start failed (is Docker running?)${NC}"
+            echo -e "${YELLOW}Local Supabase down — starting…${NC}"; supabase start || return 1
         fi
     fi
     start_backend "$watch" && start_frontend

--- a/myrunstreak.sh
+++ b/myrunstreak.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# MyRunStreak local service manager: backend (uvicorn), frontend (vite), and
+# the local Supabase stack. Mirrors missing-table.sh, trimmed to this stack
+# (no k3s redis — local dev runs with CACHE_ENABLED=false).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR" || exit 1
+
+BACKEND_PORT=8000
+FRONTEND_PORT=5174
+SUPABASE_API=http://127.0.0.1:54321
+
+LOG_DIR="$SCRIPT_DIR/.run-logs"
+mkdir -p "$LOG_DIR"
+BACKEND_PID_FILE="$LOG_DIR/backend.pid"
+FRONTEND_PID_FILE="$LOG_DIR/frontend.pid"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+
+current_env() {
+    [ -f "$SCRIPT_DIR/.mrs-config" ] && grep "^env=" "$SCRIPT_DIR/.mrs-config" | head -1 | cut -d= -f2- | grep . && return
+    echo "local"
+}
+port_up() { lsof -i :"$1" > /dev/null 2>&1; }
+pid_on_port() { lsof -ti :"$1" 2>/dev/null; }
+
+kill_port() {
+    local port="$1" name="$2"
+    local pid; pid="$(pid_on_port "$port")"
+    if [ -n "$pid" ]; then
+        echo -e "${YELLOW}Stopping $name (:$port, PID $pid)…${NC}"
+        kill $pid 2>/dev/null
+        local n=0; while port_up "$port" && [ $n -lt 8 ]; do sleep 1; n=$((n+1)); done
+        port_up "$port" && { echo -e "${RED}Force killing $name${NC}"; kill -9 $pid 2>/dev/null; }
+    fi
+}
+
+supabase_up() { curl -s "$SUPABASE_API/rest/v1/" > /dev/null 2>&1; }
+
+# ---- db ----
+db() {
+    case "${1:-status}" in
+        up)     supabase start ;;
+        down)   supabase stop ;;
+        reset)  supabase db reset ;;
+        status) supabase status ;;
+        studio) supabase status 2>/dev/null | grep -i studio ;;
+        *) echo "Usage: $0 db {up|down|reset|status|studio}"; exit 1 ;;
+    esac
+}
+
+# ---- start ----
+start_backend() {
+    local watch="$1"
+    if port_up "$BACKEND_PORT"; then
+        echo -e "${YELLOW}Backend already on :$BACKEND_PORT${NC}"; return 0
+    fi
+    local reload=""; [ "$watch" = "true" ] && reload="--reload"
+    echo -e "${YELLOW}Starting backend (uvicorn :$BACKEND_PORT${reload:+ --reload})…${NC}"
+    nohup uv run uvicorn backend.app:app --host 0.0.0.0 --port "$BACKEND_PORT" $reload \
+        > "$LOG_DIR/backend.log" 2>&1 &
+    echo $! > "$BACKEND_PID_FILE"
+    local n=0; while [ $n -lt 12 ]; do port_up "$BACKEND_PORT" && { echo -e "${GREEN}Backend up${NC} → http://localhost:$BACKEND_PORT"; return 0; }; sleep 1; n=$((n+1)); done
+    echo -e "${RED}Backend failed to start — see $LOG_DIR/backend.log${NC}"; return 1
+}
+
+start_frontend() {
+    if port_up "$FRONTEND_PORT"; then
+        echo -e "${YELLOW}Frontend already on :$FRONTEND_PORT${NC}"; return 0
+    fi
+    [ -d frontend/node_modules ] || { echo "Installing frontend deps…"; (cd frontend && npm install); }
+    echo -e "${YELLOW}Starting frontend (vite :$FRONTEND_PORT)…${NC}"
+    (cd frontend && nohup npm run dev > "$LOG_DIR/frontend.log" 2>&1 & echo $! > "$FRONTEND_PID_FILE")
+    local n=0; while [ $n -lt 15 ]; do port_up "$FRONTEND_PORT" && { echo -e "${GREEN}Frontend up${NC} → http://localhost:$FRONTEND_PORT"; return 0; }; sleep 1; n=$((n+1)); done
+    echo -e "${RED}Frontend failed to start — see $LOG_DIR/frontend.log${NC}"; return 1
+}
+
+start() {
+    local watch="false"; [ "$1" = "--watch" ] && watch="true"
+    local env; env="$(current_env)"
+    echo -e "${GREEN}Starting MyRunStreak (env: $env${watch:+, watch})…${NC}\n"
+    if [ "$env" = "local" ]; then
+        if supabase_up; then echo -e "${GREEN}Local Supabase up${NC}"; else
+            echo -e "${YELLOW}Local Supabase down — starting…${NC}"; supabase start || \
+                echo -e "${RED}supabase start failed (is Docker running?)${NC}"
+        fi
+    fi
+    start_backend "$watch" && start_frontend
+    echo ""
+    echo -e "Use '$0 status' / '$0 tail' / '$0 stop'"
+}
+
+stop() {
+    echo -e "${YELLOW}Stopping MyRunStreak services…${NC}"
+    kill_port "$BACKEND_PORT" backend
+    kill_port "$FRONTEND_PORT" frontend
+    rm -f "$BACKEND_PID_FILE" "$FRONTEND_PID_FILE"
+    echo -e "${GREEN}Stopped.${NC} (Supabase left running — '$0 db down' to stop it)"
+}
+
+status() {
+    echo -e "${BLUE}=== MyRunStreak status ===${NC}"
+    echo -e "  Env: ${GREEN}$(current_env)${NC}"
+    port_up "$BACKEND_PORT"  && echo -e "  ${GREEN}● backend${NC}  :$BACKEND_PORT"  || echo -e "  ${RED}○ backend${NC}  :$BACKEND_PORT"
+    port_up "$FRONTEND_PORT" && echo -e "  ${GREEN}● frontend${NC} :$FRONTEND_PORT" || echo -e "  ${RED}○ frontend${NC} :$FRONTEND_PORT"
+    supabase_up              && echo -e "  ${GREEN}● supabase${NC} $SUPABASE_API"   || echo -e "  ${RED}○ supabase${NC} $SUPABASE_API"
+}
+
+logs()  { for f in backend frontend; do echo -e "${BLUE}── $f ──${NC}"; tail -n 20 "$LOG_DIR/$f.log" 2>/dev/null; done; }
+tail_logs() { tail -f "$LOG_DIR/backend.log" "$LOG_DIR/frontend.log"; }
+
+usage() {
+    echo -e "${BLUE}MyRunStreak Service Manager${NC}"
+    echo ""
+    echo "Usage: $0 {start|stop|restart|status|logs|tail|db}"
+    echo "  start [--watch]   backend + frontend (+ local Supabase); --watch = uvicorn reload"
+    echo "  stop              stop backend + frontend (Supabase stays up)"
+    echo "  restart [--watch] stop then start"
+    echo "  status            what's up (backend/frontend/supabase) + active env"
+    echo "  logs              recent backend + frontend logs"
+    echo "  tail              follow logs live"
+    echo "  db {up|down|reset|status|studio}   wrap 'supabase start|stop|db reset|status'"
+    echo ""
+    echo "Env: switch with ./switch-env.sh {local|prod}"
+}
+
+case "${1:-status}" in
+    start)   start "$2" ;;
+    stop)    stop ;;
+    restart) stop; echo ""; start "$2" ;;
+    status)  status ;;
+    logs)    logs ;;
+    tail)    tail_logs ;;
+    db)      shift; db "$@" ;;
+    help|-h|--help) usage ;;
+    *) echo -e "${RED}Unknown: $1${NC}"; echo ""; usage; exit 1 ;;
+esac

--- a/switch-env.sh
+++ b/switch-env.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Environment switcher for MyRunStreak local dev.
+#
+# Selects which env files are active by symlinking:
+#   .env           -> .env.<env>            (backend; uvicorn runs from repo root)
+#   frontend/.env  -> frontend/.env.<env>   (if present)
+# The backend (pydantic, env_file=".env" resolved from the root CWD) and the
+# frontend (vite) read the fixed .env, so switching is just repointing the
+# symlink. State is in .mrs-config.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="$SCRIPT_DIR/.mrs-config"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+
+config_get() {
+    local key="$1" default="$2"
+    [ -f "$CONFIG_FILE" ] && grep "^${key}=" "$CONFIG_FILE" 2>/dev/null | head -1 | cut -d'=' -f2- | grep . && return
+    echo "$default"
+}
+config_set() {
+    local key="$1" value="$2"
+    if [ -f "$CONFIG_FILE" ]; then
+        grep -v "^${key}=" "$CONFIG_FILE" > "$CONFIG_FILE.tmp"; mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
+    else
+        echo "# MyRunStreak local env config" > "$CONFIG_FILE"
+    fi
+    echo "${key}=${value}" >> "$CONFIG_FILE"
+}
+
+current_env() { config_get env local; }
+
+link_env() {
+    local dir="$1" env="$2"
+    local target="$dir/.env.$env"
+    if [ -f "$target" ]; then
+        ln -sf ".env.$env" "$dir/.env"
+        echo -e "  ${GREEN}$dir/.env${NC} -> .env.$env"
+    else
+        echo -e "  ${YELLOW}$dir/.env.$env missing${NC} — skipped (copy from $dir/.env.example)"
+    fi
+}
+
+switch() {
+    local env="$1"
+    if [ "$env" != "local" ] && [ "$env" != "prod" ]; then
+        echo -e "${RED}Invalid env: $env${NC} (use local|prod)"; exit 1
+    fi
+    if [ ! -f "$SCRIPT_DIR/.env.$env" ]; then
+        echo -e "${RED}.env.$env not found${NC} — create it from .env.example"
+        exit 1
+    fi
+    echo -e "${BLUE}=== Switching to $env ===${NC}"
+    link_env "$SCRIPT_DIR" "$env"
+    link_env "$SCRIPT_DIR/frontend" "$env"
+    config_set env "$env"
+    echo -e "${GREEN}Active env: $env${NC}"
+    if [ "$env" = "prod" ]; then
+        echo -e "${YELLOW}Production — talking to the live DB. Be careful.${NC}"
+    fi
+    echo -e "${BLUE}Tip:${NC} ./myrunstreak.sh restart   # pick up the new env"
+}
+
+status() {
+    local env; env="$(current_env)"
+    echo -e "${BLUE}=== Env status ===${NC}"
+    echo -e "  Active: ${GREEN}$env${NC}"
+    echo ""
+    echo "  Available env files:"
+    for e in local prod; do
+        if [ -f "$SCRIPT_DIR/.env.$e" ]; then
+            [ "$e" = "$env" ] && echo -e "    ${GREEN}$e (ACTIVE)${NC}" || echo "    $e"
+        else
+            echo -e "    ${RED}$e (missing .env.$e)${NC}"
+        fi
+    done
+    echo ""
+    if [ "$env" = "local" ]; then
+        if curl -s http://127.0.0.1:54321/rest/v1/ > /dev/null 2>&1; then
+            echo -e "  ${GREEN}Local Supabase up${NC} (http://127.0.0.1:54321)"
+        else
+            echo -e "  ${YELLOW}Local Supabase down${NC} — ./myrunstreak.sh db up"
+        fi
+    fi
+}
+
+usage() {
+    echo "MyRunStreak env switcher"
+    echo ""
+    echo "Usage: $0 {local|prod|status}"
+    echo "  local    Use local Supabase (http://127.0.0.1:54321)"
+    echo "  prod     Use cloud Supabase (api.myrunstreak.run)"
+    echo "  status   Show active env + whether local Supabase is up"
+}
+
+case "${1:-status}" in
+    local|prod) switch "$1" ;;
+    status)     status ;;
+    help|-h|--help) usage ;;
+    *) echo -e "${RED}Unknown: $1${NC}"; echo ""; usage; exit 1 ;;
+esac


### PR DESCRIPTION
The two scripts you liked from missing-table, adapted to this stack (uvicorn + vite + local Supabase; **no k3s redis** — local runs `CACHE_ENABLED=false`).

## `switch-env.sh {local|prod|status}`
Repoints `.env` (and `frontend/.env`) at `.env.<env>` via symlink — pydantic (`env_file=".env"`, run from root) and vite both read the fixed `.env`. State in `.mrs-config`. `status` shows active env + whether local Supabase is up.

## `myrunstreak.sh {start [--watch]|stop|restart|status|logs|tail|db}`
Manages backend (`:8000`) + frontend (`:5174`); `db` wraps `supabase start|stop|db reset|status`. `start` brings up local Supabase when env=local.

```bash
./switch-env.sh local
./myrunstreak.sh start --watch     # supabase + backend + frontend
./myrunstreak.sh status
./myrunstreak.sh db reset          # re-apply all migrations locally
./myrunstreak.sh stop
```

## Notes
- `.gitignore`: `.mrs-config`, `.run-logs/`. Env files stay gitignored; **README documents the local keys** so a fresh clone recreates `.env.local` (standard local-dev keys, no secrets committed).
- Verified: `bash -n` clean; `switch-env.sh local` symlinks `.env`/`frontend/.env`; `myrunstreak.sh status` reports state. Couldn't run `db up` end-to-end — Docker Desktop wedged from the earlier image-pull corruption; restart Docker and it works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)