### PR TITLE
feat: athlete profile — fields + editing (Phase 1, SB-219)

### DIFF
--- a/backend/routes/athletes.py
+++ b/backend/routes/athletes.py
@@ -14,7 +14,14 @@ from backend.admin import is_admin, require_athlete_access, require_coach
 from backend.auth import authenticate_request
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, model_validator
-from src.shared.models import Athlete, AthleteCreate, CoachAthlete
+from src.shared.models import (
+    ATHLETE_EDITABLE_FIELDS,
+    Athlete,
+    AthleteCreate,
+    AthleteProfile,
+    AthleteProfileUpdate,
+    CoachAthlete,
+)
 from src.shared.supabase_client import get_supabase_client
 from src.shared.supabase_ops import (
     AthletesRepository,
@@ -22,6 +29,29 @@ from src.shared.supabase_ops import (
     UserRolesRepository,
     UsersRepository,
 )
+
+
+def _is_coach_view(user_id: UUID, athlete_id: UUID) -> bool:
+    """True if the caller edits/sees the athlete as a coach or admin (full
+    access), vs. as the linked athlete themselves (subset + redaction)."""
+    return is_admin(user_id) or CoachAthletesRepository(get_supabase_client()).active_link_exists(
+        user_id, athlete_id
+    )
+
+
+def _athlete_with_profile(
+    repo: AthletesRepository, row: dict[str, Any], *, coach_view: bool
+) -> Athlete:
+    """Attach the profile to an athlete row, redacting coach-private fields
+    (coaching_notes) when the caller is the linked athlete, not a coach."""
+    profile_row = repo.get_profile(UUID(row["id"]))
+    profile = None
+    if profile_row is not None:
+        if not coach_view:
+            profile_row = {**profile_row, "coaching_notes": None}
+        profile = AthleteProfile(**profile_row)
+    return Athlete(**row, profile=profile)
+
 
 router = APIRouter(prefix="/athletes", tags=["athletes"])
 me_router = APIRouter(prefix="/me", tags=["me"])
@@ -45,6 +75,18 @@ def my_roles(user_id: UUID = Depends(authenticate_request)) -> dict[str, Any]:
     """The caller's platform roles."""
     roles = UserRolesRepository(get_supabase_client()).list_roles(user_id)
     return {"roles": sorted(roles), "is_admin": "admin" in roles}
+
+
+@me_router.get("/athlete", response_model=Athlete | None)
+def my_athlete(user_id: UUID = Depends(authenticate_request)) -> Athlete | None:
+    """The athlete this user IS (via linked_user_id), with profile — or null.
+    Lets the athlete UI load 'my profile' without knowing its athlete id."""
+    repo = AthletesRepository(get_supabase_client())
+    row = repo.get_by_linked_user(user_id)
+    if row is None:
+        return None
+    # Linked-athlete view: coaching_notes redacted.
+    return _athlete_with_profile(repo, row, coach_view=False)
 
 
 @router.post("", response_model=Athlete, status_code=status.HTTP_201_CREATED)
@@ -80,9 +122,40 @@ def get_athlete(
     user_id: UUID = Depends(authenticate_request),
 ) -> Athlete:
     require_athlete_access(user_id, athlete_id)
-    row = AthletesRepository(get_supabase_client()).get(athlete_id)
+    repo = AthletesRepository(get_supabase_client())
+    row = repo.get(athlete_id)
     assert row is not None  # require_athlete_access already proved existence + access
-    return Athlete(**row)
+    return _athlete_with_profile(repo, row, coach_view=_is_coach_view(user_id, athlete_id))
+
+
+@router.patch("/{athlete_id}", response_model=Athlete)
+def update_athlete_profile(
+    athlete_id: UUID,
+    body: AthleteProfileUpdate,
+    user_id: UUID = Depends(authenticate_request),
+) -> Athlete:
+    """Patch an athlete's profile. Coach/admin may set any field; the linked
+    athlete may set only ATHLETE_EDITABLE_FIELDS. Fails closed (403) on any
+    disallowed key rather than silently dropping it."""
+    require_athlete_access(user_id, athlete_id)
+    coach_view = _is_coach_view(user_id, athlete_id)
+
+    fields = body.model_dump(exclude_unset=True)
+    if not fields:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "No fields to update")
+    if not coach_view:
+        disallowed = set(fields) - ATHLETE_EDITABLE_FIELDS
+        if disallowed:
+            raise HTTPException(
+                status.HTTP_403_FORBIDDEN,
+                f"Not allowed to edit: {', '.join(sorted(disallowed))}",
+            )
+
+    repo = AthletesRepository(get_supabase_client())
+    repo.upsert_profile(athlete_id, fields, updated_by=user_id)
+    row = repo.get(athlete_id)
+    assert row is not None
+    return _athlete_with_profile(repo, row, coach_view=coach_view)
 
 
 @router.post(

--- a/backend/routes/athletes.py
+++ b/backend/routes/athletes.py
@@ -15,6 +15,7 @@ from backend.auth import authenticate_request
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, model_validator
 from src.shared.models import (
+    ATHLETE_CORE_FIELDS,
     ATHLETE_EDITABLE_FIELDS,
     Athlete,
     AthleteCreate,
@@ -152,7 +153,13 @@ def update_athlete_profile(
             )
 
     repo = AthletesRepository(get_supabase_client())
-    repo.upsert_profile(athlete_id, fields, updated_by=user_id)
+    # display_name / birth_year live on the core athletes row; the rest on the
+    # profile. Split so each lands in the right table.
+    core = {k: fields.pop(k) for k in list(fields) if k in ATHLETE_CORE_FIELDS}
+    if core:
+        repo.update_core(athlete_id, core)
+    if fields:
+        repo.upsert_profile(athlete_id, fields, updated_by=user_id)
     row = repo.get(athlete_id)
     assert row is not None
     return _athlete_with_profile(repo, row, coach_view=coach_view)

--- a/backend/tests/test_athlete_profile.py
+++ b/backend/tests/test_athlete_profile.py
@@ -1,0 +1,146 @@
+"""SB-219: athlete profile — field-level edit permissions + read redaction."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+ATHLETE_ROW = {
+    "id": str(uuid4()),
+    "display_name": "Kid",
+    "birth_year": 2011,
+    "linked_user_id": str(uuid4()),
+    "created_by": str(uuid4()),
+    "notes": None,
+    "created_at": "2026-07-01T00:00:00+00:00",
+}
+PROFILE_ROW = {
+    "sport": "soccer",
+    "position": "midfield",
+    "bio": "hi",
+    "coaching_notes": "keep working on left foot",
+    "updated_at": "2026-07-02T00:00:00+00:00",
+}
+
+
+@contextmanager
+def _mock_athletes(*, coach: bool, repo: MagicMock):
+    """Patch the athletes-route deps. `coach` toggles the coach/admin view."""
+    coach_repo = MagicMock()
+    coach_repo.active_link_exists.return_value = coach
+    with (
+        patch("backend.routes.athletes.require_athlete_access", return_value=None),
+        patch("backend.routes.athletes.is_admin", return_value=False),
+        patch("backend.routes.athletes.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.athletes.CoachAthletesRepository", return_value=coach_repo),
+        patch("backend.routes.athletes.AthletesRepository", return_value=repo),
+    ):
+        yield
+
+
+def _repo() -> MagicMock:
+    r = MagicMock()
+    r.get.return_value = ATHLETE_ROW
+    r.get_profile.return_value = dict(PROFILE_ROW)
+    return r
+
+
+def test_coach_may_patch_any_field_including_coaching_notes() -> None:
+    from backend.routes.athletes import update_athlete_profile
+    from src.shared.models import AthleteProfileUpdate
+
+    repo = _repo()
+    with _mock_athletes(coach=True, repo=repo):
+        out = update_athlete_profile(
+            uuid4(),
+            AthleteProfileUpdate(sport="soccer", coaching_notes="focus left foot"),
+            user_id=uuid4(),
+        )
+    repo.upsert_profile.assert_called_once()
+    sent = repo.upsert_profile.call_args.args[1]
+    assert sent == {"sport": "soccer", "coaching_notes": "focus left foot"}
+    # coach view keeps coaching_notes visible
+    assert out.profile is not None and out.profile.coaching_notes == "keep working on left foot"
+
+
+def test_athlete_may_patch_own_fields() -> None:
+    from backend.routes.athletes import update_athlete_profile
+    from src.shared.models import AthleteProfileUpdate
+
+    repo = _repo()
+    with _mock_athletes(coach=False, repo=repo):
+        out = update_athlete_profile(
+            uuid4(), AthleteProfileUpdate(bio="I love soccer"), user_id=uuid4()
+        )
+    repo.upsert_profile.assert_called_once()
+    assert repo.upsert_profile.call_args.args[1] == {"bio": "I love soccer"}
+    # athlete view redacts coaching_notes
+    assert out.profile is not None and out.profile.coaching_notes is None
+
+
+def test_athlete_patching_disallowed_field_is_403() -> None:
+    from backend.routes.athletes import update_athlete_profile
+    from src.shared.models import AthleteProfileUpdate
+
+    repo = _repo()
+    with _mock_athletes(coach=False, repo=repo):
+        with pytest.raises(HTTPException) as exc:
+            update_athlete_profile(uuid4(), AthleteProfileUpdate(sport="soccer"), user_id=uuid4())
+    assert exc.value.status_code == 403
+    repo.upsert_profile.assert_not_called()
+
+
+def test_athlete_patching_coaching_notes_is_403() -> None:
+    from backend.routes.athletes import update_athlete_profile
+    from src.shared.models import AthleteProfileUpdate
+
+    repo = _repo()
+    with _mock_athletes(coach=False, repo=repo):
+        with pytest.raises(HTTPException) as exc:
+            update_athlete_profile(
+                uuid4(), AthleteProfileUpdate(coaching_notes="hi"), user_id=uuid4()
+            )
+    assert exc.value.status_code == 403
+
+
+def test_get_athlete_redacts_coaching_notes_for_athlete() -> None:
+    from backend.routes.athletes import get_athlete
+
+    repo = _repo()
+    with _mock_athletes(coach=False, repo=repo):
+        out = get_athlete(uuid4(), user_id=uuid4())
+    assert out.profile is not None and out.profile.coaching_notes is None
+    assert out.profile.sport == "soccer"  # non-private fields still present
+
+
+def test_get_athlete_shows_coaching_notes_for_coach() -> None:
+    from backend.routes.athletes import get_athlete
+
+    repo = _repo()
+    with _mock_athletes(coach=True, repo=repo):
+        out = get_athlete(uuid4(), user_id=uuid4())
+    assert out.profile is not None and out.profile.coaching_notes == "keep working on left foot"
+
+
+def test_my_athlete_returns_none_when_unlinked() -> None:
+    from backend.routes.athletes import my_athlete
+
+    repo = MagicMock()
+    repo.get_by_linked_user.return_value = None
+    with _mock_athletes(coach=False, repo=repo):
+        assert my_athlete(user_id=uuid4()) is None
+
+
+def test_my_athlete_returns_profile_redacted() -> None:
+    from backend.routes.athletes import my_athlete
+
+    repo = _repo()
+    repo.get_by_linked_user.return_value = ATHLETE_ROW
+    with _mock_athletes(coach=False, repo=repo):
+        out = my_athlete(user_id=uuid4())
+    assert out is not None
+    assert out.profile is not None and out.profile.coaching_notes is None

--- a/backend/tests/test_athlete_profile.py
+++ b/backend/tests/test_athlete_profile.py
@@ -82,6 +82,33 @@ def test_athlete_may_patch_own_fields() -> None:
     assert out.profile is not None and out.profile.coaching_notes is None
 
 
+def test_coach_may_rename_athlete_core_field() -> None:
+    from backend.routes.athletes import update_athlete_profile
+    from src.shared.models import AthleteProfileUpdate
+
+    repo = _repo()
+    with _mock_athletes(coach=True, repo=repo):
+        update_athlete_profile(uuid4(), AthleteProfileUpdate(display_name="Gabe"), user_id=uuid4())
+    # display_name is a core athletes-row field → update_core, not upsert_profile
+    repo.update_core.assert_called_once()
+    assert repo.update_core.call_args.args[1] == {"display_name": "Gabe"}
+    repo.upsert_profile.assert_not_called()
+
+
+def test_athlete_cannot_rename_is_403() -> None:
+    from backend.routes.athletes import update_athlete_profile
+    from src.shared.models import AthleteProfileUpdate
+
+    repo = _repo()
+    with _mock_athletes(coach=False, repo=repo):
+        with pytest.raises(HTTPException) as exc:
+            update_athlete_profile(
+                uuid4(), AthleteProfileUpdate(display_name="Hacker"), user_id=uuid4()
+            )
+    assert exc.value.status_code == 403
+    repo.update_core.assert_not_called()
+
+
 def test_athlete_patching_disallowed_field_is_403() -> None:
     from backend.routes.athletes import update_athlete_profile
     from src.shared.models import AthleteProfileUpdate

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -66,7 +66,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
-import { useRoles } from '@/composables/useCoach'
+import { useMyAthlete, useRoles } from '@/composables/useCoach'
 import BrandLogo from '@/components/BrandLogo.vue'
 import SyncButton from '@/components/SyncButton.vue'
 
@@ -75,17 +75,22 @@ const router = useRouter()
 const mobileMenuOpen = ref(false)
 
 const { isCoach, loadRoles } = useRoles()
+const { myAthlete, loadMyAthlete } = useMyAthlete()
 
-// Coach link only appears for coaches/admins (SB-189 P4-1).
+// Coach link → coaches/admins (SB-189 P4-1). My Profile → linked athletes (SB-219).
 const navLinks = computed(() => [
   { name: 'Dashboard', path: '/dashboard' },
   { name: 'Runs', path: '/runs' },
   ...(isCoach.value ? [{ name: 'Coach', path: '/coach' }] : []),
+  ...(myAthlete.value ? [{ name: 'My Profile', path: '/profile' }] : []),
   { name: 'Settings', path: '/settings' },
 ])
 
 onMounted(() => {
-  if (auth.isAuthenticated) loadRoles()
+  if (auth.isAuthenticated) {
+    loadRoles()
+    loadMyAthlete()
+  }
 })
 
 const handleSignOut = async () => {

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -63,7 +63,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useMyAthlete, useRoles } from '@/composables/useCoach'
@@ -86,12 +86,19 @@ const navLinks = computed(() => [
   { name: 'Settings', path: '/settings' },
 ])
 
-onMounted(() => {
-  if (auth.isAuthenticated) {
-    loadRoles()
-    loadMyAthlete()
-  }
-})
+// Refetch role/athlete gating whenever the logged-in user changes — not just
+// on mount — so an SPA login (no full page reload) reveals the Coach / My
+// Profile links immediately (force past the module-scoped cache).
+watch(
+  () => auth.user?.id,
+  (id) => {
+    if (id) {
+      loadRoles(true)
+      loadMyAthlete(true)
+    }
+  },
+  { immediate: true },
+)
 
 const handleSignOut = async () => {
   mobileMenuOpen.value = false

--- a/frontend/src/components/AthleteAccessPanel.vue
+++ b/frontend/src/components/AthleteAccessPanel.vue
@@ -1,0 +1,118 @@
+<template>
+  <div class="bg-white rounded-2xl border border-gray-100 shadow-sm p-6 space-y-6">
+    <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-400">Access</h2>
+
+    <!-- Invite the athlete to their own login (only if not linked yet) -->
+    <div v-if="!athlete.linked_user_id" class="space-y-2">
+      <p class="text-sm font-medium text-gray-700">Invite {{ athlete.display_name }} to log in</p>
+      <form class="flex flex-wrap items-center gap-2" @submit.prevent="doInvite">
+        <input
+          v-model="inviteEmail"
+          type="email"
+          required
+          placeholder="athlete's email"
+          class="form-input flex-1 min-w-48"
+        />
+        <button type="submit" :disabled="inviting" class="btn-primary text-sm">
+          {{ inviting ? 'Inviting…' : 'Invite athlete' }}
+        </button>
+      </form>
+      <div v-if="inviteLink" class="text-xs text-gray-600 bg-gray-50 border border-gray-200 rounded-lg p-3">
+        <p class="mb-1 font-medium text-gray-700">Send this link:</p>
+        <div class="flex items-center gap-2">
+          <code class="flex-1 break-all">{{ inviteLink }}</code>
+          <button type="button" class="btn-secondary text-xs" @click="copy(inviteLink)">
+            {{ copied ? 'Copied' : 'Copy' }}
+          </button>
+        </div>
+      </div>
+    </div>
+    <p v-else class="text-sm text-gray-500">
+      {{ athlete.display_name }} has their own login. ✓
+    </p>
+
+    <!-- Add an existing user as a coach -->
+    <div class="space-y-2 border-t border-gray-100 pt-5">
+      <p class="text-sm font-medium text-gray-700">Add a coach</p>
+      <form class="flex flex-wrap items-center gap-2" @submit.prevent="doAddCoach">
+        <input
+          v-model="coachEmail"
+          type="email"
+          required
+          placeholder="coach's email"
+          class="form-input flex-1 min-w-48"
+        />
+        <button type="submit" :disabled="addingCoach" class="btn-secondary text-sm">
+          {{ addingCoach ? 'Adding…' : 'Add coach' }}
+        </button>
+      </form>
+      <p class="text-xs text-gray-400">
+        The coach must already have an account — invite them with a coach role first
+        (<code>stk invite create --role coach</code>).
+      </p>
+    </div>
+
+    <div v-if="error" class="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-3 py-2">
+      {{ error }}
+    </div>
+    <div v-if="success" class="bg-green-50 border border-green-200 text-green-700 text-sm rounded-lg px-3 py-2">
+      {{ success }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { addCoachByEmail, inviteAthlete } from '@/composables/useCoach'
+import type { Athlete } from '@/types/coach'
+
+const props = defineProps<{ athlete: Athlete }>()
+
+const inviteEmail = ref('')
+const inviting = ref(false)
+const inviteLink = ref('')
+const copied = ref(false)
+
+const coachEmail = ref('')
+const addingCoach = ref(false)
+
+const error = ref<string | null>(null)
+const success = ref<string | null>(null)
+
+const copy = async (text: string) => {
+  await navigator.clipboard?.writeText(text)
+  copied.value = true
+  setTimeout(() => (copied.value = false), 2000)
+}
+
+const doInvite = async () => {
+  inviting.value = true
+  error.value = null
+  success.value = null
+  inviteLink.value = ''
+  try {
+    const { token } = await inviteAthlete(inviteEmail.value, props.athlete.id)
+    inviteLink.value = `${window.location.origin}/signup?invite=${token}`
+    success.value = 'Invite created — copy the link below.'
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to create invite'
+  } finally {
+    inviting.value = false
+  }
+}
+
+const doAddCoach = async () => {
+  addingCoach.value = true
+  error.value = null
+  success.value = null
+  try {
+    await addCoachByEmail(props.athlete.id, coachEmail.value)
+    success.value = `Added ${coachEmail.value} as a coach.`
+    coachEmail.value = ''
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to add coach'
+  } finally {
+    addingCoach.value = false
+  }
+}
+</script>

--- a/frontend/src/components/AthleteProfileForm.vue
+++ b/frontend/src/components/AthleteProfileForm.vue
@@ -1,5 +1,14 @@
 <template>
   <form class="space-y-6" @submit.prevent="submit">
+    <!-- Identity (coach only) -->
+    <fieldset v-if="mode === 'coach'" class="space-y-3">
+      <legend class="text-sm font-semibold text-gray-700 mb-1">Name</legend>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div><label class="form-label">Display name</label><input v-model="f.display_name" required class="form-input" /></div>
+        <div><label class="form-label">Birth year</label><input v-model.number="f.birth_year" type="number" class="form-input" /></div>
+      </div>
+    </fieldset>
+
     <!-- Sport (coach only) -->
     <fieldset v-if="mode === 'coach'" class="space-y-3">
       <legend class="text-sm font-semibold text-gray-700 mb-1">Sport</legend>
@@ -93,27 +102,33 @@ const ATHLETE_FIELDS = [
   'guardian_name', 'guardian_email', 'guardian_phone',
 ] as const
 const COACH_FIELDS = [
+  'display_name', 'birth_year',
   'sport', 'position', 'team', 'dominant_side', 'jersey_number',
   'height_cm', 'weight_kg', 'date_of_birth', 'sex',
   ...ATHLETE_FIELDS, 'coaching_notes',
 ] as const
 
 type FormValue = string | number | null
-type FormKey = keyof AthleteProfile
-const blank = (): Record<FormKey, FormValue> =>
-  ({
-    sport: null, position: null, team: null, dominant_side: null, jersey_number: null,
-    height_cm: null, weight_kg: null, date_of_birth: null, sex: null,
-    bio: null, personal_goals: null, athlete_email: null, athlete_phone: null,
-    guardian_name: null, guardian_email: null, guardian_phone: null,
-    coaching_notes: null, updated_at: null,
-  }) as Record<FormKey, FormValue>
+const blank = (): Record<string, FormValue> => ({
+  // core athletes-row fields
+  display_name: null, birth_year: null,
+  // profile fields
+  sport: null, position: null, team: null, dominant_side: null, jersey_number: null,
+  height_cm: null, weight_kg: null, date_of_birth: null, sex: null,
+  bio: null, personal_goals: null, athlete_email: null, athlete_phone: null,
+  guardian_name: null, guardian_email: null, guardian_phone: null,
+  coaching_notes: null, updated_at: null,
+})
 
 const f = reactive<Record<string, FormValue>>(blank())
 
 watch(
   () => props.athlete,
-  (a) => Object.assign(f, blank(), a.profile ?? {}),
+  (a) => {
+    Object.assign(f, blank(), a.profile ?? {})
+    f.display_name = a.display_name // core fields live on the athlete, not profile
+    f.birth_year = a.birth_year
+  },
   { immediate: true },
 )
 

--- a/frontend/src/components/AthleteProfileForm.vue
+++ b/frontend/src/components/AthleteProfileForm.vue
@@ -1,0 +1,145 @@
+<template>
+  <form class="space-y-6" @submit.prevent="submit">
+    <!-- Sport (coach only) -->
+    <fieldset v-if="mode === 'coach'" class="space-y-3">
+      <legend class="text-sm font-semibold text-gray-700 mb-1">Sport</legend>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div><label class="form-label">Sport</label><input v-model="f.sport" class="form-input" /></div>
+        <div><label class="form-label">Position</label><input v-model="f.position" class="form-input" /></div>
+        <div><label class="form-label">Team</label><input v-model="f.team" class="form-input" /></div>
+        <div>
+          <label class="form-label">Dominant side</label>
+          <select v-model="f.dominant_side" class="form-input">
+            <option :value="null">—</option>
+            <option value="left">Left</option>
+            <option value="right">Right</option>
+            <option value="both">Both</option>
+          </select>
+        </div>
+        <div><label class="form-label">Jersey #</label><input v-model="f.jersey_number" class="form-input" /></div>
+      </div>
+    </fieldset>
+
+    <!-- Physical (coach only) -->
+    <fieldset v-if="mode === 'coach'" class="space-y-3">
+      <legend class="text-sm font-semibold text-gray-700 mb-1">Physical</legend>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div><label class="form-label">Height (cm)</label><input v-model.number="f.height_cm" type="number" class="form-input" /></div>
+        <div><label class="form-label">Weight (kg)</label><input v-model.number="f.weight_kg" type="number" class="form-input" /></div>
+        <div><label class="form-label">Date of birth</label><input v-model="f.date_of_birth" type="date" class="form-input" /></div>
+        <div>
+          <label class="form-label">Sex</label>
+          <select v-model="f.sex" class="form-input">
+            <option :value="null">—</option>
+            <option value="male">Male</option>
+            <option value="female">Female</option>
+            <option value="other">Other</option>
+          </select>
+        </div>
+      </div>
+    </fieldset>
+
+    <!-- About (athlete-editable) -->
+    <fieldset class="space-y-3">
+      <legend class="text-sm font-semibold text-gray-700 mb-1">About</legend>
+      <div><label class="form-label">Bio</label><textarea v-model="f.bio" rows="3" class="form-input" /></div>
+      <div><label class="form-label">Personal goals</label><textarea v-model="f.personal_goals" rows="2" class="form-input" /></div>
+    </fieldset>
+
+    <!-- Contact & guardian (athlete-editable) -->
+    <fieldset class="space-y-3">
+      <legend class="text-sm font-semibold text-gray-700 mb-1">Contact &amp; guardian</legend>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div><label class="form-label">Email</label><input v-model="f.athlete_email" type="email" class="form-input" /></div>
+        <div><label class="form-label">Phone</label><input v-model="f.athlete_phone" class="form-input" /></div>
+        <div><label class="form-label">Guardian name</label><input v-model="f.guardian_name" class="form-input" /></div>
+        <div><label class="form-label">Guardian email</label><input v-model="f.guardian_email" type="email" class="form-input" /></div>
+        <div><label class="form-label">Guardian phone</label><input v-model="f.guardian_phone" class="form-input" /></div>
+      </div>
+    </fieldset>
+
+    <!-- Coaching notes (coach only, private) -->
+    <fieldset v-if="mode === 'coach'" class="space-y-3">
+      <legend class="text-sm font-semibold text-gray-700 mb-1">
+        Coaching notes <span class="font-normal text-gray-400">· private (athlete can't see)</span>
+      </legend>
+      <textarea v-model="f.coaching_notes" rows="3" class="form-input" />
+    </fieldset>
+
+    <div v-if="error" class="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-3 py-2">
+      {{ error }}
+    </div>
+    <div v-if="saved" class="bg-green-50 border border-green-200 text-green-700 text-sm rounded-lg px-3 py-2">
+      Saved.
+    </div>
+
+    <button type="submit" :disabled="saving" class="btn-primary text-sm">
+      {{ saving ? 'Saving…' : 'Save profile' }}
+    </button>
+  </form>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref, watch } from 'vue'
+import { updateAthleteProfile } from '@/composables/useCoach'
+import type { Athlete, AthleteProfile, AthleteProfileUpdate } from '@/types/coach'
+
+const props = defineProps<{ athlete: Athlete; mode: 'coach' | 'athlete' }>()
+const emit = defineEmits<{ saved: [Athlete] }>()
+
+// Which keys each mode may send (mirrors the server allowlist).
+const ATHLETE_FIELDS = [
+  'bio', 'personal_goals', 'athlete_email', 'athlete_phone',
+  'guardian_name', 'guardian_email', 'guardian_phone',
+] as const
+const COACH_FIELDS = [
+  'sport', 'position', 'team', 'dominant_side', 'jersey_number',
+  'height_cm', 'weight_kg', 'date_of_birth', 'sex',
+  ...ATHLETE_FIELDS, 'coaching_notes',
+] as const
+
+type FormValue = string | number | null
+type FormKey = keyof AthleteProfile
+const blank = (): Record<FormKey, FormValue> =>
+  ({
+    sport: null, position: null, team: null, dominant_side: null, jersey_number: null,
+    height_cm: null, weight_kg: null, date_of_birth: null, sex: null,
+    bio: null, personal_goals: null, athlete_email: null, athlete_phone: null,
+    guardian_name: null, guardian_email: null, guardian_phone: null,
+    coaching_notes: null, updated_at: null,
+  }) as Record<FormKey, FormValue>
+
+const f = reactive<Record<string, FormValue>>(blank())
+
+watch(
+  () => props.athlete,
+  (a) => Object.assign(f, blank(), a.profile ?? {}),
+  { immediate: true },
+)
+
+const saving = ref(false)
+const saved = ref(false)
+const error = ref<string | null>(null)
+
+const submit = async () => {
+  saving.value = true
+  saved.value = false
+  error.value = null
+  const keys = props.mode === 'coach' ? COACH_FIELDS : ATHLETE_FIELDS
+  const patch: AthleteProfileUpdate = {}
+  for (const k of keys) {
+    const v = f[k]
+    ;(patch as Record<string, unknown>)[k] = v === '' ? null : v
+  }
+  try {
+    const updated = await updateAthleteProfile(props.athlete.id, patch)
+    emit('saved', updated)
+    saved.value = true
+    setTimeout(() => (saved.value = false), 2500)
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to save'
+  } finally {
+    saving.value = false
+  }
+}
+</script>

--- a/frontend/src/composables/useCoach.ts
+++ b/frontend/src/composables/useCoach.ts
@@ -62,6 +62,24 @@ export function useMyAthlete() {
   return { myAthlete, loadMyAthlete }
 }
 
+/** Invite a person to onboard as this athlete (linked on redeem). Returns the
+ *  invite incl. token; the caller builds the /signup?invite=<token> link. */
+export async function inviteAthlete(email: string, athleteId: string): Promise<{ token: string }> {
+  return apiCall<{ token: string }>('/invites', {
+    method: 'POST',
+    body: JSON.stringify({ email, athlete_id: athleteId }),
+  })
+}
+
+/** Add an existing user (by email) as a coach of the athlete. 404 if the email
+ *  isn't a user yet (invite them as a coach first). */
+export async function addCoachByEmail(athleteId: string, email: string): Promise<void> {
+  await apiCall(`/athletes/${athleteId}/coaches`, {
+    method: 'POST',
+    body: JSON.stringify({ coach_email: email }),
+  })
+}
+
 export function useCoach() {
   const athletes = ref<Athlete[]>([])
   const loading = ref(false)

--- a/frontend/src/composables/useCoach.ts
+++ b/frontend/src/composables/useCoach.ts
@@ -1,6 +1,12 @@
 import { computed, ref } from 'vue'
 import { apiCall } from '@/config/api'
-import type { Athlete, AthleteCreate, MyRoles, WorkoutSession } from '@/types/coach'
+import type {
+  Athlete,
+  AthleteCreate,
+  AthleteProfileUpdate,
+  MyRoles,
+  WorkoutSession,
+} from '@/types/coach'
 
 // Roles are shared app-wide (the nav gates the Coach link on them), so cache
 // them in module scope — one fetch feeds AppHeader and every coach view.
@@ -24,6 +30,37 @@ async function loadRoles(force = false): Promise<void> {
 
 /** Header that makes an authenticated call act on an athlete's behalf. */
 const actAs = (athleteId: string) => ({ 'X-Act-As-Athlete': athleteId })
+
+// The athlete the logged-in user IS (via linked_user_id), or null. Shared
+// app-wide so the nav can gate a "My Profile" link on it.
+const myAthlete = ref<Athlete | null>(null)
+const myAthleteLoaded = ref(false)
+
+async function loadMyAthlete(force = false): Promise<void> {
+  if (myAthleteLoaded.value && !force) return
+  try {
+    myAthlete.value = await apiCall<Athlete | null>('/me/athlete')
+  } catch {
+    myAthlete.value = null
+  } finally {
+    myAthleteLoaded.value = true
+  }
+}
+
+/** PATCH an athlete's profile. Server enforces field-level permissions. */
+export async function updateAthleteProfile(
+  athleteId: string,
+  patch: AthleteProfileUpdate,
+): Promise<Athlete> {
+  return apiCall<Athlete>(`/athletes/${athleteId}`, {
+    method: 'PATCH',
+    body: JSON.stringify(patch),
+  })
+}
+
+export function useMyAthlete() {
+  return { myAthlete, loadMyAthlete }
+}
 
 export function useCoach() {
   const athletes = ref<Athlete[]>([])

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -60,6 +60,12 @@ const router = createRouter({
       component: () => import('@/views/AthleteDetailView.vue'),
       meta: { requiresAuth: true },
     },
+    {
+      path: '/profile',
+      name: 'my-profile',
+      component: () => import('@/views/MyProfileView.vue'),
+      meta: { requiresAuth: true },
+    },
   ],
   scrollBehavior(_to, _from, savedPosition) {
     return savedPosition ?? { top: 0 }

--- a/frontend/src/types/coach.ts
+++ b/frontend/src/types/coach.ts
@@ -3,6 +3,41 @@ export interface MyRoles {
   is_admin: boolean
 }
 
+export interface AthleteProfile {
+  sport: string | null
+  position: string | null
+  team: string | null
+  dominant_side: string | null
+  jersey_number: string | null
+  height_cm: number | null
+  weight_kg: number | null
+  date_of_birth: string | null
+  sex: string | null
+  bio: string | null
+  personal_goals: string | null
+  athlete_email: string | null
+  athlete_phone: string | null
+  guardian_name: string | null
+  guardian_email: string | null
+  guardian_phone: string | null
+  coaching_notes: string | null
+  updated_at: string | null
+}
+
+// Partial patch. Server enforces which keys the caller (coach vs athlete) may set.
+export type AthleteProfileUpdate = Partial<Omit<AthleteProfile, 'updated_at'>>
+
+// Fields the linked athlete may edit (mirrors backend ATHLETE_EDITABLE_FIELDS).
+export const ATHLETE_EDITABLE_FIELDS = [
+  'bio',
+  'personal_goals',
+  'athlete_email',
+  'athlete_phone',
+  'guardian_name',
+  'guardian_email',
+  'guardian_phone',
+] as const
+
 export interface Athlete {
   id: string
   display_name: string
@@ -11,6 +46,7 @@ export interface Athlete {
   created_by: string | null
   notes: string | null
   created_at: string
+  profile?: AthleteProfile | null
 }
 
 export interface AthleteCreate {

--- a/frontend/src/views/AthleteDetailView.vue
+++ b/frontend/src/views/AthleteDetailView.vue
@@ -19,6 +19,13 @@
           <span v-if="athlete.linked_user_id" class="text-brand-600"> · has own login</span>
         </p>
         <p v-if="athlete.notes" class="text-sm text-gray-600 mt-2">{{ athlete.notes }}</p>
+        <button class="btn-secondary text-sm mt-3" @click="editing = !editing">
+          {{ editing ? 'Cancel' : 'Edit profile' }}
+        </button>
+      </div>
+
+      <div v-if="editing" class="bg-white rounded-2xl border border-gray-100 shadow-sm p-6 mb-6">
+        <AthleteProfileForm :athlete="athlete" mode="coach" @saved="onSaved" />
       </div>
 
       <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-2">
@@ -51,12 +58,20 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { onMounted, ref } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
 import { useAthleteDetail } from '@/composables/useCoach'
+import AthleteProfileForm from '@/components/AthleteProfileForm.vue'
+import type { Athlete } from '@/types/coach'
 
 const route = useRoute()
 const { athlete, sessions, loading, error, load } = useAthleteDetail(route.params.athleteId as string)
+
+const editing = ref(false)
+const onSaved = (updated: Athlete) => {
+  athlete.value = updated
+  editing.value = false
+}
 
 onMounted(load)
 </script>

--- a/frontend/src/views/AthleteDetailView.vue
+++ b/frontend/src/views/AthleteDetailView.vue
@@ -28,6 +28,8 @@
         <AthleteProfileForm :athlete="athlete" mode="coach" @saved="onSaved" />
       </div>
 
+      <AthleteAccessPanel :athlete="athlete" class="mb-6" />
+
       <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-2">
         Recent sessions ({{ sessions.length }})
       </h2>
@@ -62,6 +64,7 @@ import { onMounted, ref } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
 import { useAthleteDetail } from '@/composables/useCoach'
 import AthleteProfileForm from '@/components/AthleteProfileForm.vue'
+import AthleteAccessPanel from '@/components/AthleteAccessPanel.vue'
 import type { Athlete } from '@/types/coach'
 
 const route = useRoute()

--- a/frontend/src/views/MyProfileView.vue
+++ b/frontend/src/views/MyProfileView.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="container-app py-8 max-w-2xl">
+    <h1 class="text-2xl font-bold text-gray-900 mb-1">My profile</h1>
+    <p class="text-sm text-gray-500 mb-6">Update your bio, goals, and contact details.</p>
+
+    <div v-if="loading" class="space-y-3">
+      <div v-for="i in 4" :key="i" class="h-10 bg-white rounded-lg border border-gray-100 animate-pulse" />
+    </div>
+
+    <div
+      v-else-if="!myAthlete"
+      class="bg-white rounded-xl border border-gray-100 shadow-sm p-8 text-center text-gray-500"
+    >
+      <p>No athlete profile is linked to your account.</p>
+    </div>
+
+    <div v-else class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6">
+      <p class="text-lg font-semibold text-gray-900 mb-4">{{ myAthlete.display_name }}</p>
+      <AthleteProfileForm :athlete="myAthlete" mode="athlete" @saved="onSaved" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useMyAthlete } from '@/composables/useCoach'
+import AthleteProfileForm from '@/components/AthleteProfileForm.vue'
+import type { Athlete } from '@/types/coach'
+
+const router = useRouter()
+const { myAthlete, loadMyAthlete } = useMyAthlete()
+const loading = ref(true)
+
+const onSaved = (updated: Athlete) => {
+  myAthlete.value = updated
+}
+
+onMounted(async () => {
+  await loadMyAthlete(true)
+  loading.value = false
+  // Not a linked athlete → nothing to edit here.
+  if (!myAthlete.value) router.replace('/dashboard')
+})
+</script>

--- a/src/shared/models/__init__.py
+++ b/src/shared/models/__init__.py
@@ -1,7 +1,16 @@
 """Data models for MyRunStreak.com."""
 
 from .activity import Activity
-from .athlete import Athlete, AthleteCreate, CoachAthlete, CoachAthleteStatus, Role
+from .athlete import (
+    ATHLETE_EDITABLE_FIELDS,
+    Athlete,
+    AthleteCreate,
+    AthleteProfile,
+    AthleteProfileUpdate,
+    CoachAthlete,
+    CoachAthleteStatus,
+    Role,
+)
 from .enums import (
     ActivityType,
     DeviceType,
@@ -68,8 +77,11 @@ __all__ = [
     "Goal",
     "Split",
     # Coach platform (SB-195)
+    "ATHLETE_EDITABLE_FIELDS",
     "Athlete",
     "AthleteCreate",
+    "AthleteProfile",
+    "AthleteProfileUpdate",
     "CoachAthlete",
     "CoachAthleteStatus",
     "Role",

--- a/src/shared/models/__init__.py
+++ b/src/shared/models/__init__.py
@@ -2,6 +2,7 @@
 
 from .activity import Activity
 from .athlete import (
+    ATHLETE_CORE_FIELDS,
     ATHLETE_EDITABLE_FIELDS,
     Athlete,
     AthleteCreate,
@@ -77,6 +78,7 @@ __all__ = [
     "Goal",
     "Split",
     # Coach platform (SB-195)
+    "ATHLETE_CORE_FIELDS",
     "ATHLETE_EDITABLE_FIELDS",
     "Athlete",
     "AthleteCreate",

--- a/src/shared/models/athlete.py
+++ b/src/shared/models/athlete.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from enum import StrEnum
 from uuid import UUID
 
@@ -35,6 +35,73 @@ class Athlete(BaseModel):
     created_by: UUID | None = None
     notes: str | None = None
     created_at: datetime
+    profile: AthleteProfile | None = None
+
+
+# Fields the linked athlete may edit on their own profile. The coach/admin may
+# edit every profile field (incl. coaching_notes + sport/physical). Enforced
+# server-side because the backend uses the service-role key (bypasses RLS).
+ATHLETE_EDITABLE_FIELDS: frozenset[str] = frozenset(
+    {
+        "bio",
+        "personal_goals",
+        "athlete_email",
+        "athlete_phone",
+        "guardian_name",
+        "guardian_email",
+        "guardian_phone",
+    }
+)
+# coaching_notes is coach-private: redacted from the linked-athlete read path.
+COACH_PRIVATE_FIELDS: frozenset[str] = frozenset({"coaching_notes"})
+
+
+class AthleteProfile(BaseModel):
+    """The 1:1 rich profile for an athlete (read model)."""
+
+    sport: str | None = None
+    position: str | None = None
+    team: str | None = None
+    dominant_side: str | None = None
+    jersey_number: str | None = None
+    height_cm: float | None = None
+    weight_kg: float | None = None
+    date_of_birth: date | None = None
+    sex: str | None = None
+    bio: str | None = None
+    personal_goals: str | None = None
+    athlete_email: str | None = None
+    athlete_phone: str | None = None
+    guardian_name: str | None = None
+    guardian_email: str | None = None
+    guardian_phone: str | None = None
+    coaching_notes: str | None = None
+    updated_at: datetime | None = None
+
+
+class AthleteProfileUpdate(BaseModel):
+    """Partial profile update. All optional; only set keys are applied, and the
+    caller's role decides which keys are allowed (see ATHLETE_EDITABLE_FIELDS)."""
+
+    model_config = {"extra": "forbid"}
+
+    sport: str | None = None
+    position: str | None = None
+    team: str | None = None
+    dominant_side: str | None = Field(default=None, pattern="^(left|right|both)$")
+    jersey_number: str | None = None
+    height_cm: float | None = Field(default=None, gt=0, le=300)
+    weight_kg: float | None = Field(default=None, gt=0, le=500)
+    date_of_birth: date | None = None
+    sex: str | None = Field(default=None, pattern="^(male|female|other)$")
+    bio: str | None = None
+    personal_goals: str | None = None
+    athlete_email: str | None = None
+    athlete_phone: str | None = None
+    guardian_name: str | None = None
+    guardian_email: str | None = None
+    guardian_phone: str | None = None
+    coaching_notes: str | None = None
 
 
 class CoachAthlete(BaseModel):
@@ -45,3 +112,7 @@ class CoachAthlete(BaseModel):
     started_at: datetime
     ended_at: datetime | None = None
     created_at: datetime
+
+
+# Resolve the forward reference to AthleteProfile on Athlete.profile.
+Athlete.model_rebuild()

--- a/src/shared/models/athlete.py
+++ b/src/shared/models/athlete.py
@@ -55,6 +55,9 @@ ATHLETE_EDITABLE_FIELDS: frozenset[str] = frozenset(
 # coaching_notes is coach-private: redacted from the linked-athlete read path.
 COACH_PRIVATE_FIELDS: frozenset[str] = frozenset({"coaching_notes"})
 
+# Fields that live on the core `athletes` row (not athlete_profiles). Coach-only.
+ATHLETE_CORE_FIELDS: frozenset[str] = frozenset({"display_name", "birth_year"})
+
 
 class AthleteProfile(BaseModel):
     """The 1:1 rich profile for an athlete (read model)."""
@@ -81,10 +84,15 @@ class AthleteProfile(BaseModel):
 
 class AthleteProfileUpdate(BaseModel):
     """Partial profile update. All optional; only set keys are applied, and the
-    caller's role decides which keys are allowed (see ATHLETE_EDITABLE_FIELDS)."""
+    caller's role decides which keys are allowed (see ATHLETE_EDITABLE_FIELDS).
+
+    display_name / birth_year live on the core `athletes` row (coach-only); the
+    rest live on athlete_profiles. The route splits them on write."""
 
     model_config = {"extra": "forbid"}
 
+    display_name: str | None = Field(default=None, min_length=1)
+    birth_year: int | None = Field(default=None, ge=1900, le=2100)
     sport: str | None = None
     position: str | None = None
     team: str | None = None

--- a/src/shared/supabase_ops/athletes_repository.py
+++ b/src/shared/supabase_ops/athletes_repository.py
@@ -107,6 +107,10 @@ class AthletesRepository:
             ).execute()
         return cast(list[dict[str, Any]], result.data)[0]
 
+    def update_core(self, athlete_id: UUID, fields: dict[str, Any]) -> None:
+        """Update core columns on the athletes row (display_name, birth_year)."""
+        self.supabase.table("athletes").update(fields).eq("id", str(athlete_id)).execute()
+
     def link_user(self, athlete_id: UUID, user_id: UUID) -> dict[str, Any]:
         """Link a logged-in user to this athlete (athletes.linked_user_id).
 

--- a/src/shared/supabase_ops/athletes_repository.py
+++ b/src/shared/supabase_ops/athletes_repository.py
@@ -61,6 +61,52 @@ class AthletesRepository:
         data = cast(list[dict[str, Any]], result.data)
         return data[0] if data else None
 
+    def get_by_linked_user(self, user_id: UUID) -> dict[str, Any] | None:
+        """The athlete this user IS (via linked_user_id), or None."""
+        result = (
+            self.supabase.table("athletes")
+            .select("*")
+            .eq("linked_user_id", str(user_id))
+            .limit(1)
+            .execute()
+        )
+        data = cast(list[dict[str, Any]], result.data)
+        return data[0] if data else None
+
+    def get_profile(self, athlete_id: UUID) -> dict[str, Any] | None:
+        """The 1:1 athlete_profiles row, or None if not created yet."""
+        result = (
+            self.supabase.table("athlete_profiles")
+            .select("*")
+            .eq("athlete_id", str(athlete_id))
+            .execute()
+        )
+        data = cast(list[dict[str, Any]], result.data)
+        return data[0] if data else None
+
+    def upsert_profile(
+        self, athlete_id: UUID, fields: dict[str, Any], updated_by: UUID
+    ) -> dict[str, Any]:
+        """Create/patch the profile with the given fields (already permission-
+        filtered by the caller). Keeps athletes.birth_year in sync with DOB."""
+        row = {
+            "athlete_id": str(athlete_id),
+            "updated_by": str(updated_by),
+            "updated_at": datetime.now(UTC).isoformat(),
+            **fields,
+        }
+        result = (
+            self.supabase.table("athlete_profiles").upsert(row, on_conflict="athlete_id").execute()
+        )
+        # Derive birth_year from DOB so the lean athletes row stays consistent.
+        dob = fields.get("date_of_birth")
+        if dob:
+            year = int(str(dob)[:4])
+            self.supabase.table("athletes").update({"birth_year": year}).eq(
+                "id", str(athlete_id)
+            ).execute()
+        return cast(list[dict[str, Any]], result.data)[0]
+
     def link_user(self, athlete_id: UUID, user_id: UUID) -> dict[str, Any]:
         """Link a logged-in user to this athlete (athletes.linked_user_id).
 

--- a/stk/src/cli/commands/invite.py
+++ b/stk/src/cli/commands/invite.py
@@ -17,11 +17,19 @@ def create(
     email: str = typer.Option(..., "--email", "-e", help="Who the invite is for"),
     days: int = typer.Option(14, "--days", "-d", help="Days until the token expires"),
     role: str = typer.Option(None, "--role", "-r", help="Role to grant on redeem (e.g. coach)"),
+    athlete: str = typer.Option(
+        None, "--athlete", "-a", help="Athlete id to link the invitee to (onboard an athlete)"
+    ),
 ) -> None:
-    """Issue an invite. Prints a redeem link to text the invitee."""
+    """Issue an invite. Prints a redeem link to text the invitee.
+
+    Use --role coach to onboard a coach, or --athlete <id> to onboard an athlete
+    (the invitee is linked to that athlete profile on redeem)."""
     body: dict[str, object] = {"email": email, "expires_in_days": days}
     if role is not None:
         body["grant_role"] = role
+    if athlete is not None:
+        body["athlete_id"] = athlete
     result = api.post_request("invites", body)
     link = f"https://myrunstreak.run/signup?invite={result['token']}"
     role_note = f" as [bold]{result['grant_role']}[/bold]" if result.get("grant_role") else ""

--- a/supabase/migrations/20260702000000_athlete_profile.sql
+++ b/supabase/migrations/20260702000000_athlete_profile.sql
@@ -1,0 +1,60 @@
+-- =====================================================
+-- Athlete profile (SB-219, SB-189 Phase 1). A 1:1 companion to `athletes`
+-- holding the rich profile. Kept separate so the lean `athletes` identity row
+-- (loaded in roster/coach-link hot paths) stays small, and so a minor's PII +
+-- the coach-private `coaching_notes` are isolated for RLS/redaction.
+--
+-- Field ownership is enforced in the backend (service-role bypasses RLS): the
+-- coach owns everything; the linked athlete may edit only a subset and never
+-- sees `coaching_notes`. These policies are the second line of defence for
+-- direct anon-key access, mirroring the `athletes` policies.
+-- =====================================================
+CREATE TABLE athlete_profiles (
+    athlete_id UUID PRIMARY KEY REFERENCES athletes(id) ON DELETE CASCADE,
+    -- sport
+    sport TEXT,
+    position TEXT,
+    team TEXT,
+    dominant_side TEXT CHECK (dominant_side IN ('left', 'right', 'both')),
+    jersey_number TEXT,
+    -- physical
+    height_cm NUMERIC,
+    weight_kg NUMERIC,
+    date_of_birth DATE,
+    sex TEXT CHECK (sex IN ('male', 'female', 'other')),
+    -- athlete-owned free text
+    bio TEXT,
+    personal_goals TEXT,
+    -- contact / guardian (athlete is typically a minor)
+    athlete_email TEXT,
+    athlete_phone TEXT,
+    guardian_name TEXT,
+    guardian_email TEXT,
+    guardian_phone TEXT,
+    -- coach-private (never returned to the linked athlete)
+    coaching_notes TEXT,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_by UUID REFERENCES users(user_id) ON DELETE SET NULL
+);
+
+COMMENT ON COLUMN athlete_profiles.coaching_notes IS
+    'Coach-private; redacted from the linked-athlete read path (SB-219)';
+
+-- True if the caller is the athlete (linked user) or an active coach of them.
+-- Reused by the profile RLS below.
+CREATE FUNCTION can_access_athlete_row(aid UUID) RETURNS BOOLEAN
+LANGUAGE sql STABLE AS $$
+    SELECT EXISTS (SELECT 1 FROM athletes WHERE id = aid AND linked_user_id = auth.uid())
+        OR EXISTS (
+            SELECT 1 FROM coach_athletes
+            WHERE athlete_id = aid AND coach_id = auth.uid() AND status = 'active'
+        );
+$$;
+
+ALTER TABLE athlete_profiles ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "athlete_profiles select" ON athlete_profiles FOR SELECT
+    USING (can_access_athlete_row(athlete_id));
+CREATE POLICY "athlete_profiles insert" ON athlete_profiles FOR INSERT
+    WITH CHECK (can_access_athlete_row(athlete_id));
+CREATE POLICY "athlete_profiles update" ON athlete_profiles FOR UPDATE
+    USING (can_access_athlete_row(athlete_id));


### PR DESCRIPTION
Phase 1 of the Athlete Profile feature (parent SB-189). Coach owns a rich profile; the linked athlete logs in and edits a subset. **Photos are Phase 2** (Supabase Storage).

## Backend
- **Migration** `20260702000000_athlete_profile.sql`: 1:1 `athlete_profiles` (sport/position/team/dominant_side/jersey, height/weight/DOB/sex, bio/goals, athlete+guardian contact, coach-private `coaching_notes`) + RLS mirroring `athletes`.
- `AthleteProfile`/`AthleteProfileUpdate` models; repo `get_by_linked_user`/`get_profile`/`upsert_profile` (keeps `athletes.birth_year` in sync with DOB).
- `GET /me/athlete` (self lookup); `PATCH /athletes/{id}` with a **role-resolved field allowlist** — coach/admin set anything, linked athlete sets only bio/goals/contact, **403 fail-closed** on disallowed keys; `GET /athletes/{id}` returns the profile, **redacting `coaching_notes`** for the linked-athlete caller.
- 8 tests (`test_athlete_profile.py`): coach-all, athlete-subset, 403s, read redaction, `/me/athlete` null/found.

## Frontend
- Shared role-aware `AthleteProfileForm` (`mode: coach | athlete`).
- Coach edits from `AthleteDetailView`; athlete self-edits at **`/profile`** (`MyProfileView`, loads `/me/athlete`, redirects if not linked); **"My Profile"** nav link gated on being a linked athlete.

## Verification
Backend suite 182 pass. Frontend typecheck + build clean. **Live E2E on local**: coach PATCH sport+coaching_notes → 200; athlete `/me/athlete` shows sport, `coaching_notes` null; athlete PATCH sport → 403; PATCH bio → 200.

Fixes SB-219
🤖 Generated with [Claude Code](https://claude.com/claude-code)