### PR TITLE
UX polish (ui-ux-pro-max): a11y + emoji→SVG icons (SB-215)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@supabase/supabase-js": "^2.45.0",
         "apexcharts": "^5.10.6",
         "date-fns": "^4.1.0",
+        "lucide-vue-next": "^1.0.0",
         "pinia": "^2.1.7",
         "vue": "^3.4.15",
         "vue-router": "^4.2.5",
@@ -3527,6 +3528,16 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-vue-next": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-1.0.0.tgz",
+      "integrity": "sha512-V6SPvx1IHTj/UY+FrIYWV5faISsPSb8BnWSFDxAtezWKvWc9ZZ40PDrdu1/Qb5vg4lHWr1hs1BAMGVGm6V1Xdg==",
+      "deprecated": "Package deprecated. Please use @lucide/vue instead.",
+      "license": "ISC",
+      "peerDependencies": {
+        "vue": ">=3.0.1"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@supabase/supabase-js": "^2.45.0",
     "apexcharts": "^5.10.6",
     "date-fns": "^4.1.0",
+    "lucide-vue-next": "^1.0.0",
     "pinia": "^2.1.7",
     "vue": "^3.4.15",
     "vue-router": "^4.2.5",

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -6,6 +6,18 @@
   body {
     @apply bg-gray-50 text-gray-900;
   }
+
+  /* Respect reduced-motion: near-instant animations/transitions (a11y). */
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    ::before,
+    ::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
 }
 
 @layer components {
@@ -14,11 +26,11 @@
   }
 
   .btn-primary {
-    @apply bg-brand-600 hover:bg-brand-700 text-white font-semibold py-2 px-4 rounded-lg transition duration-200 disabled:opacity-50 disabled:cursor-not-allowed;
+    @apply bg-brand-600 hover:bg-brand-700 text-white font-semibold py-2 px-4 rounded-lg transition duration-200 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed;
   }
 
   .btn-secondary {
-    @apply bg-gray-100 hover:bg-gray-200 text-gray-800 font-semibold py-2 px-4 rounded-lg transition duration-200;
+    @apply bg-gray-100 hover:bg-gray-200 text-gray-800 font-semibold py-2 px-4 rounded-lg transition duration-200 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2;
   }
 
   .form-input {

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -25,6 +25,8 @@
         <button
           @click="mobileMenuOpen = !mobileMenuOpen"
           class="md:hidden text-gray-700 hover:text-brand-600"
+          :aria-label="mobileMenuOpen ? 'Close menu' : 'Open menu'"
+          :aria-expanded="mobileMenuOpen"
         >
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path

--- a/frontend/src/components/EmptyState.vue
+++ b/frontend/src/components/EmptyState.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="bg-white rounded-xl border border-gray-100 shadow-sm p-10 text-center">
-    <div class="text-5xl mb-4">🏃</div>
+    <Footprints class="w-12 h-12 mx-auto mb-4 text-brand-600" />
     <h2 class="text-xl font-bold text-gray-900 mb-2">Connect SmashRun to import your runs</h2>
     <p class="text-gray-500 max-w-md mx-auto mb-6">
       MyRunStreak pulls your activity from SmashRun. Authorize SmashRun once and we'll
@@ -11,6 +11,7 @@
 </template>
 
 <script setup lang="ts">
+import { Footprints } from 'lucide-vue-next'
 import SyncButton from './SyncButton.vue'
 
 defineEmits<{ synced: [] }>()

--- a/frontend/src/components/GoalsCard.vue
+++ b/frontend/src/components/GoalsCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="bg-white rounded-2xl shadow-md p-6 h-full border border-gray-100">
     <div class="flex items-center gap-2 mb-4">
-      <span class="text-lg">🎯</span>
+      <Target class="w-4 h-4 text-gray-700" />
       <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-700">
         Goals
       </h3>
@@ -18,9 +18,9 @@
     <!-- Monthly goal -->
     <div v-if="monthly" class="mb-4">
       <div class="flex items-start justify-between gap-2 mb-1">
-        <span class="text-xs font-medium text-gray-700">
-          📅 {{ currentMonthName }}
-          <span v-if="monthlyPercent >= 100" class="ml-1">🎉</span>
+        <span class="inline-flex items-center gap-1 text-xs font-medium text-gray-700">
+          <Calendar class="w-3.5 h-3.5" /> {{ currentMonthName }}
+          <PartyPopper v-if="monthlyPercent >= 100" class="w-3.5 h-3.5 text-brand-600" />
         </span>
         <span class="text-xs font-semibold text-gray-900 whitespace-nowrap">
           {{ monthly.progress_mi.toFixed(1) }} / {{ monthly.goal_mi.toFixed(0) }} mi
@@ -44,8 +44,8 @@
         <span class="text-gray-500">
           {{ monthlyPercent.toFixed(1) }}%
         </span>
-        <span v-if="monthlyPercent >= 100" class="text-green-600 font-medium">
-          🎉 Goal achieved!
+        <span v-if="monthlyPercent >= 100" class="inline-flex items-center gap-1 text-green-600 font-medium">
+          <PartyPopper class="w-3.5 h-3.5" /> Goal achieved!
         </span>
         <span v-else :class="paceColor(monthlyPaceDelta)">
           {{ formatMilesDelta(monthlyMilesDelta) }}
@@ -56,9 +56,9 @@
     <!-- Yearly goal -->
     <div v-if="yearly">
       <div class="flex items-start justify-between gap-2 mb-1">
-        <span class="text-xs font-medium text-gray-700">
-          🎯 {{ currentYear }}
-          <span v-if="yearlyPercent >= 100" class="ml-1">🎉</span>
+        <span class="inline-flex items-center gap-1 text-xs font-medium text-gray-700">
+          <Target class="w-3.5 h-3.5" /> {{ currentYear }}
+          <PartyPopper v-if="yearlyPercent >= 100" class="w-3.5 h-3.5 text-brand-600" />
         </span>
         <span class="text-xs font-semibold text-gray-900 whitespace-nowrap">
           {{ yearly.progress_mi.toFixed(1) }} / {{ yearly.goal_mi.toFixed(0) }} mi
@@ -82,8 +82,8 @@
         <span class="text-gray-500">
           {{ yearlyPercent.toFixed(1) }}%
         </span>
-        <span v-if="yearlyPercent >= 100" class="text-green-600 font-medium">
-          🎉 Goal achieved!
+        <span v-if="yearlyPercent >= 100" class="inline-flex items-center gap-1 text-green-600 font-medium">
+          <PartyPopper class="w-3.5 h-3.5" /> Goal achieved!
         </span>
         <span v-else :class="paceColor(yearlyPaceDelta)">
           {{ formatMilesDelta(yearlyMilesDelta) }}
@@ -95,6 +95,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { Calendar, PartyPopper, Target } from 'lucide-vue-next'
 import type { GoalProgress } from '@/types/runs'
 
 const props = defineProps<{

--- a/frontend/src/components/QuickLog.vue
+++ b/frontend/src/components/QuickLog.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="bg-white rounded-2xl shadow-md p-6 border border-gray-100">
     <div class="flex items-center gap-2 mb-4">
-      <span class="text-lg">⚡</span>
+      <Zap class="w-4 h-4 text-gray-700" />
       <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-700">
         Quick log
       </h3>
@@ -10,7 +10,9 @@
     <!-- Push-ups: one-tap presets + custom -->
     <div class="mb-5">
       <div class="flex items-center justify-between mb-2">
-        <span class="text-xs font-medium text-gray-700">💪 Push-ups</span>
+        <span class="inline-flex items-center gap-1 text-xs font-medium text-gray-700">
+          <Dumbbell class="w-3.5 h-3.5" /> Push-ups
+        </span>
       </div>
       <div class="flex flex-wrap items-center gap-2">
         <button
@@ -78,6 +80,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { Dumbbell, Zap } from 'lucide-vue-next'
 import { useMetrics } from '@/composables/useMetrics'
 import type { MetricType } from '@/types/metrics'
 import { displayUnit, toStored } from '@/utils/metrics'

--- a/frontend/src/components/StreakHero.vue
+++ b/frontend/src/components/StreakHero.vue
@@ -10,7 +10,7 @@
 
     <div class="relative flex flex-col h-full">
       <div class="flex items-center gap-2 text-white/80 text-xs font-semibold uppercase tracking-wide mb-1">
-        <span class="text-lg">🔥</span>
+        <Flame class="w-4 h-4" />
         <span>Current streak</span>
       </div>
       <p class="text-5xl sm:text-6xl font-extrabold leading-none tabular-nums">
@@ -40,6 +40,7 @@
 
 <script setup lang="ts">
 import { computed, toRef } from 'vue'
+import { Flame } from 'lucide-vue-next'
 import { useCountUp } from '@/composables/useCountUp'
 
 const props = defineProps<{

--- a/frontend/src/components/TodayCard.vue
+++ b/frontend/src/components/TodayCard.vue
@@ -2,7 +2,7 @@
   <div class="bg-white rounded-2xl shadow-md p-6 h-full border border-gray-100">
     <div class="flex items-center justify-between mb-4">
       <div class="flex items-center gap-2">
-        <span class="text-lg">📈</span>
+        <TrendingUp class="w-4 h-4 text-gray-700" />
         <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-700">
           Today
         </h3>
@@ -24,7 +24,7 @@
       <div class="flex items-start justify-between gap-2 mb-1">
         <span class="text-xs font-medium text-gray-700">
           {{ row.label }}
-          <span v-if="row.met" class="ml-1">🎉</span>
+          <PartyPopper v-if="row.met" class="inline w-3.5 h-3.5 ml-1 text-brand-600" />
         </span>
         <span class="text-xs font-semibold text-gray-900 whitespace-nowrap">
           {{ row.progressText }}
@@ -47,6 +47,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { PartyPopper, TrendingUp } from 'lucide-vue-next'
 import type { GoalProgress, MetricType } from '@/types/metrics'
 import { displayDecimals, displayUnit, toDisplay } from '@/utils/metrics'
 
@@ -104,14 +105,14 @@ const rows = computed<Row[]>(() =>
       percent,
       met: g.met,
       barClass: barClass(g, percent),
-      paceText: g.met ? 'Achieved 🎉' : paceText,
+      paceText: g.met ? 'Achieved' : paceText,
       paceClass: paceClass(g),
     }
   }),
 )
 
 function paceForVolume(g: GoalProgress, unit: string): string {
-  if (g.met) return 'Achieved 🎉'
+  if (g.met) return 'Achieved'
   if (g.projected !== null) {
     const u = displayUnit(unit)
     const proj = `on pace for ${fmt(unit, g.projected)} ${u}`

--- a/frontend/src/composables/useCountUp.ts
+++ b/frontend/src/composables/useCountUp.ts
@@ -4,8 +4,17 @@ export function useCountUp(target: () => number, durationMs = 900) {
   const value = ref(0)
   let raf: number | null = null
 
+  const prefersReducedMotion = () =>
+    typeof window !== 'undefined' &&
+    window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+
   const animate = (to: number) => {
     if (raf !== null) cancelAnimationFrame(raf)
+    // Reduced-motion: skip the count-up, show the final value immediately.
+    if (prefersReducedMotion()) {
+      value.value = to
+      return
+    }
     const from = value.value
     const start = performance.now()
     const step = (now: number) => {


### PR DESCRIPTION
Driven by the **ui-ux-pro-max** design-intelligence skill's review of the app (it confirmed *Data-Dense Dashboard* as the right style; applied its a11y + style rules, kept our navy brand).

## Tier 1 — accessibility (CRITICAL)
- **Reduced motion**: global `prefers-reduced-motion` guard (near-instant animations/transitions); `useCountUp` skips the count and shows the final value immediately.
- **Focus rings**: `btn-primary`/`btn-secondary` now get `focus-visible` rings + `cursor-pointer` (previously only inputs had focus rings — keyboard focus was invisible on buttons).
- **aria**: mobile menu button gets `aria-label` + `aria-expanded`.

## Tier 2 — emoji → SVG (rule `no-emoji-icons`)
Emoji are font-dependent, inconsistent cross-platform, and un-themeable. Swapped structural/label emoji for `lucide-vue-next` across 5 components:
`📈→TrendingUp, 🔥→Flame, 🎯→Target, ⚡→Zap, 💪→Dumbbell, 📅→Calendar, 🏃→Footprints, 🎉→PartyPopper`. Stripped celebratory emoji from JS-returned strings (badge conveys it). Adds `lucide-vue-next` (tree-shakeable).

## Verification
`vue-tsc` typecheck + production build clean. No emoji remain in `src/**.vue`.

## Follow-ups (not in this PR)
Further ui-ux-pro-max findings for later: richer empty/error-recovery states, coach athlete-card density (avatar/last-activity), loading skeletons, chart a11y.

Refs SB-215
🤖 Generated with [Claude Code](https://claude.com/claude-code)