### PR TITLE
fix: correct current streak (SB-209) + streak miles on dashboard (SB-210)

### DIFF
--- a/backend/routes/stats.py
+++ b/backend/routes/stats.py
@@ -14,7 +14,7 @@ from backend.auth import authenticate_request
 from backend.cache import cached
 from backend.goals import build_goals_block
 from backend.splits_analysis import analyze_run, summarize
-from backend.streaks import compute_streaks
+from backend.streaks import Streak, compute_streaks
 from fastapi import APIRouter, Depends, Query
 from src.shared.supabase_client import get_supabase_client
 from src.shared.supabase_ops import GoalsRepository, RunsRepository, TokenRepository
@@ -39,25 +39,47 @@ async def get_overall_stats(
 async def _streaks(user_id: UUID) -> dict[str, Any]:
     supabase = get_supabase_client()
 
-    # Pull every distinct run-date for this user. With 4-5k rows the
-    # round-trip is fine; if a user ever exceeds 10k we'd push this into
-    # a Supabase RPC.
-    rows = (
-        supabase.table("runs")
-        .select("start_date")
-        .eq("user_id", str(user_id))
-        .order("start_date", desc=False)
-        .limit(10000)
-        .execute()
-    )
-    data = cast(list[dict[str, Any]], rows.data)
+    # Pull every run-date for this user. PostgREST caps a single response at
+    # its server-side `db-max-rows` (~1000) regardless of the client `.limit`,
+    # so a lone query silently truncates to the oldest ~1000 runs — which drops
+    # every recent run and makes the current streak read as 0 (SB-209). Page
+    # with .range() until exhausted so compute_streaks sees the full history.
+    data: list[dict[str, Any]] = []
+    page = 1000
+    offset = 0
+    while True:
+        batch = cast(
+            list[dict[str, Any]],
+            (
+                supabase.table("runs")
+                .select("start_date,distance_km")
+                .eq("user_id", str(user_id))
+                .order("start_date", desc=False)
+                .range(offset, offset + page - 1)
+                .execute()
+            ).data,
+        )
+        data.extend(batch)
+        if len(batch) < page:
+            break
+        offset += page
     run_dates = [date.fromisoformat(r["start_date"]) for r in data]
+
+    # Sum distance per day so we can total the mileage inside any streak window.
+    km_by_day: dict[date, float] = {}
+    for r in data:
+        d = date.fromisoformat(r["start_date"])
+        km_by_day[d] = km_by_day.get(d, 0.0) + (r["distance_km"] or 0.0)
+
+    def streak_km(s: Streak) -> float:
+        return round(sum(km for d, km in km_by_day.items() if s.start_date <= d <= s.end_date), 3)
 
     today = _today_local()
     streaks = compute_streaks(run_dates, today)
 
     current = next((s for s in streaks if s.is_current), None)
-    longest_length = streaks[0].length_days if streaks else 0
+    longest = streaks[0] if streaks else None
+    longest_length = longest.length_days if longest else 0
 
     top = [
         {
@@ -71,7 +93,9 @@ async def _streaks(user_id: UUID) -> dict[str, Any]:
 
     return {
         "current_streak": current.length_days if current else 0,
+        "current_streak_km": streak_km(current) if current else 0.0,
         "longest_streak": longest_length,
+        "longest_streak_km": streak_km(longest) if longest else 0.0,
         "top_streaks": top,
     }
 

--- a/backend/tests/test_stats_streaks.py
+++ b/backend/tests/test_stats_streaks.py
@@ -1,0 +1,125 @@
+"""Regression tests for the /stats/streaks endpoint fetch (SB-209, SB-210).
+
+SB-209: `_streaks` used a single `.limit(10000)` query, but PostgREST caps a
+response at ~1000 rows server-side, silently truncating to the oldest ~1000
+runs. For a user with >1000 runs that dropped every recent run and made the
+current streak read as 0. The fix pages with `.range()` until exhausted.
+
+SB-210: `_streaks` also returns `current_streak_km` / `longest_streak_km`,
+the summed distance over each streak's date window.
+
+The fake client below is paging-aware: `.range(offset, end)` narrows what the
+next `.execute()` returns, so a query that fails to paginate would see only the
+first 1000-row window — exactly the truncation this guards against.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+from uuid import uuid4
+
+from backend.routes import stats
+
+PAGE = 1000
+
+
+class _PagingQuery:
+    """Records the active range() window and slices rows on execute()."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+        self._range: tuple[int, int] | None = None
+        self.range_calls: list[tuple[int, int]] = []
+
+    def select(self, *a: Any, **k: Any) -> _PagingQuery:
+        return self
+
+    def eq(self, *a: Any, **k: Any) -> _PagingQuery:
+        return self
+
+    def order(self, *a: Any, **k: Any) -> _PagingQuery:
+        return self
+
+    def range(self, start: int, end: int) -> _PagingQuery:
+        self._range = (start, end)
+        self.range_calls.append((start, end))
+        return self
+
+    def execute(self) -> SimpleNamespace:
+        if self._range is None:
+            return SimpleNamespace(data=list(self._rows))
+        start, end = self._range
+        # PostgREST range is inclusive; also cap the window at PAGE rows to
+        # mimic the server-side db-max-rows ceiling that caused SB-209.
+        window = self._rows[start : min(end + 1, start + PAGE)]
+        return SimpleNamespace(data=window)
+
+
+class _PagingClient:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.query = _PagingQuery(rows)
+
+    def table(self, _name: str) -> _PagingQuery:
+        return self.query
+
+
+def _daily_rows(n: int, end: date, km: float) -> list[dict[str, Any]]:
+    """n consecutive daily runs ending on `end`, oldest first."""
+    start = end - timedelta(days=n - 1)
+    return [
+        {"start_date": (start + timedelta(days=i)).isoformat(), "distance_km": km} for i in range(n)
+    ]
+
+
+async def test_streaks_pages_past_1000_rows_and_reports_full_streak() -> None:
+    """SB-209: >1000 consecutive runs must not truncate to a 0 current streak."""
+    end = date(2026, 7, 1)
+    rows = _daily_rows(1500, end, km=5.0)
+    client = _PagingClient(rows)
+
+    with (
+        patch.object(stats, "get_supabase_client", return_value=client),
+        patch.object(stats, "_today_local", return_value=end),
+    ):
+        result = await stats._streaks(uuid4())
+
+    # Would be 0 (or 1000) under the truncating single-query bug.
+    assert result["current_streak"] == 1500
+    assert result["longest_streak"] == 1500
+    # Paged, didn't stop at the first window.
+    assert client.query.range_calls[0] == (0, PAGE - 1)
+    assert len(client.query.range_calls) >= 2
+
+
+async def test_streaks_reports_streak_mileage() -> None:
+    """SB-210: current/longest streak km == summed distance over the window."""
+    end = date(2026, 7, 1)
+    rows = _daily_rows(1500, end, km=5.0)
+    client = _PagingClient(rows)
+
+    with (
+        patch.object(stats, "get_supabase_client", return_value=client),
+        patch.object(stats, "_today_local", return_value=end),
+    ):
+        result = await stats._streaks(uuid4())
+
+    assert result["current_streak_km"] == 1500 * 5.0
+    assert result["longest_streak_km"] == 1500 * 5.0
+
+
+async def test_streaks_empty_history_is_zeroed() -> None:
+    client = _PagingClient([])
+
+    with (
+        patch.object(stats, "get_supabase_client", return_value=client),
+        patch.object(stats, "_today_local", return_value=date(2026, 7, 1)),
+    ):
+        result = await stats._streaks(uuid4())
+
+    assert result["current_streak"] == 0
+    assert result["current_streak_km"] == 0.0
+    assert result["longest_streak"] == 0
+    assert result["longest_streak_km"] == 0.0

--- a/frontend/src/components/StreakHero.vue
+++ b/frontend/src/components/StreakHero.vue
@@ -19,6 +19,9 @@
       <p class="text-white/80 text-sm mt-1">
         {{ current === 1 ? 'day' : 'days' }} of running
       </p>
+      <p v-if="currentDistance" class="text-white font-semibold text-sm mt-2">
+        {{ currentDistance }} this streak
+      </p>
 
       <div class="mt-auto pt-4 border-t border-white/15">
         <p class="text-white/70 text-[11px] font-semibold uppercase tracking-wide">
@@ -42,6 +45,7 @@ import { useCountUp } from '@/composables/useCountUp'
 const props = defineProps<{
   current: number
   longest: number
+  currentDistance?: string
 }>()
 
 const currentRef = toRef(props, 'current')

--- a/frontend/src/types/runs.ts
+++ b/frontend/src/types/runs.ts
@@ -10,7 +10,9 @@ export interface OverallStats {
 
 export interface StreakInfo {
   current_streak: number
+  current_streak_km: number
   longest_streak: number
+  longest_streak_km: number
   top_streaks: TopStreak[]
 }
 

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -28,6 +28,7 @@
         <StreakHero
           :current="streak?.current_streak ?? 0"
           :longest="streak?.longest_streak ?? 0"
+          :current-distance="formatDistanceWithUnit(streak?.current_streak_km ?? 0, unit, 0)"
         />
         <GoalsCard
           :yearly="goals?.yearly ?? null"


### PR DESCRIPTION
## What

Two dashboard fixes, verified against prod data (4,753 runs, 4,330-day streak).

### SB-209 — current streak shows 0 (bug)
`GET /stats/streaks` fetched run-dates with a single `.limit(10000)` query. PostgREST caps a response at ~1000 rows server-side, so with ascending order it silently truncated to the **oldest ~1000 runs** — dropping every recent run. For any user with >1000 runs the current streak read as **0**, and longest showed **725** (the streak frozen at row ~1000). The RPC-backed goals card was unaffected, which is why the dashboard disagreed with itself.

**Fix:** page with `.range(offset, offset+page-1)` until a short batch, so `compute_streaks` sees the full history.

### SB-210 — streak miles on the dashboard (feature)
`_streaks` now also returns `current_streak_km` / `longest_streak_km` (summed `distance_km` over each streak's date window). The StreakHero card shows **"19,015 mi this streak"** under the day count.

## Verification
- Reproduced against prod (pod-side, paginated): unbroken **4,330-day** streak, **19,015.5 streak mi** — vs the deployed endpoint's truncated `0`.
- New regression tests: `backend/tests/test_stats_streaks.py` — >1000-row pagination (asserts 1500, not 0) + streak mileage + empty history.
- Backend suite: 168 passed. Frontend `vue-tsc` clean.

Fixes SB-209
Fixes SB-210

🤖 Generated with [Claude Code](https://claude.com/claude-code)