### PR TITLE
fix: allow X-Act-As-Athlete through CORS (SB-213)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -41,7 +41,9 @@ def create_app() -> FastAPI:
         allow_origins=origins,
         allow_credentials=False,
         allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
-        allow_headers=["Authorization", "Content-Type", "X-Api-Key"],
+        # X-Act-As-Athlete: coach acting on an athlete's behalf (browser sends it
+        # on workout reads, so it must survive CORS preflight).
+        allow_headers=["Authorization", "Content-Type", "X-Api-Key", "X-Act-As-Athlete"],
         max_age=300,
     )
 

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,36 @@
+"""CORS preflight must allow the headers browser clients actually send.
+
+The coach web view (SB-211) reads an athlete's workouts with the
+`X-Act-As-Athlete` header; if the CORS preflight rejects it, the browser blocks
+the call and the athlete detail page fails to load. This guards that.
+"""
+
+from __future__ import annotations
+
+from backend.app import create_app
+from fastapi.testclient import TestClient
+
+
+def _preflight(request_headers: str) -> str:
+    client = TestClient(create_app())
+    resp = client.options(
+        "/workouts/sessions",
+        headers={
+            "Origin": "http://localhost:5174",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": request_headers,
+        },
+    )
+    assert resp.status_code == 200, resp.status_code
+    return resp.headers.get("access-control-allow-headers", "").lower()
+
+
+def test_preflight_allows_act_as_athlete_header() -> None:
+    allowed = _preflight("authorization,x-act-as-athlete")
+    assert "x-act-as-athlete" in allowed
+
+
+def test_preflight_still_allows_authorization() -> None:
+    allowed = _preflight("authorization,content-type")
+    assert "authorization" in allowed
+    assert "content-type" in allowed


### PR DESCRIPTION
## What
Coach web view (SB-211): clicking an athlete failed with "failed to load". The athlete detail reads `GET /workouts/sessions` with the `X-Act-As-Athlete` header, but CORS `allow_headers` omitted it — so the browser preflight was rejected and the call blocked. The roster works because it only sends `Authorization`. curl skips preflight, so API tests were green.

The act-as header was built for the CLI (no CORS); the web view is the first browser client to send it.

## Fix
Add `X-Act-As-Athlete` to `allow_headers` in `backend/app.py`. Regression test `backend/tests/test_cors.py` asserts the preflight allows it (and still allows Authorization/Content-Type).

Verified live: preflight `OPTIONS /workouts/sessions` now returns `access-control-allow-headers: …, X-Act-As-Athlete`.

Fixes SB-213
🤖 Generated with [Claude Code](https://claude.com/claude-code)