### PR TITLE
fix: local dev migrations + backend venv + coach seed guard

### DIFF
--- a/myrunstreak.sh
+++ b/myrunstreak.sh
@@ -49,12 +49,13 @@ require_docker() {
 # ---- db ----
 db() {
     case "${1:-status}" in
-        up)     require_docker && supabase start ;;
-        down)   supabase stop ;;
-        reset)  require_docker && supabase db reset ;;
-        status) supabase status ;;
-        studio) supabase status 2>/dev/null | grep -i studio ;;
-        *) echo "Usage: $0 db {up|down|reset|status|studio}"; exit 1 ;;
+        up)      require_docker && supabase start ;;
+        down)    supabase stop ;;
+        migrate) require_docker && supabase migration up ;;
+        reset)   require_docker && supabase db reset ;;
+        status)  supabase status ;;
+        studio)  supabase status 2>/dev/null | grep -i studio ;;
+        *) echo "Usage: $0 db {up|down|migrate|reset|status|studio}"; exit 1 ;;
     esac
 }
 
@@ -66,7 +67,9 @@ start_backend() {
     fi
     local reload=""; [ "$watch" = "true" ] && reload="--reload"
     echo -e "${YELLOW}Starting backend (uvicorn :$BACKEND_PORT${reload:+ --reload})…${NC}"
-    nohup uv run uvicorn backend.app:app --host 0.0.0.0 --port "$BACKEND_PORT" $reload \
+    # Backend deps live in backend/pyproject.toml (its own uv project); run from
+    # the root CWD so `backend.app` + `src.shared` both import as top-level pkgs.
+    nohup uv run --project backend uvicorn backend.app:app --host 0.0.0.0 --port "$BACKEND_PORT" $reload \
         > "$LOG_DIR/backend.log" 2>&1 &
     echo $! > "$BACKEND_PID_FILE"
     local n=0; while [ $n -lt 12 ]; do port_up "$BACKEND_PORT" && { echo -e "${GREEN}Backend up${NC} → http://localhost:$BACKEND_PORT"; return 0; }; sleep 1; n=$((n+1)); done
@@ -93,6 +96,9 @@ start() {
         if supabase_up; then echo -e "${GREEN}Local Supabase up${NC}"; else
             echo -e "${YELLOW}Local Supabase down — starting…${NC}"; supabase start || return 1
         fi
+        # Apply any migrations added since the volume was created (non-destructive,
+        # idempotent — only pending ones run). Keeps schema current without a reset.
+        echo -e "${YELLOW}Applying pending migrations…${NC}"; supabase migration up || return 1
     fi
     start_backend "$watch" && start_frontend
     echo ""
@@ -128,7 +134,7 @@ usage() {
     echo "  status            what's up (backend/frontend/supabase) + active env"
     echo "  logs              recent backend + frontend logs"
     echo "  tail              follow logs live"
-    echo "  db {up|down|reset|status|studio}   wrap 'supabase start|stop|db reset|status'"
+    echo "  db {up|down|migrate|reset|status|studio}   wrap supabase: start|stop|migration up|db reset|status"
     echo ""
     echo "Env: switch with ./switch-env.sh {local|prod}"
 }

--- a/supabase/migrations/20260621000000_coach_foundation.sql
+++ b/supabase/migrations/20260621000000_coach_foundation.sql
@@ -100,7 +100,13 @@ CREATE POLICY "coach_athletes update" ON coach_athletes FOR UPDATE
     USING (coach_id = auth.uid());
 
 -- ---- seed: owner is admin + coach (usable immediately; keeps invites working) ----
-INSERT INTO user_roles (user_id, role) VALUES
-    ('16eb502d-7fc0-4fce-9107-9931df747e28', 'admin'),
-    ('16eb502d-7fc0-4fce-9107-9931df747e28', 'coach')
+-- Guarded: only grants when that user actually exists (prod), so fresh/local/CI
+-- databases without the owner row apply this migration cleanly instead of
+-- tripping the user_roles -> users foreign key.
+INSERT INTO user_roles (user_id, role)
+SELECT '16eb502d-7fc0-4fce-9107-9931df747e28'::uuid, role
+FROM (VALUES ('admin'::user_role), ('coach'::user_role)) AS v(role)
+WHERE EXISTS (
+    SELECT 1 FROM users WHERE user_id = '16eb502d-7fc0-4fce-9107-9931df747e28'
+)
 ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## What

Three fixes surfaced bringing the local stack up for the first time end-to-end.

### 1. Migration FK bug (ships beyond local) 🐛
`20260621000000_coach_foundation.sql` seeds owner roles with a **hardcoded prod
`user_id`**. The `user_roles → users` FK fails on any DB without that row —
local, **CI from scratch**, and any fresh environment. It only ever worked in
prod because that user happens to exist there.

Fix: guard the seed with `WHERE EXISTS` — no-op when the owner is absent,
identical behavior in prod. Migration now applies cleanly everywhere.

### 2. Backend ran in the wrong venv
`myrunstreak.sh` started uvicorn with `uv run` in the **root** venv, which has
no `fastapi` (backend deps live in `backend/pyproject.toml`). The process
crashed on import while the port briefly showed "up". Now runs
`uv run --project backend …` from the root CWD so `backend.app` + `src.shared`
both import — mirrors CI's `uv sync --project backend`.

### 3. Incremental migrations
Added `db migrate` (`supabase migration up`) and auto-apply pending migrations
on `start`. Non-destructive — new migrations land on an existing local volume
without a data-wiping `db reset`.

## Verified locally
- 19/19 migrations applied; coach tables (`user_roles`, `athletes`,
  `coach_athletes`) created; `user_roles` correctly empty (guard no-op'd).
- backend `:8000` → `/health` 200, `/docs` 200; clean uvicorn boot.
- frontend `:5174` → 200.

## Files
- `supabase/migrations/20260621000000_coach_foundation.sql` — seed guard
- `myrunstreak.sh` — `--project backend`, `db migrate`, auto-migrate on start

🤖 Generated with [Claude Code](https://claude.com/claude-code)