### PR TITLE
feat: Personal Bests card on the dashboard (SB-221)

### DIFF
--- a/frontend/src/components/PersonalBestsCard.vue
+++ b/frontend/src/components/PersonalBestsCard.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6">
+    <div class="flex items-center gap-2 mb-4">
+      <Trophy class="w-4 h-4 text-gray-700" />
+      <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-700">Personal bests</h3>
+    </div>
+
+    <div v-if="!hasAny" class="text-sm text-gray-500">No records yet — sync some runs.</div>
+
+    <div v-else class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <div v-if="records?.longest_run" class="rounded-xl bg-gray-50 border border-gray-100 p-4">
+        <div class="flex items-center gap-1.5 text-xs font-medium text-gray-500">
+          <Route class="w-3.5 h-3.5" /> Longest run
+        </div>
+        <p class="text-2xl font-bold text-gray-900 mt-1 tabular-nums">
+          {{ formatDistanceWithUnit(records.longest_run.distance_km, unit, 1) }}
+        </p>
+        <p class="text-xs text-gray-400 mt-0.5">{{ fmtDate(records.longest_run.date) }}</p>
+      </div>
+
+      <div v-if="records?.fastest_pace" class="rounded-xl bg-gray-50 border border-gray-100 p-4">
+        <div class="flex items-center gap-1.5 text-xs font-medium text-gray-500">
+          <Timer class="w-3.5 h-3.5" /> Fastest pace
+        </div>
+        <p class="text-2xl font-bold text-gray-900 mt-1 tabular-nums">
+          {{ formatPace(records.fastest_pace.pace_min_per_km, unit) }}
+        </p>
+        <p class="text-xs text-gray-400 mt-0.5">
+          {{ formatDistanceWithUnit(records.fastest_pace.distance_km, unit, 1) }} ·
+          {{ fmtDate(records.fastest_pace.date) }}
+        </p>
+      </div>
+
+      <div v-if="records?.most_km_month" class="rounded-xl bg-gray-50 border border-gray-100 p-4">
+        <div class="flex items-center gap-1.5 text-xs font-medium text-gray-500">
+          <CalendarDays class="w-3.5 h-3.5" /> Biggest month
+        </div>
+        <p class="text-2xl font-bold text-gray-900 mt-1 tabular-nums">
+          {{ formatDistanceWithUnit(records.most_km_month.total_km, unit, 0) }}
+        </p>
+        <p class="text-xs text-gray-400 mt-0.5">
+          {{ fmtMonth(records.most_km_month.month) }} · {{ records.most_km_month.run_count }} runs
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { CalendarDays, Route, Timer, Trophy } from 'lucide-vue-next'
+import { formatDistanceWithUnit, formatPace } from '@/utils/format'
+import type { RecordsInfo } from '@/types/runs'
+import type { Unit } from '@/types/runs'
+
+const props = defineProps<{ records: RecordsInfo | null; unit: Unit }>()
+
+const hasAny = computed(
+  () => !!(props.records?.longest_run || props.records?.fastest_pace || props.records?.most_km_month),
+)
+
+const fmtDate = (iso: string): string =>
+  new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+
+const fmtMonth = (iso: string): string =>
+  new Date(iso).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
+</script>

--- a/frontend/src/composables/useStats.ts
+++ b/frontend/src/composables/useStats.ts
@@ -1,10 +1,11 @@
 import { ref } from 'vue'
 import { apiCall } from '@/config/api'
-import type { OverallStats, StreakInfo } from '@/types/runs'
+import type { OverallStats, RecordsInfo, StreakInfo } from '@/types/runs'
 
 export function useStats() {
   const stats = ref<OverallStats | null>(null)
   const streak = ref<StreakInfo | null>(null)
+  const records = ref<RecordsInfo | null>(null)
   const loading = ref(false)
   const error = ref<string | null>(null)
 
@@ -12,12 +13,14 @@ export function useStats() {
     loading.value = true
     error.value = null
     try {
-      const [overall, streaks] = await Promise.all([
+      const [overall, streaks, recs] = await Promise.all([
         apiCall<OverallStats>('/stats/overall'),
         apiCall<StreakInfo>('/stats/streaks'),
+        apiCall<RecordsInfo>('/stats/records'),
       ])
       stats.value = overall
       streak.value = streaks
+      records.value = recs
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to load stats'
     } finally {
@@ -25,5 +28,5 @@ export function useStats() {
     }
   }
 
-  return { stats, streak, loading, error, load }
+  return { stats, streak, records, loading, error, load }
 }

--- a/frontend/src/types/runs.ts
+++ b/frontend/src/types/runs.ts
@@ -8,6 +8,17 @@ export interface OverallStats {
   avg_pace_min_per_km: number
 }
 
+export interface RecordsInfo {
+  longest_run?: { date: string; distance_km: number; activity_id: string }
+  fastest_pace?: {
+    date: string
+    pace_min_per_km: number
+    distance_km: number
+    activity_id: string
+  }
+  most_km_month?: { month: string; run_count: number; total_km: number }
+}
+
 export interface StreakInfo {
   current_streak: number
   current_streak_km: number

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -74,6 +74,10 @@
       </div>
 
       <div class="mb-6">
+        <PersonalBestsCard :records="records" :unit="unit" />
+      </div>
+
+      <div class="mb-6">
         <StreakHeatmap :grid="heatmapGrid" :unit="unit" />
       </div>
 
@@ -117,6 +121,7 @@ import SyncButton from '@/components/SyncButton.vue'
 import EmptyState from '@/components/EmptyState.vue'
 import StreakHero from '@/components/StreakHero.vue'
 import StreakHeatmap from '@/components/StreakHeatmap.vue'
+import PersonalBestsCard from '@/components/PersonalBestsCard.vue'
 import MonthlyDistanceChart from '@/components/MonthlyDistanceChart.vue'
 import GoalsCard from '@/components/GoalsCard.vue'
 import TodayCard from '@/components/TodayCard.vue'
@@ -140,7 +145,14 @@ import { buildHeatmapGrid } from '@/utils/heatmap'
 const auth = useAuthStore()
 const userEmail = computed(() => auth.user?.email ?? 'runner')
 
-const { stats, streak, loading: statsLoading, error: statsError, load: loadStats } = useStats()
+const {
+  stats,
+  streak,
+  records,
+  loading: statsLoading,
+  error: statsError,
+  load: loadStats,
+} = useStats()
 const {
   runs: recentRuns,
   loading: recentLoading,


### PR DESCRIPTION
Adds a **Personal Bests** card to the dashboard — longest run, fastest pace (≥5k), biggest month, each with its date.

Frontend-only: the data already comes from `GET /stats/records`. `useStats` now also fetches records; `PersonalBestsCard.vue` renders the tiles (slots above the heatmap, helping fill the layout the UX review flagged). Miles/pace via `utils/format`, Lucide icons, navy theme; graceful "No records yet" empty state.

Typecheck + build clean.

Fixes SB-221
🤖 Generated with [Claude Code](https://claude.com/claude-code)