### PR TITLE
chore: local-dev seed-users script + documented setup (SB-216)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ are gitignored; create them once:
 - **`.env.local`** — local Supabase. Uses the standard local-dev keys
   (`SUPABASE_URL=http://127.0.0.1:54321`, the well-known demo anon/service keys,
   `SUPABASE_JWT_SECRET=super-secret-jwt-token-with-at-least-32-characters-long`,
-  `CACHE_ENABLED=false`). After signing up a local user, set `ADMIN_USER_IDS` to
-  its UID (Studio → Authentication) so coach/invite endpoints work locally.
+  `CACHE_ENABLED=false`). **Also set `SUPABASE_KEY` to the service-role key** —
+  the backend requires it or every DB route 500s. Seed dev users with
+  `scripts/seed_local_users.py` (see below) instead of hand-setting admin IDs.
 - **`.env.prod`** — copy from `.env.example` and fill with the real cloud keys.
 
 Or do it by hand:
@@ -92,6 +93,18 @@ supabase start                                   # local Postgres
 uv run uvicorn backend.app:app --reload --port 8000
 cd frontend && npm install && npm run dev
 ```
+
+Seed a clean set of local users (idempotent, local-only; rerun after `db reset`):
+
+```bash
+eval "$(supabase status -o env | sed 's/^/export SB_/')"
+SUPABASE_URL="$SB_API_URL" SERVICE_KEY="$SB_SERVICE_ROLE_KEY" \
+  uv run python scripts/seed_local_users.py
+```
+
+Creates `admin@test.local` / `coach@test.local` / `a1@test.local` /
+`a2@test.local` (coach + two linked athletes) — log in at
+http://localhost:5174. Full guide: **[docs/LOCAL_DEV.md](docs/LOCAL_DEV.md)**.
 
 See [QUICKSTART.md](QUICKSTART.md) and [docs/TESTING.md](docs/TESTING.md).
 

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -1,0 +1,119 @@
+# Local Development
+
+How to run MyRunStreak on your machine against a local Supabase stack, with a
+clean set of seeded users.
+
+## Prerequisites
+
+- **Docker Desktop** (running) — local Supabase runs in containers.
+- **[uv](https://github.com/astral-sh/uv)** — Python deps + commands.
+- **Node + npm** — the Vue frontend.
+- **[Supabase CLI](https://supabase.com/docs/guides/cli)** — local Postgres/Auth.
+- (Optional) **1Password CLI (`op`)** + `jt` — only for prod secrets / syncing
+  prod users; not needed for pure local work.
+
+## Environment files
+
+`./switch-env.sh {local|prod}` repoints `.env` (and `frontend/.env`) at
+`.env.<env>`. These files are gitignored — create them once.
+
+### `.env.local`
+
+Local Supabase uses the well-known demo keys. Minimum working file:
+
+```bash
+ENVIRONMENT=dev
+LOG_LEVEL=INFO
+CACHE_ENABLED=false
+
+SUPABASE_URL=http://127.0.0.1:54321
+SUPABASE_ANON_KEY=<local anon key from `supabase status`>
+SUPABASE_SERVICE_ROLE_KEY=<local service_role key from `supabase status`>
+# REQUIRED: the backend's SupabaseSettings reads SUPABASE_KEY (service role).
+# Without it every DB route 500s locally. Set it to the same service_role key.
+SUPABASE_KEY=<same as SUPABASE_SERVICE_ROLE_KEY>
+SUPABASE_JWT_SECRET=super-secret-jwt-token-with-at-least-32-characters-long
+```
+
+> ⚠️ **`SUPABASE_KEY` is required.** The backend (`src/shared/supabase_client.py`)
+> loads `SUPABASE_KEY`; if it's missing, `SupabaseSettings` fails to validate and
+> every DB-backed route returns 500 (health still returns 200, which is
+> misleading). `.env.example` already includes it — don't drop it from
+> `.env.local`.
+
+### `.env.prod`
+
+Copy `.env.example` and fill with the real cloud keys (or resolve via 1Password
+with `jt secrets run`).
+
+## Running the stack
+
+```bash
+./switch-env.sh local            # point env at local Supabase
+./myrunstreak.sh start --watch   # local Supabase + backend (:8000) + frontend (:5174)
+./myrunstreak.sh status          # what's up + active env
+./myrunstreak.sh logs            # snapshot of backend/frontend logs
+./myrunstreak.sh stop            # stop backend + frontend
+```
+
+The frontend serves at **http://localhost:5174** (Vite binds IPv6 — use
+`localhost`, not `127.0.0.1`). Backend at http://localhost:8000.
+
+## Seed local users
+
+After the stack is up (and after any `db reset`), seed a clean, memorable set of
+dev users:
+
+```bash
+eval "$(supabase status -o env | sed 's/^/export SB_/')"
+SUPABASE_URL="$SB_API_URL" SERVICE_KEY="$SB_SERVICE_ROLE_KEY" \
+  uv run python scripts/seed_local_users.py
+```
+
+The script is **idempotent** (rerun anytime) and **local-only** (it refuses to
+run against a non-local Supabase URL). It produces:
+
+| Email | Password | Role |
+|-------|----------|------|
+| `admin@test.local` | `admin123` | admin |
+| `coach@test.local` | `coach123` | coach — coaches both athletes below |
+| `a1@test.local` | `a12345` | athlete "Athlete One" (logs in as self) |
+| `a2@test.local` | `a12345` | athlete "Athlete Two" (logs in as self) |
+
+Athlete passwords are `a12345` because Supabase enforces a **6-character minimum**
+(it ignores a lower `minimum_password_length` in `supabase/config.toml`).
+
+The coach↔athlete links + `linked_user_id` are wired so the **Coach** tab,
+act-as, and athlete-self-login all work immediately. Any `silverbeer.io@gmail.com`
+user (from `jt supabase sync-users`) is left untouched; ad-hoc throwaway users
+are purged.
+
+Log in at http://localhost:5174 with any of the above.
+
+## Database
+
+```bash
+./myrunstreak.sh db status    # is local Supabase up
+./myrunstreak.sh db reset     # wipe local DB + re-apply all migrations (destructive, local only)
+supabase migration up --local # apply pending migrations without wiping
+```
+
+After a `db reset`, re-run the seed script above.
+
+> Prod migrations are **not** applied by these scripts — they ship via the
+> `.github/workflows/supabase-migrations.yml` workflow on merge to `main`.
+
+## Port convention (SB-113)
+
+Each silverbeer repo gets its own 100-port block so local stacks coexist:
+
+| Repo | API | DB | Studio |
+|------|-----|----|--------|
+| myrunstreak (this repo) | 54321 | 54322 | 54323 |
+| missing-table | 55321 | 55322 | 55323 |
+
+## See also
+
+- [README](../README.md) — Quick start
+- [docs/TESTING.md](TESTING.md) — running the test suites
+- [docs/SUPABASE_MIGRATION.md](SUPABASE_MIGRATION.md) — schema migration notes

--- a/scripts/seed_local_users.py
+++ b/scripts/seed_local_users.py
@@ -1,0 +1,191 @@
+"""Seed a clean set of LOCAL dev users for STK.
+
+Idempotent + local-only (refuses to run against anything but 127.0.0.1/localhost
+Supabase). Produces:
+
+    admin@test.local / admin123   -> admin role
+    coach@test.local / coach123   -> coach role, coaches both athletes below
+    a1@test.local    / a12345     -> athlete "Athlete One" (logs in as self)
+    a2@test.local    / a12345     -> athlete "Athlete Two" (logs in as self)
+
+Removes ad-hoc throwaway users (p42.*, coach.verify*). Leaves any other user
+(e.g. silverbeer.io@gmail.com from `jt sync-users`) untouched.
+
+Run:
+    eval "$(supabase status -o env | sed 's/^/export SB_/')"
+    SUPABASE_URL=$SB_API_URL SERVICE_KEY=$SB_SERVICE_ROLE_KEY \
+      uv run python scripts/seed_local_users.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+URL = os.environ.get("SUPABASE_URL", "http://127.0.0.1:54321").rstrip("/")
+KEY = os.environ.get("SERVICE_KEY") or os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
+
+if not any(h in URL for h in ("127.0.0.1", "localhost")):
+    sys.exit(f"REFUSING: SUPABASE_URL is not local ({URL}). This script is local-only.")
+if not KEY:
+    sys.exit("Missing SERVICE_KEY / SUPABASE_SERVICE_ROLE_KEY.")
+
+H = {"apikey": KEY, "Authorization": f"Bearer {KEY}", "Content-Type": "application/json"}
+
+
+def _req(method: str, path: str, body: dict | list | None = None, headers: dict | None = None):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        URL + path, data=data, method=method, headers={**H, **(headers or {})}
+    )
+    try:
+        with urllib.request.urlopen(req) as r:
+            raw = r.read()
+            return json.loads(raw) if raw else None
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"{method} {path} -> {e.code}: {e.read().decode()[:200]}") from e
+
+
+def list_auth_users() -> list[dict]:
+    out = _req("GET", "/auth/v1/admin/users?per_page=200")
+    return out.get("users", out) if isinstance(out, dict) else out
+
+
+def auth_by_email(email: str) -> dict | None:
+    return next((u for u in list_auth_users() if u.get("email") == email), None)
+
+
+def delete_auth_user(uid: str) -> None:
+    _req("DELETE", f"/auth/v1/admin/users/{uid}")
+
+
+def create_auth_user(email: str, password: str) -> str:
+    out = _req(
+        "POST",
+        "/auth/v1/admin/users",
+        {"email": email, "password": password, "email_confirm": True},
+    )
+    return out["id"]
+
+
+def set_password(uid: str, password: str) -> None:
+    _req("PUT", f"/auth/v1/admin/users/{uid}", {"password": password, "email_confirm": True})
+
+
+def rest(method: str, table: str, body=None, params: str = "", prefer: str = "") -> list:
+    headers = {"Prefer": prefer} if prefer else {}
+    out = _req(method, f"/rest/v1/{table}{params}", body, headers)
+    return out or []
+
+
+def main() -> None:
+    users = list_auth_users()
+
+    # 1. Purge ad-hoc throwaway users.
+    for u in users:
+        email = u["email"] or ""
+        if email.startswith("p42.") or email.startswith("coach.verify"):
+            delete_auth_user(u["id"])
+            print(f"deleted junk user {email}")
+
+    # 2. Ensure each target user: update-in-place if present (stable uid, just
+    # reset the password), else create. Clear any orphaned public.users rows
+    # sharing the email under a different uid (+ their roles), then upsert the
+    # users row keyed on the live auth uid.
+    def ensure_user(email: str, password: str) -> str:
+        au = auth_by_email(email)
+        if au:
+            uid = au["id"]
+            set_password(uid, password)
+        else:
+            uid = create_auth_user(email, password)
+        orphans = [
+            o["user_id"]
+            for o in rest(
+                "GET", "users", params=f"?email=eq.{email}&user_id=neq.{uid}&select=user_id"
+            )
+        ]
+        # Free the email off any orphan row so the live row can take it.
+        for oid in orphans:
+            rest("PATCH", "users", {"email": f"stale+{oid}@local"}, params=f"?user_id=eq.{oid}")
+        rest(
+            "POST", "users", {"user_id": uid, "email": email}, prefer="resolution=merge-duplicates"
+        )
+        # Now the live users row exists: repoint the orphan's deps onto it, then
+        # drop the orphan (athletes.created_by is NOT NULL, so it must move first).
+        for oid in orphans:
+            rest("PATCH", "athletes", {"created_by": uid}, params=f"?created_by=eq.{oid}")
+            rest("DELETE", "coach_athletes", params=f"?coach_id=eq.{oid}")
+            rest("DELETE", "user_roles", params=f"?user_id=eq.{oid}")
+            rest("DELETE", "users", params=f"?user_id=eq.{oid}")
+        print(f"user {email} -> {uid[:8]}")
+        return uid
+
+    admin_id = ensure_user("admin@test.local", "admin123")
+    coach_id = ensure_user("coach@test.local", "coach123")
+    a1_uid = ensure_user("a1@test.local", "a12345")
+    a2_uid = ensure_user("a2@test.local", "a12345")
+
+    # 3. Roles.
+    rest(
+        "POST",
+        "user_roles",
+        {"user_id": admin_id, "role": "admin"},
+        prefer="resolution=merge-duplicates",
+    )
+    rest(
+        "POST",
+        "user_roles",
+        {"user_id": coach_id, "role": "coach"},
+        prefer="resolution=merge-duplicates",
+    )
+
+    # 4. Athletes coached by coach@, each linked to its login user.
+    def ensure_athlete(display_name: str, linked_uid: str) -> None:
+        # Match by name only so a row left over from an earlier run gets reused
+        # (and re-pointed) rather than duplicated.
+        existing = rest(
+            "GET",
+            "athletes",
+            params=f"?display_name=eq.{display_name.replace(' ', '%20')}&select=id",
+        )
+        if existing:
+            aid = existing[0]["id"]
+        else:
+            aid = rest(
+                "POST",
+                "athletes",
+                {"created_by": coach_id, "display_name": display_name},
+                prefer="return=representation",
+            )[0]["id"]
+        rest(
+            "PATCH",
+            "athletes",
+            {"created_by": coach_id, "linked_user_id": linked_uid},
+            params=f"?id=eq.{aid}",
+        )
+        # active coaching link (idempotent-ish: only insert if absent)
+        link = rest(
+            "GET",
+            "coach_athletes",
+            params=f"?coach_id=eq.{coach_id}&athlete_id=eq.{aid}&status=eq.active&select=id",
+        )
+        if not link:
+            rest("POST", "coach_athletes", {"coach_id": coach_id, "athlete_id": aid})
+        print(f"athlete '{display_name}' -> {aid[:8]} linked {linked_uid[:8]}")
+
+    ensure_athlete("Athlete One", a1_uid)
+    ensure_athlete("Athlete Two", a2_uid)
+
+    print("\nseeded local users:")
+    print("  admin@test.local / admin123   (admin)")
+    print("  coach@test.local / coach123   (coach)")
+    print("  a1@test.local    / a12345     (Athlete One)")
+    print("  a2@test.local    / a12345     (Athlete Two)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What
A repeatable local-user seed + a proper local-dev guide, so the coach/athlete features work out of the box on a fresh local stack.

### `scripts/seed_local_users.py`
Idempotent, **local-only** (refuses any non-127.0.0.1/localhost Supabase URL). Seeds:

| Email | Password | Role |
|-------|----------|------|
| `admin@test.local` | `admin123` | admin |
| `coach@test.local` | `coach123` | coach (coaches both athletes) |
| `a1@test.local` | `a12345` | athlete "Athlete One" (linked login) |
| `a2@test.local` | `a12345` | athlete "Athlete Two" (linked login) |

Wires the coach↔athlete links + `linked_user_id` so the **Coach** tab, act-as, and athlete self-login all work immediately. Rerun after `db reset`; leaves `silverbeer.io@gmail.com` (jt-synced) untouched; purges ad-hoc throwaway users. (Athlete pw is `a12345` — Supabase hard-floors passwords at 6 chars.)

### Docs
- **`docs/LOCAL_DEV.md`** — full guide: prereqs, env files (incl. the **required `SUPABASE_KEY`** that was missing before → every DB route 500'd), start/stop, seeding, migrations, port convention.
- **README** — notes the `SUPABASE_KEY` requirement + links the seed step and the new guide.

Ruff clean (pre-commit passed).

Fixes SB-216
🤖 Generated with [Claude Code](https://claude.com/claude-code)