### PR TITLE
feat: adopt jt secrets (Varlock + 1Password) for STK env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@
 # Local development: http://127.0.0.1:54321
 # Production: https://your-project.supabase.co
 SUPABASE_URL=http://127.0.0.1:54321
-SUPABASE_KEY=sb_secret_N7UND0UgjKTVK-Uodkm0Hg_xSvEMPvz
+SUPABASE_KEY=your-supabase-secret-key   # never commit a real key — resolve via 1Password (.env.schema)
 
 # SmashRun OAuth Credentials
 # Get these from: https://smashrun.com/settings/api

--- a/.env.schema
+++ b/.env.schema
@@ -8,32 +8,62 @@
 #
 # Setup on a machine:  jt secrets base   (writes the shared base this imports)
 # Run:                 jt secrets run -- jt supabase sync-users stk
+#                      jt secrets run -- ./myrunstreak.sh start
 #
 # @import(~/.config/janitor/base/.env.schema)
 # ---
 
-# ---- jt supabase workflow: prod (item: stk-prod) ----
+# ================= jt supabase workflow secrets (op-backed) =================
 # @required @sensitive
 STK_PROD_SERVICE_ROLE_KEY=op(op://Personal/stk-prod/service_role_key)
 # @required @sensitive
 STK_PROD_DATABASE_URL=op(op://Personal/stk-prod/db_url)
-
-# ---- jt supabase workflow: local (item: stk-local; static Supabase dev key) ----
 # @required @sensitive
 STK_LOCAL_SERVICE_ROLE_KEY=op(op://Personal/stk-local/service_role_key)
 
-# ---- full app env migration (SB-206) — TODO ----
-# The app's other secrets are injected by k8s in cloud today. To resolve them
-# locally too, add matching fields to the stk-prod 1Password item, then declare
-# each below in the same "@required @sensitive / NAME=op(...)" form as above.
-# `jt secrets doctor` lists which cloud vars still need declaring. Planned:
-#
-#   env var                      1Password field (stk-prod)
-#   SUPABASE_KEY                 service_role_key
-#   SUPABASE_SERVICE_ROLE_KEY    service_role_key
-#   SUPABASE_ANON_KEY            anon_key
-#   SUPABASE_JWT_SECRET          jwt_secret
-#   SUPABASE_URL                 url            (config, not @sensitive)
-#   SMASHRUN_CLIENT_ID           smashrun_client_id
-#   SMASHRUN_CLIENT_SECRET       smashrun_client_secret
-#   GCS_SERVICE_ACCOUNT_JSON     gcs_service_account_json
+# ===================== app secrets (migrating to op) =======================
+# Declared optional for now so varlock validates while values still come from
+# .env.local. Move each to op() once its field exists on the stk-prod item;
+# `jt secrets doctor` tracks parity with the Helm ExternalSecret. Planned refs:
+#   SUPABASE_KEY               -> op://Personal/stk-prod/service_role_key
+#   SUPABASE_SERVICE_ROLE_KEY  -> op://Personal/stk-prod/service_role_key
+#   SUPABASE_ANON_KEY          -> op://Personal/stk-prod/anon_key
+#   SUPABASE_JWT_SECRET        -> op://Personal/stk-prod/jwt_secret
+#   SMASHRUN_CLIENT_ID         -> op://Personal/stk-prod/smashrun_client_id
+#   SMASHRUN_CLIENT_SECRET     -> op://Personal/stk-prod/smashrun_client_secret
+#   ADMIN_USER_IDS             -> op://Personal/stk-prod/admin_user_ids
+# @sensitive @optional
+SUPABASE_KEY=
+# @sensitive @optional
+SUPABASE_SERVICE_ROLE_KEY=
+# @sensitive @optional
+SUPABASE_ANON_KEY=
+# @sensitive @optional
+SUPABASE_JWT_SECRET=
+# @sensitive @optional
+SMASHRUN_CLIENT_ID=
+# @sensitive @optional
+SMASHRUN_CLIENT_SECRET=
+# @sensitive @optional
+ADMIN_USER_IDS=
+
+# ============================ config (non-secret) ==========================
+# Values come from .env.local; declared so varlock validates the full surface.
+# @optional
+SUPABASE_URL=
+# @optional
+SMASHRUN_REDIRECT_URI=
+# @optional
+AWS_REGION=
+# @optional
+ENVIRONMENT=
+# @optional
+LOG_LEVEL=
+# @optional
+CACHE_ENABLED=
+# @optional
+CACHE_DEFAULT_TTL_SECONDS=
+# @optional
+CORS_ALLOW_ORIGINS=
+# @optional
+REDIS_URL=

--- a/.env.schema
+++ b/.env.schema
@@ -1,0 +1,39 @@
+# myrunstreak (STK) env schema — managed with `jt secrets`. COMMIT-SAFE:
+# 1Password references only (op://...), never secret values. Varlock resolves
+# them at runtime and injects env vars that `jt` / the app read.
+#
+# 1Password layout (SB convention): "API Credential" items in the Personal vault
+# titled "stk-prod" and "stk-local", one concealed field per secret. Copy each
+# ref via the field's "Copy Secret Reference".
+#
+# Setup on a machine:  jt secrets base   (writes the shared base this imports)
+# Run:                 jt secrets run -- jt supabase sync-users stk
+#
+# @import(~/.config/janitor/base/.env.schema)
+# ---
+
+# ---- jt supabase workflow: prod (item: stk-prod) ----
+# @required @sensitive
+STK_PROD_SERVICE_ROLE_KEY=op(op://Personal/stk-prod/service_role_key)
+# @required @sensitive
+STK_PROD_DATABASE_URL=op(op://Personal/stk-prod/db_url)
+
+# ---- jt supabase workflow: local (item: stk-local; static Supabase dev key) ----
+# @required @sensitive
+STK_LOCAL_SERVICE_ROLE_KEY=op(op://Personal/stk-local/service_role_key)
+
+# ---- full app env migration (SB-206) — TODO ----
+# The app's other secrets are injected by k8s in cloud today. To resolve them
+# locally too, add matching fields to the stk-prod 1Password item, then declare
+# each below in the same "@required @sensitive / NAME=op(...)" form as above.
+# `jt secrets doctor` lists which cloud vars still need declaring. Planned:
+#
+#   env var                      1Password field (stk-prod)
+#   SUPABASE_KEY                 service_role_key
+#   SUPABASE_SERVICE_ROLE_KEY    service_role_key
+#   SUPABASE_ANON_KEY            anon_key
+#   SUPABASE_JWT_SECRET          jwt_secret
+#   SUPABASE_URL                 url            (config, not @sensitive)
+#   SMASHRUN_CLIENT_ID           smashrun_client_id
+#   SMASHRUN_CLIENT_SECRET       smashrun_client_secret
+#   GCS_SERVICE_ACCOUNT_JSON     gcs_service_account_json

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ terraform.tfplan
 .env
 .env.*
 !.env.example
+!.env.schema
 secrets.json
 credentials.json
 


### PR DESCRIPTION
STK adopts the shared `jt secrets` secret-resolution (SB-206). Verified live:
`jt secrets run -- jt supabase sync-users stk` resolves prod secrets from
1Password and syncs a prod user into local Supabase (real 200s from the Admin
API).

## Changes

- **`.env.schema`** (commit-safe, references only) — imports the shared janitor
  base and declares the full backend env surface:
  - 3 jt-supabase secrets: `@required` `op()` refs (`stk-prod` / `stk-local` items)
  - app secrets (`SUPABASE_*`, `SMASHRUN_*`, `ADMIN_USER_IDS`): `@optional` for
    now (values still from `.env.local`); `op://` migration mapped in comments
  - config vars: `@optional`
- **`.gitignore`** — `!.env.schema` so the reference-only schema is committable.
- **`.env.example`** — 🔒 remove a committed live `sb_secret_...` key (placeholder).

## How it works

Local: `varlock run` → `op` CLI → 1Password → injects env → app/`jt` read it.
Cloud: unchanged (AWS Secrets Manager → ESO → k8s Secret → env → uvicorn).
`.env.schema` var names == Helm ExternalSecret keys — one contract, two sources.

## Follow-ups (tracked)

- Rotate the exposed key (still valid until rolled; history retains it).
- Migrate app secrets `@optional → op()` as `stk-prod` gains fields
  (`jt secrets doctor` tracks parity).

Closes SB-206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)