### PR TITLE
feat: athlete-as-user-#2 onboarding — link invite to athlete (SB-212)

### DIFF
--- a/backend/routes/invites.py
+++ b/backend/routes/invites.py
@@ -15,7 +15,7 @@ from typing import Any
 from uuid import UUID
 
 import httpx
-from backend.admin import require_admin
+from backend.admin import require_admin, require_athlete_access
 from backend.auth import authenticate_request
 from backend.config import get_settings
 from backend.routes.auth_routes import _proxy_supabase_auth
@@ -24,6 +24,7 @@ from pydantic import BaseModel, Field
 from src.shared.models import Invite, InviteCreate
 from src.shared.supabase_client import get_supabase_client
 from src.shared.supabase_ops import (
+    AthletesRepository,
     InvitesRepository,
     UserRolesRepository,
     UsersRepository,
@@ -75,8 +76,12 @@ def issue_invite(
     body: InviteCreate,
     user_id: UUID = Depends(authenticate_request),
 ) -> Invite:
-    """Issue an invite (admin only). Returns the invite incl. its token."""
-    require_admin(user_id)
+    """Issue an invite. Admin-only, except an athlete invite (athlete_id set),
+    which a coach of that athlete may issue to onboard them (SB-212 P4-2)."""
+    if body.athlete_id is not None:
+        require_athlete_access(user_id, body.athlete_id)
+    else:
+        require_admin(user_id)
     token = secrets.token_urlsafe(32)
     expires_at = datetime.now(UTC) + timedelta(days=body.expires_in_days)
     row = InvitesRepository(get_supabase_client()).create(
@@ -85,6 +90,7 @@ def issue_invite(
         token=token,
         expires_at=expires_at,
         grant_role=body.grant_role.value if body.grant_role else None,
+        athlete_id=body.athlete_id,
     )
     return Invite(**row)
 
@@ -127,6 +133,19 @@ def redeem_invite(body: RedeemRequest) -> dict[str, Any]:
     # Grant the invite's role (e.g. coach) so they can act immediately (SB-204).
     if invite.get("grant_role"):
         UserRolesRepository(supabase).grant(auth_uid, str(invite["grant_role"]))
+    # Link the new user to the invited athlete, onboarding them as user #2 so
+    # they see their own data via the linked_user_id RLS (SB-212 P4-2).
+    if invite.get("athlete_id"):
+        athlete_id = UUID(str(invite["athlete_id"]))
+        athletes = AthletesRepository(supabase)
+        existing = athletes.get(athlete_id)
+        linked = existing.get("linked_user_id") if existing else None
+        if linked and str(linked) != str(auth_uid):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Athlete is already linked to another user",
+            )
+        athletes.link_user(athlete_id, auth_uid)
     invites.mark_redeemed(body.token, auth_uid, datetime.now(UTC))
 
     # Hand back a live session so the invitee is logged straight in.

--- a/backend/tests/test_invites.py
+++ b/backend/tests/test_invites.py
@@ -149,17 +149,20 @@ def test_issue_invite_route_admin_issues_token() -> None:
 
     admin = uuid4()
     repo = MagicMock()
-    repo.create.side_effect = lambda created_by, email, token, expires_at, grant_role=None: {
-        "id": str(uuid4()),
-        "token": token,
-        "email": email,
-        "created_by": str(created_by),
-        "expires_at": expires_at.isoformat(),
-        "grant_role": grant_role,
-        "redeemed_at": None,
-        "redeemed_by": None,
-        "created_at": "2026-06-20T00:00:00+00:00",
-    }
+    repo.create.side_effect = (
+        lambda created_by, email, token, expires_at, grant_role=None, athlete_id=None: {
+            "id": str(uuid4()),
+            "token": token,
+            "email": email,
+            "created_by": str(created_by),
+            "expires_at": expires_at.isoformat(),
+            "grant_role": grant_role,
+            "athlete_id": str(athlete_id) if athlete_id else None,
+            "redeemed_at": None,
+            "redeemed_by": None,
+            "created_at": "2026-06-20T00:00:00+00:00",
+        }
+    )
 
     with (
         patch("backend.routes.invites.require_admin", return_value=None),
@@ -192,11 +195,14 @@ def _redeem(invite_row: dict[str, Any] | None) -> Any:
     repo = MagicMock()
     repo.get_by_token.return_value = invite_row
     roles_repo = MagicMock()
+    athletes_repo = MagicMock()
+    athletes_repo.get.return_value = None  # athlete not yet linked, by default
     with (
         patch("backend.routes.invites.get_supabase_client", return_value=MagicMock()),
         patch("backend.routes.invites.InvitesRepository", return_value=repo),
         patch("backend.routes.invites.UsersRepository", return_value=MagicMock()),
         patch("backend.routes.invites.UserRolesRepository", return_value=roles_repo),
+        patch("backend.routes.invites.AthletesRepository", return_value=athletes_repo),
         patch(
             "backend.routes.invites._admin_create_user",
             return_value={"id": str(uuid4())},
@@ -210,6 +216,7 @@ def _redeem(invite_row: dict[str, Any] | None) -> Any:
             redeem_invite(RedeemRequest(token="tok-abcdef", password="secret1")),
             repo,
             roles_repo,
+            athletes_repo,
         )
 
 
@@ -235,13 +242,14 @@ def test_redeem_expired_410() -> None:
 
 def test_redeem_happy_path_creates_user_and_returns_session() -> None:
     row = {"email": "friend@example.com", "expires_at": _future(), "redeemed_at": None}
-    result, repo, roles_repo = _redeem(row)
+    result, repo, roles_repo, athletes_repo = _redeem(row)
     assert result["access_token"] == "at"
     assert result["user"]["email"] == "friend@example.com"
     # invite consumed; account email comes from the invite, not the request
     repo.mark_redeemed.assert_called_once()
     assert repo.mark_redeemed.call_args[0][0] == "tok-abcdef"
     roles_repo.grant.assert_not_called()  # no grant_role on this invite
+    athletes_repo.link_user.assert_not_called()  # no athlete_id on this invite
 
 
 def test_redeem_grants_role_when_set() -> None:
@@ -251,6 +259,103 @@ def test_redeem_grants_role_when_set() -> None:
         "redeemed_at": None,
         "grant_role": "coach",
     }
-    _result, _repo, roles_repo = _redeem(row)
+    _result, _repo, roles_repo, _athletes = _redeem(row)
     roles_repo.grant.assert_called_once()
     assert roles_repo.grant.call_args[0][1] == "coach"
+
+
+def test_redeem_links_athlete_when_athlete_id_set() -> None:
+    """SB-212: an athlete invite links the new user to the athlete profile."""
+    athlete_id = uuid4()
+    row = {
+        "email": "kid@example.com",
+        "expires_at": _future(),
+        "redeemed_at": None,
+        "athlete_id": str(athlete_id),
+    }
+    result, _repo, _roles, athletes_repo = _redeem(row)
+    athletes_repo.link_user.assert_called_once()
+    called_athlete, called_user = athletes_repo.link_user.call_args[0]
+    assert called_athlete == athlete_id
+    assert str(called_user) == result["user"]["id"]
+
+
+def test_redeem_conflicts_when_athlete_already_linked() -> None:
+    """SB-212: refuse to steal an athlete already linked to a different user."""
+    from backend.routes.invites import RedeemRequest, redeem_invite
+
+    athlete_id = uuid4()
+    row = {
+        "email": "kid@example.com",
+        "expires_at": _future(),
+        "redeemed_at": None,
+        "athlete_id": str(athlete_id),
+    }
+    repo = MagicMock()
+    repo.get_by_token.return_value = row
+    athletes_repo = MagicMock()
+    athletes_repo.get.return_value = {"id": str(athlete_id), "linked_user_id": str(uuid4())}
+    with (
+        patch("backend.routes.invites.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.invites.InvitesRepository", return_value=repo),
+        patch("backend.routes.invites.UsersRepository", return_value=MagicMock()),
+        patch("backend.routes.invites.UserRolesRepository", return_value=MagicMock()),
+        patch("backend.routes.invites.AthletesRepository", return_value=athletes_repo),
+        patch("backend.routes.invites._admin_create_user", return_value={"id": str(uuid4())}),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            redeem_invite(RedeemRequest(token="tok-abcdef", password="secret1"))
+    assert exc.value.status_code == 409
+    athletes_repo.link_user.assert_not_called()
+
+
+def test_issue_athlete_invite_uses_athlete_access_not_admin() -> None:
+    """SB-212: a coach may issue an athlete invite via athlete access (not admin)."""
+    from backend.routes.invites import issue_invite
+    from src.shared.models import InviteCreate
+
+    coach = uuid4()
+    athlete_id = uuid4()
+    repo = MagicMock()
+    repo.create.side_effect = (
+        lambda created_by, email, token, expires_at, grant_role=None, athlete_id=None: {
+            "id": str(uuid4()),
+            "token": token,
+            "email": email,
+            "created_by": str(created_by),
+            "expires_at": expires_at.isoformat(),
+            "grant_role": grant_role,
+            "athlete_id": str(athlete_id) if athlete_id else None,
+            "redeemed_at": None,
+            "redeemed_by": None,
+            "created_at": "2026-06-20T00:00:00+00:00",
+        }
+    )
+    access = MagicMock()
+    with (
+        # admin gate would raise — proving the athlete path doesn't require admin
+        patch("backend.routes.invites.require_admin", side_effect=AssertionError("used admin")),
+        patch("backend.routes.invites.require_athlete_access", access),
+        patch("backend.routes.invites.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.invites.InvitesRepository", return_value=repo),
+    ):
+        out = issue_invite(
+            InviteCreate(email="kid@example.com", athlete_id=athlete_id), user_id=coach
+        )
+
+    access.assert_called_once_with(coach, athlete_id)
+    assert out.athlete_id == athlete_id
+    assert repo.create.call_args.kwargs["athlete_id"] == athlete_id
+
+
+def test_link_user_sets_linked_user_id() -> None:
+    """SB-212: AthletesRepository.link_user writes linked_user_id."""
+    from src.shared.supabase_ops.athletes_repository import AthletesRepository
+
+    athlete_id = uuid4()
+    user_id = uuid4()
+    store = [{"id": str(athlete_id), "display_name": "Kid", "linked_user_id": None}]
+    repo = AthletesRepository(_FakeClient())  # type: ignore[arg-type]
+    repo.supabase.store = store  # type: ignore[attr-defined]
+    updated = repo.link_user(athlete_id, user_id)
+    assert updated["linked_user_id"] == str(user_id)

--- a/src/shared/models/invite.py
+++ b/src/shared/models/invite.py
@@ -20,6 +20,10 @@ class InviteCreate(BaseModel):
     grant_role: Role | None = Field(
         default=None, description="Role granted on redemption (e.g. coach)"
     )
+    athlete_id: UUID | None = Field(
+        default=None,
+        description="If set, redeeming links the new user to this athlete (SB-212 P4-2)",
+    )
 
 
 class Invite(BaseModel):
@@ -31,6 +35,7 @@ class Invite(BaseModel):
     created_by: UUID
     expires_at: datetime
     grant_role: Role | None = None
+    athlete_id: UUID | None = None
     redeemed_at: datetime | None = None
     redeemed_by: UUID | None = None
     created_at: datetime

--- a/src/shared/supabase_ops/athletes_repository.py
+++ b/src/shared/supabase_ops/athletes_repository.py
@@ -61,6 +61,20 @@ class AthletesRepository:
         data = cast(list[dict[str, Any]], result.data)
         return data[0] if data else None
 
+    def link_user(self, athlete_id: UUID, user_id: UUID) -> dict[str, Any]:
+        """Link a logged-in user to this athlete (athletes.linked_user_id).
+
+        Onboards the athlete as user #2 (SB-212 P4-2): once set, the linked user
+        reaches their own athlete-scoped rows via the linked_user_id RLS.
+        """
+        result = (
+            self.supabase.table("athletes")
+            .update({"linked_user_id": str(user_id)})
+            .eq("id", str(athlete_id))
+            .execute()
+        )
+        return cast(list[dict[str, Any]], result.data)[0]
+
     def list_for_coach(self, coach_id: UUID) -> list[dict[str, Any]]:
         """Athletes the coach actively coaches (joined via coach_athletes)."""
         links = (

--- a/src/shared/supabase_ops/invites_repository.py
+++ b/src/shared/supabase_ops/invites_repository.py
@@ -26,6 +26,7 @@ class InvitesRepository:
         token: str,
         expires_at: datetime,
         grant_role: str | None = None,
+        athlete_id: UUID | None = None,
     ) -> dict[str, Any]:
         row = {
             "created_by": str(created_by),
@@ -35,6 +36,8 @@ class InvitesRepository:
         }
         if grant_role is not None:
             row["grant_role"] = grant_role
+        if athlete_id is not None:
+            row["athlete_id"] = str(athlete_id)
         result = self.supabase.table("invites").insert(row).execute()
         return cast(list[dict[str, Any]], result.data)[0]
 

--- a/supabase/migrations/20260701000000_invite_athlete_link.sql
+++ b/supabase/migrations/20260701000000_invite_athlete_link.sql
@@ -1,0 +1,11 @@
+-- =====================================================
+-- Athlete onboarding (SB-212, SB-189 P4-2): an invite can be tied to a managed
+-- athlete. When such an invite is redeemed, the new user is linked to that
+-- athlete (athletes.linked_user_id = new uid), so the athlete becomes a
+-- logged-in user #2 who sees their own data via the existing linked_user_id
+-- RLS. Nothing set linked_user_id before this.
+-- =====================================================
+ALTER TABLE invites ADD COLUMN athlete_id UUID REFERENCES athletes(id) ON DELETE CASCADE;
+
+COMMENT ON COLUMN invites.athlete_id IS
+    'If set, redeeming links the new user to this athlete (athletes.linked_user_id) — SB-212 P4-2';


### PR DESCRIPTION
## What

`athletes.linked_user_id` existed and RLS (`can_access_athlete`/`can_coach_athlete`) honored it, but **nothing ever set it** — so a coach-created athlete could never become a logged-in user seeing their own data. This ties an invite to an athlete and wires the link on redemption (SB-189 P4-2).

- **Migration:** `invites.athlete_id` → FK to `athletes` (nullable, `ON DELETE CASCADE`)
- `InviteCreate` / `Invite` carry `athlete_id`
- `InvitesRepository.create` accepts `athlete_id`
- **`AthletesRepository.link_user(athlete_id, user_id)`** — sets `linked_user_id`
- **`POST /invites`:** an athlete invite (`athlete_id` set) is authorized by *athlete access* (coach of them, or admin), not admin-only; plain coach/admin invites unchanged
- **`POST /invites/redeem`:** links the new user to the athlete; **409** if the athlete is already linked to a different user

## Verification
End-to-end on the local stack:
```
coach creates athlete       → linked_user_id: null
coach issues athlete invite → athlete_id attached
athlete redeems             → linked_user_id = new user ✓
athlete GET /athletes/{id}  → 200 (linked access)
athlete GET /workouts/sessions → 200 (own data)
```
Tests (`test_invites.py`, 14 pass): link on redeem, the 409 already-linked guard, the coach-access issue path (asserts admin gate NOT used), and the repo write. Full backend suite 172 pass, ruff clean.

## Follow-ups (not here)
- CLI `stk invite create --athlete <id>` + "Invite this athlete" button in the coach web view (SB-211).
- Optional link/unlink endpoint for an already-existing user.

Parent: SB-189.

Fixes SB-212

🤖 Generated with [Claude Code](https://claude.com/claude-code)