### PR TITLE
feat: coach web view — athlete roster + act-as detail (SB-211)

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -62,20 +62,29 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
+import { useRoles } from '@/composables/useCoach'
 import SyncButton from '@/components/SyncButton.vue'
 
 const auth = useAuthStore()
 const router = useRouter()
 const mobileMenuOpen = ref(false)
 
-const navLinks = [
+const { isCoach, loadRoles } = useRoles()
+
+// Coach link only appears for coaches/admins (SB-189 P4-1).
+const navLinks = computed(() => [
   { name: 'Dashboard', path: '/dashboard' },
   { name: 'Runs', path: '/runs' },
+  ...(isCoach.value ? [{ name: 'Coach', path: '/coach' }] : []),
   { name: 'Settings', path: '/settings' },
-]
+])
+
+onMounted(() => {
+  if (auth.isAuthenticated) loadRoles()
+})
 
 const handleSignOut = async () => {
   mobileMenuOpen.value = false

--- a/frontend/src/composables/__tests__/useCoach.test.ts
+++ b/frontend/src/composables/__tests__/useCoach.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the API layer; each test drives responses by path via mockImplementation.
+const apiCallMock = vi.fn()
+vi.mock('@/config/api', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+}))
+
+// Fresh module per test so the module-scoped roles cache (shared by useRoles /
+// AppHeader) doesn't leak between cases.
+async function freshModule() {
+  vi.resetModules()
+  return import('../useCoach')
+}
+
+beforeEach(() => {
+  apiCallMock.mockReset()
+})
+
+describe('useRoles / isCoach gating', () => {
+  it('is false before roles load', async () => {
+    const { useRoles } = await freshModule()
+    const { isCoach } = useRoles()
+    expect(isCoach.value).toBe(false)
+  })
+
+  it('is true when the coach role is present', async () => {
+    apiCallMock.mockResolvedValue({ roles: ['coach'], is_admin: false })
+    const { useRoles } = await freshModule()
+    const { isCoach, loadRoles } = useRoles()
+    await loadRoles()
+    expect(isCoach.value).toBe(true)
+  })
+
+  it('is true for an admin even without the coach role', async () => {
+    apiCallMock.mockResolvedValue({ roles: [], is_admin: true })
+    const { useRoles } = await freshModule()
+    const { isCoach, loadRoles } = useRoles()
+    await loadRoles()
+    expect(isCoach.value).toBe(true)
+  })
+
+  it('is false for a plain user', async () => {
+    apiCallMock.mockResolvedValue({ roles: [], is_admin: false })
+    const { useRoles } = await freshModule()
+    const { isCoach, loadRoles } = useRoles()
+    await loadRoles()
+    expect(isCoach.value).toBe(false)
+  })
+
+  it('caches roles — second load does not refetch unless forced', async () => {
+    apiCallMock.mockResolvedValue({ roles: ['coach'], is_admin: false })
+    const { useRoles } = await freshModule()
+    const { loadRoles } = useRoles()
+    await loadRoles()
+    await loadRoles()
+    expect(apiCallMock).toHaveBeenCalledTimes(1)
+    await loadRoles(true)
+    expect(apiCallMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('degrades to no-role on a failed roles fetch', async () => {
+    apiCallMock.mockRejectedValue(new Error('boom'))
+    const { useRoles } = await freshModule()
+    const { isCoach, loadRoles } = useRoles()
+    await loadRoles()
+    expect(isCoach.value).toBe(false)
+  })
+})
+
+describe('useCoach roster', () => {
+  it('loads athletes into state', async () => {
+    apiCallMock.mockResolvedValue([
+      { id: 'a1', display_name: 'Kid', birth_year: 2011, linked_user_id: null, created_by: 'c1', notes: null, created_at: 'x' },
+    ])
+    const { useCoach } = await freshModule()
+    const { athletes, loadAthletes } = useCoach()
+    await loadAthletes()
+    expect(apiCallMock).toHaveBeenCalledWith('/athletes')
+    expect(athletes.value).toHaveLength(1)
+    expect(athletes.value[0].display_name).toBe('Kid')
+  })
+
+  it('createAthlete POSTs, appends to the roster, and returns the created row', async () => {
+    const created = { id: 'a2', display_name: 'New', birth_year: null, linked_user_id: null, created_by: 'c1', notes: null, created_at: 'x' }
+    apiCallMock.mockResolvedValue(created)
+    const { useCoach } = await freshModule()
+    const { athletes, createAthlete } = useCoach()
+    const result = await createAthlete({ display_name: 'New' })
+    expect(result).toEqual(created)
+    expect(athletes.value).toContainEqual(created)
+    const [path, opts] = apiCallMock.mock.calls[0]
+    expect(path).toBe('/athletes')
+    expect(opts.method).toBe('POST')
+    expect(JSON.parse(opts.body)).toEqual({ display_name: 'New' })
+  })
+
+  it('createAthlete surfaces an error and returns null on failure', async () => {
+    apiCallMock.mockRejectedValue(new Error('nope'))
+    const { useCoach } = await freshModule()
+    const { athletes, error, createAthlete } = useCoach()
+    const result = await createAthlete({ display_name: 'X' })
+    expect(result).toBeNull()
+    expect(error.value).toBe('nope')
+    expect(athletes.value).toHaveLength(0)
+  })
+})
+
+describe('useAthleteDetail act-as', () => {
+  it('loads the athlete and their sessions with the X-Act-As-Athlete header', async () => {
+    const athlete = { id: 'a1', display_name: 'Kid', birth_year: 2011, linked_user_id: null, created_by: 'c1', notes: null, created_at: 'x' }
+    apiCallMock.mockImplementation((path: string) => {
+      if (path === '/athletes/a1') return Promise.resolve(athlete)
+      if (path.startsWith('/workouts/sessions')) return Promise.resolve([{ id: 's1', athlete_id: 'a1', session_date: '2026-07-01', type: 'circuit', total_minutes: 30, how_felt: 'good', notes: null, sets: [] }])
+      return Promise.reject(new Error('unexpected ' + path))
+    })
+    const { useAthleteDetail } = await freshModule()
+    const { athlete: a, sessions, load } = useAthleteDetail('a1')
+    await load()
+
+    expect(a.value?.display_name).toBe('Kid')
+    expect(sessions.value).toHaveLength(1)
+
+    const sessionsCall = apiCallMock.mock.calls.find((c) => String(c[0]).startsWith('/workouts/sessions'))
+    expect(sessionsCall).toBeTruthy()
+    expect(sessionsCall![1].headers).toEqual({ 'X-Act-As-Athlete': 'a1' })
+  })
+
+  it('captures an error when the athlete load fails', async () => {
+    apiCallMock.mockRejectedValue(new Error('403'))
+    const { useAthleteDetail } = await freshModule()
+    const { error, load } = useAthleteDetail('a1')
+    await load()
+    expect(error.value).toBe('403')
+  })
+})

--- a/frontend/src/composables/useCoach.ts
+++ b/frontend/src/composables/useCoach.ts
@@ -1,0 +1,94 @@
+import { computed, ref } from 'vue'
+import { apiCall } from '@/config/api'
+import type { Athlete, AthleteCreate, MyRoles, WorkoutSession } from '@/types/coach'
+
+// Roles are shared app-wide (the nav gates the Coach link on them), so cache
+// them in module scope — one fetch feeds AppHeader and every coach view.
+const roles = ref<MyRoles | null>(null)
+const rolesLoaded = ref(false)
+
+const isCoach = computed(
+  () => !!roles.value && (roles.value.roles.includes('coach') || roles.value.is_admin),
+)
+
+async function loadRoles(force = false): Promise<void> {
+  if (rolesLoaded.value && !force) return
+  try {
+    roles.value = await apiCall<MyRoles>('/me/roles')
+  } catch {
+    roles.value = { roles: [], is_admin: false }
+  } finally {
+    rolesLoaded.value = true
+  }
+}
+
+/** Header that makes an authenticated call act on an athlete's behalf. */
+const actAs = (athleteId: string) => ({ 'X-Act-As-Athlete': athleteId })
+
+export function useCoach() {
+  const athletes = ref<Athlete[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const loadAthletes = async (): Promise<void> => {
+    loading.value = true
+    error.value = null
+    try {
+      athletes.value = await apiCall<Athlete[]>('/athletes')
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load athletes'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  const createAthlete = async (body: AthleteCreate): Promise<Athlete | null> => {
+    error.value = null
+    try {
+      const created = await apiCall<Athlete>('/athletes', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      })
+      athletes.value = [...athletes.value, created]
+      return created
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to create athlete'
+      return null
+    }
+  }
+
+  return { athletes, loading, error, loadAthletes, createAthlete }
+}
+
+/** State for a single athlete's detail view — profile + their sessions (act-as). */
+export function useAthleteDetail(athleteId: string) {
+  const athlete = ref<Athlete | null>(null)
+  const sessions = ref<WorkoutSession[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const load = async (): Promise<void> => {
+    loading.value = true
+    error.value = null
+    try {
+      const [a, s] = await Promise.all([
+        apiCall<Athlete>(`/athletes/${athleteId}`),
+        apiCall<WorkoutSession[]>('/workouts/sessions?limit=50', {
+          headers: actAs(athleteId),
+        }),
+      ])
+      athlete.value = a
+      sessions.value = s
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load athlete'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { athlete, sessions, loading, error, load }
+}
+
+export function useRoles() {
+  return { roles, isCoach, loadRoles }
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -48,6 +48,18 @@ const router = createRouter({
       component: () => import('@/views/SettingsView.vue'),
       meta: { requiresAuth: true },
     },
+    {
+      path: '/coach',
+      name: 'coach',
+      component: () => import('@/views/CoachView.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/coach/:athleteId',
+      name: 'athlete-detail',
+      component: () => import('@/views/AthleteDetailView.vue'),
+      meta: { requiresAuth: true },
+    },
   ],
   scrollBehavior(_to, _from, savedPosition) {
     return savedPosition ?? { top: 0 }

--- a/frontend/src/types/coach.ts
+++ b/frontend/src/types/coach.ts
@@ -1,0 +1,45 @@
+export interface MyRoles {
+  roles: string[]
+  is_admin: boolean
+}
+
+export interface Athlete {
+  id: string
+  display_name: string
+  birth_year: number | null
+  linked_user_id: string | null
+  created_by: string | null
+  notes: string | null
+  created_at: string
+}
+
+export interface AthleteCreate {
+  display_name: string
+  birth_year?: number | null
+  notes?: string | null
+}
+
+export type WorkoutType = 'circuit' | 'intervals' | 'test' | string
+
+export interface ExerciseSet {
+  id: string
+  exercise_key: string
+  round_number: number | null
+  reps: number | null
+  duration_seconds: number | null
+  load_kg: number | null
+  distance_m: number | null
+  time_seconds: number | null
+  rpe: number | null
+}
+
+export interface WorkoutSession {
+  id: string
+  athlete_id: string | null
+  session_date: string
+  type: WorkoutType
+  total_minutes: number | null
+  how_felt: string | null
+  notes: string | null
+  sets: ExerciseSet[]
+}

--- a/frontend/src/views/AthleteDetailView.vue
+++ b/frontend/src/views/AthleteDetailView.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="container-app py-8">
+    <RouterLink to="/coach" class="text-sm text-brand-600 hover:text-brand-700">← Athletes</RouterLink>
+
+    <div v-if="loading" class="mt-4 space-y-2">
+      <div class="bg-white rounded-lg border border-gray-100 h-20 animate-pulse" />
+      <div v-for="i in 4" :key="i" class="bg-white rounded-lg border border-gray-100 h-14 animate-pulse" />
+    </div>
+
+    <div v-else-if="error" class="mt-4 bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-700">
+      {{ error }}
+    </div>
+
+    <template v-else-if="athlete">
+      <div class="mt-4 mb-6">
+        <h1 class="text-2xl font-bold text-gray-900">{{ athlete.display_name }}</h1>
+        <p class="text-sm text-gray-500 mt-1">
+          {{ athlete.birth_year ? `Born ${athlete.birth_year}` : 'No birth year' }}
+          <span v-if="athlete.linked_user_id" class="text-brand-600"> · has own login</span>
+        </p>
+        <p v-if="athlete.notes" class="text-sm text-gray-600 mt-2">{{ athlete.notes }}</p>
+      </div>
+
+      <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-2">
+        Recent sessions ({{ sessions.length }})
+      </h2>
+
+      <div
+        v-if="sessions.length === 0"
+        class="bg-white rounded-xl border border-gray-100 shadow-sm p-8 text-center text-gray-500"
+      >
+        <p>No workout sessions logged yet.</p>
+      </div>
+
+      <div v-else class="bg-white rounded-xl border border-gray-100 shadow-sm divide-y divide-gray-100">
+        <div v-for="s in sessions" :key="s.id" class="px-4 py-3 flex items-center justify-between">
+          <div>
+            <p class="font-medium text-gray-900">{{ s.session_date }}</p>
+            <p class="text-xs text-gray-500 mt-0.5 capitalize">
+              {{ s.type }}<span v-if="s.how_felt"> · felt {{ s.how_felt }}</span>
+            </p>
+          </div>
+          <div class="text-right text-sm text-gray-600">
+            <p>{{ s.sets.length }} {{ s.sets.length === 1 ? 'set' : 'sets' }}</p>
+            <p v-if="s.total_minutes" class="text-xs text-gray-400">{{ s.total_minutes }} min</p>
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { RouterLink, useRoute } from 'vue-router'
+import { useAthleteDetail } from '@/composables/useCoach'
+
+const route = useRoute()
+const { athlete, sessions, loading, error, load } = useAthleteDetail(route.params.athleteId as string)
+
+onMounted(load)
+</script>

--- a/frontend/src/views/CoachView.vue
+++ b/frontend/src/views/CoachView.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="container-app py-8">
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900">Athletes</h1>
+        <p class="text-sm text-gray-500 mt-1">
+          {{ athletes.length > 0 ? `Coaching ${athletes.length}` : 'No athletes yet' }}
+        </p>
+      </div>
+      <button class="btn-primary text-sm" @click="showForm = !showForm">
+        {{ showForm ? 'Cancel' : '+ Add athlete' }}
+      </button>
+    </div>
+
+    <form
+      v-if="showForm"
+      class="bg-white rounded-xl border border-gray-100 shadow-sm p-4 mb-6 space-y-3"
+      @submit.prevent="submit"
+    >
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <input
+          v-model="form.display_name"
+          required
+          placeholder="Name"
+          class="border border-gray-200 rounded-lg px-3 py-2 text-sm sm:col-span-2"
+        />
+        <input
+          v-model.number="form.birth_year"
+          type="number"
+          placeholder="Birth year"
+          class="border border-gray-200 rounded-lg px-3 py-2 text-sm"
+        />
+      </div>
+      <input
+        v-model="form.notes"
+        placeholder="Notes (optional)"
+        class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm"
+      />
+      <button type="submit" :disabled="saving" class="btn-primary text-sm">
+        {{ saving ? 'Saving…' : 'Create athlete' }}
+      </button>
+    </form>
+
+    <div v-if="loading && athletes.length === 0" class="space-y-2">
+      <div v-for="i in 3" :key="i" class="bg-white rounded-lg border border-gray-100 h-16 animate-pulse" />
+    </div>
+
+    <div v-else-if="error" class="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-700">
+      {{ error }}
+    </div>
+
+    <div
+      v-else-if="athletes.length === 0"
+      class="bg-white rounded-xl border border-gray-100 shadow-sm p-10 text-center text-gray-500"
+    >
+      <p>No athletes yet. Click <span class="font-semibold">Add athlete</span> to create one.</p>
+    </div>
+
+    <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <RouterLink
+        v-for="a in athletes"
+        :key="a.id"
+        :to="`/coach/${a.id}`"
+        class="bg-white rounded-xl border border-gray-100 shadow-sm p-4 hover:border-brand-300 hover:shadow transition"
+      >
+        <p class="font-semibold text-gray-900">{{ a.display_name }}</p>
+        <p class="text-sm text-gray-500 mt-1">
+          {{ a.birth_year ? `Born ${a.birth_year}` : 'No birth year' }}
+          <span v-if="a.linked_user_id" class="text-brand-600"> · has login</span>
+        </p>
+      </RouterLink>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, reactive, ref } from 'vue'
+import { RouterLink } from 'vue-router'
+import { useCoach } from '@/composables/useCoach'
+import type { AthleteCreate } from '@/types/coach'
+
+const { athletes, loading, error, loadAthletes, createAthlete } = useCoach()
+
+const showForm = ref(false)
+const saving = ref(false)
+const form = reactive<AthleteCreate>({ display_name: '', birth_year: null, notes: null })
+
+const submit = async () => {
+  saving.value = true
+  const created = await createAthlete({
+    display_name: form.display_name,
+    birth_year: form.birth_year || null,
+    notes: form.notes || null,
+  })
+  saving.value = false
+  if (created) {
+    form.display_name = ''
+    form.birth_year = null
+    form.notes = null
+    showForm.value = false
+  }
+}
+
+onMounted(loadAthletes)
+</script>


### PR DESCRIPTION
## What

First **web UI** for the coach↔athlete relationship. Backend + CLI already shipped (SB-195/198/204); a coach was CLI-only. This adds the browser surface — over existing endpoints, **no backend change**.

- **Coach nav link**, role-gated on `GET /me/roles` (coach or admin).
- **`/coach` roster** — athletes the coach actively coaches (`GET /athletes`) + inline "add athlete" form (`POST /athletes`).
- **`/coach/:athleteId` detail** — athlete profile + recent workout sessions, read via the act-as path (`GET /workouts/sessions` with `X-Act-As-Athlete`).

## Verification
- **Live, local stack, real coach JWT:** `/me/roles` → `{"roles":["coach"]}`, create/list/get athlete, act-as sessions (no 403). All response shapes match the frontend types.
- **`useCoach.test.ts`** — 11 Vitest cases: `isCoach` gating (incl. admin), roles cache + force-refetch, fail-degrade, roster load, `createAthlete` append/error, and asserts the **`X-Act-As-Athlete`** header on the session fetch.
- Typecheck (`vue-tsc`) + prod build clean.

## Not in scope (follow-ups)
- Component tests for the two views (presentational).
- Web-based session logging (currently CLI-only).
- Athlete-as-user-#2 onboarding + `linked_user_id` wiring (P4-2).

## Note (no code change)
Found `.env.local` locally missing `SUPABASE_KEY` (backend `SupabaseSettings` requires it) → every local DB route 500'd. `.env.local` is gitignored/per-dev and `.env.example` already carries the key, so nothing to change in-repo — repaired the local file only.

Parent: SB-189.

Fixes SB-211

🤖 Generated with [Claude Code](https://claude.com/claude-code)