### PR TITLE
feat: STK prod→local DB restore over Supabase REST API (SB-224)

### DIFF
--- a/frontend/src/components/PersonalBestsCard.vue
+++ b/frontend/src/components/PersonalBestsCard.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6">
+    <div class="flex items-center gap-2 mb-4">
+      <Trophy class="w-4 h-4 text-gray-700" />
+      <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-700">Personal bests</h3>
+    </div>
+
+    <div v-if="!hasAny" class="text-sm text-gray-500">No records yet — sync some runs.</div>
+
+    <div v-else class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <div v-if="records?.longest_run" class="rounded-xl bg-gray-50 border border-gray-100 p-4">
+        <div class="flex items-center gap-1.5 text-xs font-medium text-gray-500">
+          <Route class="w-3.5 h-3.5" /> Longest run
+        </div>
+        <p class="text-2xl font-bold text-gray-900 mt-1 tabular-nums">
+          {{ formatDistanceWithUnit(records.longest_run.distance_km, unit, 1) }}
+        </p>
+        <p class="text-xs text-gray-400 mt-0.5">{{ fmtDate(records.longest_run.date) }}</p>
+      </div>
+
+      <div v-if="records?.fastest_pace" class="rounded-xl bg-gray-50 border border-gray-100 p-4">
+        <div class="flex items-center gap-1.5 text-xs font-medium text-gray-500">
+          <Timer class="w-3.5 h-3.5" /> Fastest pace
+        </div>
+        <p class="text-2xl font-bold text-gray-900 mt-1 tabular-nums">
+          {{ formatPace(records.fastest_pace.pace_min_per_km, unit) }}
+        </p>
+        <p class="text-xs text-gray-400 mt-0.5">
+          {{ formatDistanceWithUnit(records.fastest_pace.distance_km, unit, 1) }} ·
+          {{ fmtDate(records.fastest_pace.date) }}
+        </p>
+      </div>
+
+      <div v-if="records?.most_km_month" class="rounded-xl bg-gray-50 border border-gray-100 p-4">
+        <div class="flex items-center gap-1.5 text-xs font-medium text-gray-500">
+          <CalendarDays class="w-3.5 h-3.5" /> Biggest month
+        </div>
+        <p class="text-2xl font-bold text-gray-900 mt-1 tabular-nums">
+          {{ formatDistanceWithUnit(records.most_km_month.total_km, unit, 0) }}
+        </p>
+        <p class="text-xs text-gray-400 mt-0.5">
+          {{ fmtMonth(records.most_km_month.month) }} · {{ records.most_km_month.run_count }} runs
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { CalendarDays, Route, Timer, Trophy } from 'lucide-vue-next'
+import { formatDistanceWithUnit, formatPace } from '@/utils/format'
+import type { RecordsInfo } from '@/types/runs'
+import type { Unit } from '@/types/runs'
+
+const props = defineProps<{ records: RecordsInfo | null; unit: Unit }>()
+
+const hasAny = computed(
+  () => !!(props.records?.longest_run || props.records?.fastest_pace || props.records?.most_km_month),
+)
+
+const fmtDate = (iso: string): string =>
+  new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+
+const fmtMonth = (iso: string): string =>
+  new Date(iso).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
+</script>

--- a/frontend/src/composables/useStats.ts
+++ b/frontend/src/composables/useStats.ts
@@ -1,10 +1,11 @@
 import { ref } from 'vue'
 import { apiCall } from '@/config/api'
-import type { OverallStats, StreakInfo } from '@/types/runs'
+import type { OverallStats, RecordsInfo, StreakInfo } from '@/types/runs'
 
 export function useStats() {
   const stats = ref<OverallStats | null>(null)
   const streak = ref<StreakInfo | null>(null)
+  const records = ref<RecordsInfo | null>(null)
   const loading = ref(false)
   const error = ref<string | null>(null)
 
@@ -12,12 +13,14 @@ export function useStats() {
     loading.value = true
     error.value = null
     try {
-      const [overall, streaks] = await Promise.all([
+      const [overall, streaks, recs] = await Promise.all([
         apiCall<OverallStats>('/stats/overall'),
         apiCall<StreakInfo>('/stats/streaks'),
+        apiCall<RecordsInfo>('/stats/records'),
       ])
       stats.value = overall
       streak.value = streaks
+      records.value = recs
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to load stats'
     } finally {
@@ -25,5 +28,5 @@ export function useStats() {
     }
   }
 
-  return { stats, streak, loading, error, load }
+  return { stats, streak, records, loading, error, load }
 }

--- a/frontend/src/types/runs.ts
+++ b/frontend/src/types/runs.ts
@@ -8,6 +8,17 @@ export interface OverallStats {
   avg_pace_min_per_km: number
 }
 
+export interface RecordsInfo {
+  longest_run?: { date: string; distance_km: number; activity_id: string }
+  fastest_pace?: {
+    date: string
+    pace_min_per_km: number
+    distance_km: number
+    activity_id: string
+  }
+  most_km_month?: { month: string; run_count: number; total_km: number }
+}
+
 export interface StreakInfo {
   current_streak: number
   current_streak_km: number

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -74,6 +74,10 @@
       </div>
 
       <div class="mb-6">
+        <PersonalBestsCard :records="records" :unit="unit" />
+      </div>
+
+      <div class="mb-6">
         <StreakHeatmap :grid="heatmapGrid" :unit="unit" />
       </div>
 
@@ -117,6 +121,7 @@ import SyncButton from '@/components/SyncButton.vue'
 import EmptyState from '@/components/EmptyState.vue'
 import StreakHero from '@/components/StreakHero.vue'
 import StreakHeatmap from '@/components/StreakHeatmap.vue'
+import PersonalBestsCard from '@/components/PersonalBestsCard.vue'
 import MonthlyDistanceChart from '@/components/MonthlyDistanceChart.vue'
 import GoalsCard from '@/components/GoalsCard.vue'
 import TodayCard from '@/components/TodayCard.vue'
@@ -140,7 +145,14 @@ import { buildHeatmapGrid } from '@/utils/heatmap'
 const auth = useAuthStore()
 const userEmail = computed(() => auth.user?.email ?? 'runner')
 
-const { stats, streak, loading: statsLoading, error: statsError, load: loadStats } = useStats()
+const {
+  stats,
+  streak,
+  records,
+  loading: statsLoading,
+  error: statsError,
+  load: loadStats,
+} = useStats()
 const {
   runs: recentRuns,
   loading: recentLoading,

--- a/scripts/_db_env.py
+++ b/scripts/_db_env.py
@@ -1,0 +1,32 @@
+"""Shared Supabase env resolution for the STK backup/restore scripts (SB-224)."""
+
+from __future__ import annotations
+
+import os
+
+
+def resolve_env() -> tuple[str, str]:
+    """Return (url, service_key) from the environment.
+
+    Accepts SUPABASE_SERVICE_KEY (matches missing-table) or the longer
+    SUPABASE_SERVICE_ROLE_KEY (matches `supabase status -o env`).
+    """
+    url = os.environ.get("SUPABASE_URL", "").rstrip("/")
+    key = os.environ.get("SUPABASE_SERVICE_KEY") or os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
+    return url, key
+
+
+def require_env() -> tuple[str, str]:
+    """Same as resolve_env but exits with a clear message if either is missing."""
+    url, key = resolve_env()
+    if not url or not key:
+        raise SystemExit(
+            "Missing SUPABASE_URL and/or SUPABASE_SERVICE_KEY "
+            "(SUPABASE_SERVICE_ROLE_KEY also accepted)."
+        )
+    return url, key
+
+
+def is_local(url: str) -> bool:
+    """True when the URL points at a local Supabase instance."""
+    return any(host in url for host in ("127.0.0.1", "localhost"))

--- a/scripts/backup_database.py
+++ b/scripts/backup_database.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""REST-based production data dump for STK (SB-224).
+
+Dumps STK's run-data tables over the Supabase REST API (HTTPS, IPv4-safe) into
+a gzip'd JSON file. This is the IPv4-safe alternative to ``pg_dump``: the prod
+direct DB host is IPv6-only and the session pooler rejects the tenant on this
+network, so we go through PostgREST with the service-role key instead.
+
+Only run-data tables are dumped — the tables that power the dashboard's
+personal bests, streak, records and goals. Auth users, OAuth tokens and invites
+are intentionally excluded (managed per-environment).
+
+Env:
+    SUPABASE_URL          e.g. https://dnwllbukmvdddwhlsmqb.supabase.co (prod)
+    SUPABASE_SERVICE_KEY  prod service_role key (SUPABASE_SERVICE_ROLE_KEY also accepted)
+
+Usage:
+    SUPABASE_URL=... SUPABASE_SERVICE_KEY=... \
+      uv run --project backend python scripts/backup_database.py --backup-dir ~/backups/stk
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from _db_env import require_env
+
+from supabase import Client, create_client
+
+# Run-data tables in FK-parent order (parents first). This is the data that
+# powers the dashboard: PB / streak / records / monthly + yearly goals.
+#
+#   user_sources ─┬─ runs ── splits
+#                 └─ goals
+#   metric_types ─┬─ metric_entries
+#                 └─ metric_goals
+#
+# EXCLUDED (managed per-environment, contain secrets, or per-env identity):
+#   users / auth      -> handled by `jt supabase sync-users stk`
+#   oauth tokens      -> stripped from user_sources below; never leave prod
+#   invites           -> per-environment
+#   coach/athlete dom -> owned by scripts/seed_local_users.py locally
+BACKUP_TABLES = [
+    "user_sources",
+    "metric_types",
+    "runs",
+    "splits",
+    "goals",
+    "metric_entries",
+    "metric_goals",
+]
+
+# Columns scrubbed to NULL before the dump ever touches disk. user_sources rows
+# are needed because runs.source_id / goals.source_id reference them (NOT NULL),
+# but the OAuth secrets they carry must never land in a backup file on a laptop.
+SENSITIVE_COLUMNS: dict[str, list[str]] = {
+    "user_sources": [
+        "access_token",
+        "refresh_token",
+        "token_expires_at",
+        "access_token_secret",
+    ],
+}
+
+PAGE_SIZE = 1000
+
+
+def dump_table(sb: Client, table: str) -> list[dict]:
+    """Fetch every row of a table, paginating in PAGE_SIZE chunks."""
+    print(f"Dumping {table}...")
+    rows: list[dict] = []
+    offset = 0
+    while True:
+        result = sb.table(table).select("*").range(offset, offset + PAGE_SIZE - 1).execute()
+        batch = result.data or []
+        rows.extend(batch)
+        if len(batch) < PAGE_SIZE:
+            break
+        offset += PAGE_SIZE
+
+    scrub = SENSITIVE_COLUMNS.get(table)
+    if scrub:
+        for row in rows:
+            for col in scrub:
+                if col in row:
+                    row[col] = None
+        print(f"  🔒 scrubbed {', '.join(scrub)}")
+
+    print(f"  ✓ {len(rows)} rows")
+    return rows
+
+
+def create_backup(sb: Client, url: str, backup_dir: Path) -> Path:
+    """Dump all run-data tables into a single gzip'd JSON file."""
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    backup_file = backup_dir / f"stk_backup_{timestamp}.json.gz"
+
+    print(f"Creating STK data backup: {backup_file}")
+    print("=" * 50)
+
+    payload: dict = {
+        "backup_info": {
+            "timestamp": timestamp,
+            "created_at": datetime.now().isoformat(),
+            "source_url": url,
+            "version": "1.0",
+        },
+        "tables": {},
+    }
+    for table in BACKUP_TABLES:
+        payload["tables"][table] = dump_table(sb, table)
+
+    with gzip.open(backup_file, "wt", encoding="utf-8") as f:
+        json.dump(payload, f, default=str)
+
+    total = sum(len(v) for v in payload["tables"].values())
+    print("=" * 50)
+    print(f"✅ Backup complete: {backup_file}")
+    print(
+        f"📊 {backup_file.stat().st_size / 1024:.1f} KB, {total} rows across {len(BACKUP_TABLES)} tables"
+    )
+    return backup_file
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="STK REST data backup (SB-224)")
+    parser.add_argument(
+        "--backup-dir",
+        type=Path,
+        default=Path.home() / "backups" / "stk",
+        help="Directory to write the backup into (default: ~/backups/stk)",
+    )
+    args = parser.parse_args()
+
+    url, key = require_env()
+    sb = create_client(url, key)
+    try:
+        create_backup(sb, url, args.backup_dir)
+    except Exception as e:  # noqa: BLE001 — top-level guard, surface and exit
+        print(f"❌ Backup failed: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backup_database.py
+++ b/scripts/backup_database.py
@@ -35,17 +35,23 @@ from supabase import Client, create_client
 # Run-data tables in FK-parent order (parents first). This is the data that
 # powers the dashboard: PB / streak / records / monthly + yearly goals.
 #
-#   user_sources ─┬─ runs ── splits
-#                 └─ goals
+#   users ─┬─ user_sources ─┬─ runs ── splits
+#          │                └─ goals
+#          └─ (runs/goals also ref users)
 #   metric_types ─┬─ metric_entries
 #                 └─ metric_goals
 #
+# public.users is dumped (no secrets — just user_id/email/display_name) so the
+# restore has a FK target. On restore it is gated to local auth.users, so only
+# prod users that `jt sync-users` recreated locally get added.
+#
 # EXCLUDED (managed per-environment, contain secrets, or per-env identity):
-#   users / auth      -> handled by `jt supabase sync-users stk`
+#   auth.users        -> handled by `jt supabase sync-users stk`
 #   oauth tokens      -> stripped from user_sources below; never leave prod
 #   invites           -> per-environment
 #   coach/athlete dom -> owned by scripts/seed_local_users.py locally
 BACKUP_TABLES = [
+    "users",
     "user_sources",
     "metric_types",
     "runs",

--- a/scripts/restore_database.py
+++ b/scripts/restore_database.py
@@ -39,38 +39,60 @@ from supabase import Client, create_client
 # Restore order = FK-parent order (parents first). Clearing runs in reverse.
 #
 # Per table:
-#   pk       primary-key column used to clear and to track surviving rows
-#   user_col column referencing users.user_id — row dropped if uid not local
-#   parents  [(fk_col, parent_table)] — row dropped if fk not among survivors
-#   upsert   merge on the pk instead of clear+insert (reference data)
+#   pk        primary-key column used to clear and to track surviving rows
+#   parents   [(fk_col, parent_table)] — row dropped if fk not among survivors
+#   upsert    merge on the pk instead of clear+insert (reference / shared data)
+#   auth_gate keep a row only if its pk exists in local auth.users — used for
+#             public.users so we mirror prod identity WITHOUT creating a
+#             public.users row that has no matching auth user
+#
+# public.users is upserted (never cleared) so the seeded local test users
+# (coach@/a1@…) survive; only prod users that `jt sync-users` recreated in local
+# auth get added. runs/goals/etc. then reference survivors["users"], which is
+# the union of the pre-existing local users and the ones just restored.
 RESTORE_ORDER: list[dict] = [
-    {"table": "user_sources", "pk": "id", "user_col": "user_id"},
+    {"table": "users", "pk": "user_id", "upsert": True, "auth_gate": True},
+    {"table": "user_sources", "pk": "id", "parents": [("user_id", "users")]},
     {"table": "metric_types", "pk": "key", "upsert": True},
     {
         "table": "runs",
         "pk": "id",
-        "user_col": "user_id",
-        "parents": [("source_id", "user_sources")],
+        "parents": [("user_id", "users"), ("source_id", "user_sources")],
     },
     {"table": "splits", "pk": "id", "parents": [("run_id", "runs")]},
     {
         "table": "goals",
         "pk": "id",
-        "user_col": "user_id",
-        "parents": [("source_id", "user_sources")],
+        "parents": [("user_id", "users"), ("source_id", "user_sources")],
     },
-    {"table": "metric_entries", "pk": "id", "user_col": "user_id"},
-    {"table": "metric_goals", "pk": "id", "user_col": "user_id"},
+    {"table": "metric_entries", "pk": "id", "parents": [("user_id", "users")]},
+    {"table": "metric_goals", "pk": "id", "parents": [("user_id", "users")]},
 ]
 
 BATCH_SIZE = 100
 PAGE_SIZE = 1000
 
 
-def local_user_ids(sb: Client) -> set[str]:
-    """All users.user_id present locally (populated by `jt sync-users`)."""
+def existing_user_ids(sb: Client) -> set[str]:
+    """user_id of every public.users row already present locally (test users)."""
     result = sb.table("users").select("user_id").execute()
     return {row["user_id"] for row in (result.data or [])}
+
+
+def local_auth_ids(sb: Client) -> set[str]:
+    """Every auth.users id present locally (populated by `jt sync-users`)."""
+    ids: set[str] = set()
+    page = 1
+    while True:
+        resp = sb.auth.admin.list_users(page=page, per_page=1000)
+        users = resp if isinstance(resp, list) else getattr(resp, "users", [])
+        if not users:
+            break
+        ids.update(str(u.id) for u in users)
+        if len(users) < 1000:
+            break
+        page += 1
+    return ids
 
 
 def clear_table(sb: Client, table: str, pk: str) -> None:
@@ -92,15 +114,16 @@ def clear_table(sb: Client, table: str, pk: str) -> None:
 
 
 def sanitize(
-    rows: list[dict], spec: dict, local_ids: set[str], survivors: dict[str, set]
+    rows: list[dict], spec: dict, auth_ids: set[str], survivors: dict[str, set]
 ) -> list[dict]:
-    """Drop rows whose user_id / parent FKs don't resolve locally."""
-    user_col = spec.get("user_col")
+    """Drop rows whose auth gate / parent FKs don't resolve locally."""
+    pk = spec["pk"]
+    auth_gate = spec.get("auth_gate")
     parents = spec.get("parents", [])
     kept: list[dict] = []
     dropped = 0
     for row in rows:
-        if user_col and row.get(user_col) not in local_ids:
+        if auth_gate and row.get(pk) not in auth_ids:
             dropped += 1
             continue
         if any(row.get(col) not in survivors[parent] for col, parent in parents):
@@ -113,16 +136,17 @@ def sanitize(
 
 
 def restore_table(
-    sb: Client, spec: dict, rows: list[dict], local_ids: set[str], survivors: dict[str, set]
+    sb: Client, spec: dict, rows: list[dict], auth_ids: set[str], survivors: dict[str, set]
 ) -> None:
     table, pk = spec["table"], spec["pk"]
     if not rows:
         print(f"Restoring {table}: no data")
-        survivors[table] = set()
+        survivors.setdefault(table, set())
         return
 
-    rows = sanitize(rows, spec, local_ids, survivors)
-    survivors[table] = {row[pk] for row in rows}
+    rows = sanitize(rows, spec, auth_ids, survivors)
+    # Union so pre-seeded survivors (e.g. existing local users) are preserved.
+    survivors[table] = survivors.get(table, set()) | {row[pk] for row in rows}
     if not rows:
         print(f"Restoring {table}: nothing left after sanitize")
         return
@@ -150,26 +174,30 @@ def restore(sb: Client, backup_file: Path) -> None:
     print(f"Restoring from {backup_file.name} (created {info.get('created_at', '?')})")
     print("=" * 50)
 
-    # Clear child → parent. metric_types is upserted, not cleared (it is
-    # reference data seeded by migration and referenced by metric_entries/goals).
+    # Clear child → parent. Upserted tables (users, metric_types) are NOT
+    # cleared: users keeps the seeded local test users, metric_types is
+    # migration-seeded reference data referenced by metric_entries/goals.
     print("🧹 Clearing existing run-data...")
     for spec in reversed(RESTORE_ORDER):
         if spec.get("upsert"):
             continue
         clear_table(sb, spec["table"], spec["pk"])
 
-    local_ids = local_user_ids(sb)
-    print(f"🔍 {len(local_ids)} local user(s) for FK sanitization")
-    if not local_ids:
+    # Gate public.users to local auth. Seed survivors["users"] with the users
+    # that already exist locally (test users) so their run-data still matches
+    # even though we only *add* prod users on top.
+    auth_ids = local_auth_ids(sb)
+    survivors: dict[str, set] = {"users": existing_user_ids(sb)}
+    print(f"🔍 {len(auth_ids)} local auth user(s); {len(survivors['users'])} existing public.users")
+    if not auth_ids:
         print(
-            "  ⚠️  no local users — run `jt supabase sync-users stk` first, "
-            "or all run-data will be dropped."
+            "  ⚠️  no local auth users — run `jt supabase sync-users stk` first, "
+            "or prod users (and their run-data) will be dropped."
         )
 
-    survivors: dict[str, set] = {}
     print("📥 Restoring parent → child...")
     for spec in RESTORE_ORDER:
-        restore_table(sb, spec, tables.get(spec["table"], []), local_ids, survivors)
+        restore_table(sb, spec, tables.get(spec["table"], []), auth_ids, survivors)
 
     print("=" * 50)
     restored = sum(len(s) for s in survivors.values())

--- a/scripts/restore_database.py
+++ b/scripts/restore_database.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""REST-based restore of an STK data backup into a LOCAL Supabase (SB-224).
+
+Loads a gzip'd JSON dump produced by ``backup_database.py`` into the local
+Supabase over the REST API. Clears the run-data tables (child → parent) then
+re-inserts them (parent → child), sanitizing foreign keys so only rows that
+resolve against local ``users`` survive.
+
+LOCAL ONLY: this truncates tables, so it refuses to run against any URL that is
+not 127.0.0.1 / localhost.
+
+Ordering contract (run these BEFORE this script):
+    1. `jt supabase sync-users stk` — recreates silverbeer.io@gmail.com locally
+       with the SAME prod uid, so runs.user_id resolves.
+Then AFTER this script:
+    2. `scripts/seed_local_users.py` — owns the coach/athlete test data.
+
+Env:
+    SUPABASE_URL          http://127.0.0.1:54321 (local)
+    SUPABASE_SERVICE_KEY  local service_role key (SUPABASE_SERVICE_ROLE_KEY also accepted)
+
+Usage:
+    SUPABASE_URL=... SUPABASE_SERVICE_KEY=... \
+      uv run --project backend python scripts/restore_database.py --latest --backup-dir ~/backups/stk
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import sys
+from pathlib import Path
+
+from _db_env import is_local, require_env
+
+from supabase import Client, create_client
+
+# Restore order = FK-parent order (parents first). Clearing runs in reverse.
+#
+# Per table:
+#   pk       primary-key column used to clear and to track surviving rows
+#   user_col column referencing users.user_id — row dropped if uid not local
+#   parents  [(fk_col, parent_table)] — row dropped if fk not among survivors
+#   upsert   merge on the pk instead of clear+insert (reference data)
+RESTORE_ORDER: list[dict] = [
+    {"table": "user_sources", "pk": "id", "user_col": "user_id"},
+    {"table": "metric_types", "pk": "key", "upsert": True},
+    {
+        "table": "runs",
+        "pk": "id",
+        "user_col": "user_id",
+        "parents": [("source_id", "user_sources")],
+    },
+    {"table": "splits", "pk": "id", "parents": [("run_id", "runs")]},
+    {
+        "table": "goals",
+        "pk": "id",
+        "user_col": "user_id",
+        "parents": [("source_id", "user_sources")],
+    },
+    {"table": "metric_entries", "pk": "id", "user_col": "user_id"},
+    {"table": "metric_goals", "pk": "id", "user_col": "user_id"},
+]
+
+BATCH_SIZE = 100
+PAGE_SIZE = 1000
+
+
+def local_user_ids(sb: Client) -> set[str]:
+    """All users.user_id present locally (populated by `jt sync-users`)."""
+    result = sb.table("users").select("user_id").execute()
+    return {row["user_id"] for row in (result.data or [])}
+
+
+def clear_table(sb: Client, table: str, pk: str) -> None:
+    """Delete every row from a table, paginating to handle >1000 rows."""
+    total = 0
+    while True:
+        result = sb.table(table).select(pk).limit(PAGE_SIZE).execute()
+        rows = result.data or []
+        if not rows:
+            break
+        ids = [r[pk] for r in rows]
+        for i in range(0, len(ids), BATCH_SIZE):
+            chunk = ids[i : i + BATCH_SIZE]
+            sb.table(table).delete().in_(pk, chunk).execute()
+            total += len(chunk)
+        if len(rows) < PAGE_SIZE:
+            break
+    print(f"  ✓ cleared {total} from {table}")
+
+
+def sanitize(
+    rows: list[dict], spec: dict, local_ids: set[str], survivors: dict[str, set]
+) -> list[dict]:
+    """Drop rows whose user_id / parent FKs don't resolve locally."""
+    user_col = spec.get("user_col")
+    parents = spec.get("parents", [])
+    kept: list[dict] = []
+    dropped = 0
+    for row in rows:
+        if user_col and row.get(user_col) not in local_ids:
+            dropped += 1
+            continue
+        if any(row.get(col) not in survivors[parent] for col, parent in parents):
+            dropped += 1
+            continue
+        kept.append(row)
+    if dropped:
+        print(f"  ℹ️  dropped {dropped} row(s) with FK not present locally")
+    return kept
+
+
+def restore_table(
+    sb: Client, spec: dict, rows: list[dict], local_ids: set[str], survivors: dict[str, set]
+) -> None:
+    table, pk = spec["table"], spec["pk"]
+    if not rows:
+        print(f"Restoring {table}: no data")
+        survivors[table] = set()
+        return
+
+    rows = sanitize(rows, spec, local_ids, survivors)
+    survivors[table] = {row[pk] for row in rows}
+    if not rows:
+        print(f"Restoring {table}: nothing left after sanitize")
+        return
+
+    print(f"Restoring {table} ({len(rows)} rows)...")
+    inserted = 0
+    for i in range(0, len(rows), BATCH_SIZE):
+        batch = rows[i : i + BATCH_SIZE]
+        if spec.get("upsert"):
+            sb.table(table).upsert(batch, on_conflict=pk).execute()
+        else:
+            sb.table(table).insert(batch).execute()
+        inserted += len(batch)
+    print(f"  ✅ {inserted} rows into {table}")
+
+
+def restore(sb: Client, backup_file: Path) -> None:
+    with gzip.open(backup_file, "rt", encoding="utf-8") as f:
+        payload = json.load(f)
+    if "tables" not in payload:
+        raise SystemExit("❌ invalid backup file: no 'tables' key")
+
+    tables = payload["tables"]
+    info = payload.get("backup_info", {})
+    print(f"Restoring from {backup_file.name} (created {info.get('created_at', '?')})")
+    print("=" * 50)
+
+    # Clear child → parent. metric_types is upserted, not cleared (it is
+    # reference data seeded by migration and referenced by metric_entries/goals).
+    print("🧹 Clearing existing run-data...")
+    for spec in reversed(RESTORE_ORDER):
+        if spec.get("upsert"):
+            continue
+        clear_table(sb, spec["table"], spec["pk"])
+
+    local_ids = local_user_ids(sb)
+    print(f"🔍 {len(local_ids)} local user(s) for FK sanitization")
+    if not local_ids:
+        print(
+            "  ⚠️  no local users — run `jt supabase sync-users stk` first, "
+            "or all run-data will be dropped."
+        )
+
+    survivors: dict[str, set] = {}
+    print("📥 Restoring parent → child...")
+    for spec in RESTORE_ORDER:
+        restore_table(sb, spec, tables.get(spec["table"], []), local_ids, survivors)
+
+    print("=" * 50)
+    restored = sum(len(s) for s in survivors.values())
+    print(f"✅ Restore complete: {restored} rows")
+
+
+def find_latest(backup_dir: Path) -> Path | None:
+    candidates = sorted(backup_dir.glob("stk_backup_*.json.gz"), reverse=True)
+    return candidates[0] if candidates else None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="STK REST data restore (SB-224)")
+    parser.add_argument("backup_file", nargs="?", help="Backup file (path or name)")
+    parser.add_argument("--latest", action="store_true", help="Use newest backup in --backup-dir")
+    parser.add_argument(
+        "--backup-dir",
+        type=Path,
+        default=Path.home() / "backups" / "stk",
+        help="Directory holding backups (default: ~/backups/stk)",
+    )
+    args = parser.parse_args()
+
+    url, key = require_env()
+    if not is_local(url):
+        raise SystemExit(
+            f"REFUSING: SUPABASE_URL is not local ({url}). "
+            "Restore truncates tables and is local-only."
+        )
+
+    if args.latest:
+        backup_file = find_latest(args.backup_dir)
+        if not backup_file:
+            raise SystemExit(f"❌ no backups found in {args.backup_dir}")
+    elif args.backup_file:
+        backup_file = Path(args.backup_file)
+        if not backup_file.is_absolute() and "/" not in args.backup_file:
+            backup_file = args.backup_dir / args.backup_file
+    else:
+        raise SystemExit("❌ specify a backup file or --latest")
+
+    if not backup_file.exists():
+        raise SystemExit(f"❌ backup file not found: {backup_file}")
+
+    sb = create_client(url, key)
+    try:
+        restore(sb, backup_file)
+    except Exception as e:  # noqa: BLE001 — top-level guard, surface and exit
+        print(f"❌ Restore failed: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/restore_prod_to_local.sh
+++ b/scripts/restore_prod_to_local.sh
@@ -1,136 +1,89 @@
 #!/usr/bin/env bash
-# Restore production Supabase data to the local Supabase instance.
+# Restore production STK run-data into the LOCAL Supabase — over the REST API.
 #
-# Workflow:
-#   1. Reset local DB (applies all migrations from supabase/migrations/)
-#   2. Dump production public-schema data via pg_dump
-#   3. Load dump into local DB via psql
+# Why REST and not pg_dump (SB-224):
+#   The prod direct DB host (db.<ref>.supabase.co) is IPv6-only ("No route to
+#   host" on an IPv4 network) and the session pooler rejects the tenant here.
+#   The Supabase REST API is plain HTTPS, so it works fine on IPv4. We dump prod
+#   over REST with the service-role key, then load it into local over REST.
 #
-# Schema comes from migrations, not the dump. This keeps local schema aligned
-# with the migration history and works even when prod hasn't received a new
-# migration yet.
+# Flow:
+#   1. Read prod creds (op) and back up prod run-data -> ~/backups/stk/*.json.gz
+#   2. `jt supabase sync-users stk` — recreate silverbeer locally w/ prod uid
+#   3. Restore the backup into local (clears + reloads run-data tables)
+#   4. `seed_local_users.py` — (re)create the coach/athlete test data
 #
-# Requirements:
-#   - supabase CLI (for local dev)
-#   - pg_dump, psql (PostgreSQL client tools)
-#   - PROD_DATABASE_URL from one of: shell env, .env, or .env.restore
+# EXCLUDED from the copy: auth users (step 2 owns them), OAuth tokens (scrubbed
+# from the dump), invites, and the coach/athlete domain (step 4 owns it).
 #
-# WARNING: Downloads production data (may contain PII) to your laptop. Treat
-# the dump file as sensitive. The script deletes it on exit but check your
-# backups/trash.
+# Run this yourself — it uses `op` (1Password), which needs biometric auth and
+# will not work in a non-interactive agent shell.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-DUMP_FILE="$(mktemp -t myrunstreak_prod_dump.XXXXXX.sql)"
-trap 'rm -f "$DUMP_FILE"' EXIT
+BACKUP_DIR="${STK_BACKUP_DIR:-$HOME/backups/stk}"
 
-# Local Supabase default (from supabase/config.toml: [db] port = 54322)
-LOCAL_DB_URL="${LOCAL_DATABASE_URL:-postgresql://postgres:postgres@127.0.0.1:54322/postgres}"
+# --- Prod credentials -------------------------------------------------------
+# URL is public; service key comes from 1Password. Override PROD_* to skip op.
+PROD_URL="${STK_PROD_SUPABASE_URL:-https://dnwllbukmvdddwhlsmqb.supabase.co}"
+PROD_KEY="${STK_PROD_SERVICE_KEY:-}"
 
-# Load PROD_DATABASE_URL from .env or .env.restore if not already set.
-# Both files are gitignored. .env is the main app env file; .env.restore is a
-# separate file if you prefer to keep DB dumps creds isolated from app config.
-# Priority: shell env > .env.restore > .env
-for env_file in .env.restore .env; do
-    if [[ -z "${PROD_DATABASE_URL:-}" && -f "$env_file" ]]; then
-        # Grep only the var we need to avoid leaking other secrets into shell
-        line=$(grep -E '^[[:space:]]*PROD_DATABASE_URL[[:space:]]*=' "$env_file" || true)
-        if [[ -n "$line" ]]; then
-            # Strip leading/trailing whitespace, leading "export ", surrounding quotes
-            value="${line#*=}"
-            value="${value%\"}"; value="${value#\"}"
-            value="${value%\'}"; value="${value#\'}"
-            export PROD_DATABASE_URL="$value"
-            echo "Loaded PROD_DATABASE_URL from $env_file"
-        fi
-    fi
-done
-
-if [[ -z "${PROD_DATABASE_URL:-}" ]]; then
-    cat >&2 <<EOF
-ERROR: PROD_DATABASE_URL not set.
-
-Get the prod connection string from Supabase dashboard:
-  Project → Settings → Database → Connection string → URI
-
-Then either export it:
-  export PROD_DATABASE_URL='postgresql://postgres.xxxxx:PASSWORD@aws-0-us-east-1.pooler.supabase.com:6543/postgres'
-
-Or add to .env (or .env.restore):
-  PROD_DATABASE_URL='postgresql://...'
-EOF
-    exit 1
-fi
-
-# Check required tools
-for cmd in supabase pg_dump psql; do
-    if ! command -v "$cmd" >/dev/null 2>&1; then
-        echo "ERROR: '$cmd' not found on PATH" >&2
+if [[ -z "$PROD_KEY" ]]; then
+    if ! command -v op >/dev/null 2>&1; then
+        echo "ERROR: 'op' (1Password CLI) not found and STK_PROD_SERVICE_KEY unset." >&2
         exit 1
     fi
-done
-
-# Confirm destructive action
-echo "This will:"
-echo "  1. RESET the local Supabase DB (all local data destroyed)"
-echo "  2. Apply all migrations from supabase/migrations/"
-echo "  3. Dump public-schema data from PROD"
-echo "  4. Load prod data into local DB"
-echo ""
-echo "Local DB: $LOCAL_DB_URL"
-echo "Prod DB:  ${PROD_DATABASE_URL%%@*}@<redacted>"
-echo ""
-read -r -p "Continue? [y/N] " confirm
-if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
-    echo "Aborted."
-    exit 0
+    echo "==> Reading prod service key from 1Password..."
+    PROD_KEY="$(op read 'op://Personal/stk-prod/service_role_key')"
 fi
 
-# Step 1: reset local DB (applies migrations)
+# --- Confirm destructive action --------------------------------------------
+echo "This will OVERWRITE local run-data (runs, splits, goals, metrics) with prod's."
+echo "  Prod:  $PROD_URL"
+echo "  Local: (discovered via 'supabase status')"
+echo "  Backup dir: $BACKUP_DIR"
 echo ""
-echo "==> Resetting local Supabase DB..."
-supabase db reset
+read -r -p "Continue? [y/N] " confirm
+[[ "$confirm" == "y" || "$confirm" == "Y" ]] || { echo "Aborted."; exit 0; }
 
-# Step 2: dump prod data
+# --- Step 1: back up prod over REST ----------------------------------------
 echo ""
-echo "==> Dumping prod public-schema data..."
-# --data-only: schema already applied via migrations
-# --disable-triggers: avoid trigger side effects on reload
-# --schema=public: exclude auth, storage, supabase internals
-# --no-owner --no-acl: strip ownership/grants (different between envs)
-pg_dump \
-    --data-only \
-    --disable-triggers \
-    --schema=public \
-    --no-owner \
-    --no-acl \
-    --file="$DUMP_FILE" \
-    "$PROD_DATABASE_URL"
+echo "==> Step 1/4: backing up prod run-data over REST..."
+SUPABASE_URL="$PROD_URL" SUPABASE_SERVICE_KEY="$PROD_KEY" \
+    uv run --project backend python scripts/backup_database.py --backup-dir "$BACKUP_DIR"
 
-DUMP_SIZE=$(wc -c < "$DUMP_FILE" | tr -d ' ')
-echo "    Dumped $DUMP_SIZE bytes"
+# --- Discover local creds ---------------------------------------------------
+echo ""
+echo "==> Discovering local Supabase creds..."
+eval "$(supabase status -o env | sed 's/^/export SB_/')"
+LOCAL_URL="${SB_API_URL:-http://127.0.0.1:54321}"
+LOCAL_KEY="${SB_SERVICE_ROLE_KEY:?supabase status did not return SERVICE_ROLE_KEY — is the stack running?}"
 
-# Step 3: load into local
+# --- Step 2: sync auth users (silverbeer gets prod uid) ---------------------
 echo ""
-echo "==> Loading dump into local DB..."
-psql \
-    --single-transaction \
-    --set ON_ERROR_STOP=on \
-    --quiet \
-    --dbname="$LOCAL_DB_URL" \
-    --file="$DUMP_FILE"
+echo "==> Step 2/4: syncing auth users (jt supabase sync-users stk)..."
+if command -v jt >/dev/null 2>&1; then
+    jt supabase sync-users stk
+else
+    echo "WARNING: 'jt' not found — skipping sync-users. Run-data for users not"
+    echo "         present locally will be dropped on restore." >&2
+fi
+
+# --- Step 3: restore into local over REST -----------------------------------
+echo ""
+echo "==> Step 3/4: restoring backup into local..."
+SUPABASE_URL="$LOCAL_URL" SUPABASE_SERVICE_KEY="$LOCAL_KEY" \
+    uv run --project backend python scripts/restore_database.py --latest --backup-dir "$BACKUP_DIR"
+
+# --- Step 4: seed coach/athlete test data -----------------------------------
+echo ""
+echo "==> Step 4/4: seeding local coach/athlete test users..."
+SUPABASE_URL="$LOCAL_URL" SUPABASE_SERVICE_ROLE_KEY="$LOCAL_KEY" \
+    uv run --project backend python scripts/seed_local_users.py
 
 echo ""
-echo "==> Done."
-echo ""
-echo "Row counts in local:"
-psql --dbname="$LOCAL_DB_URL" --quiet --no-align --tuples-only <<'SQL'
-SELECT 'users: ' || COUNT(*) FROM users
-UNION ALL SELECT 'user_sources: ' || COUNT(*) FROM user_sources
-UNION ALL SELECT 'runs: ' || COUNT(*) FROM runs
-UNION ALL SELECT 'splits: ' || COUNT(*) FROM splits
-UNION ALL SELECT 'goals: ' || COUNT(*) FROM goals;
-SQL
+echo "==> Done. Log into the app as silverbeer.io@gmail.com to see real data;"
+echo "    coach@test.local / coach123 still has the seeded test athletes."

--- a/scripts/seed_local_users.py
+++ b/scripts/seed_local_users.py
@@ -21,12 +21,45 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import urllib.error
 import urllib.request
 
-URL = os.environ.get("SUPABASE_URL", "http://127.0.0.1:54321").rstrip("/")
-KEY = os.environ.get("SERVICE_KEY") or os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
+
+def _discover_local() -> tuple[str, str]:
+    """Read API URL + service-role key from `supabase status -o env`.
+
+    Lets the script run with no env set (e.g. from the restore orchestrator).
+    Returns ("", "") if the CLI isn't available or the stack isn't running.
+    """
+    try:
+        out = subprocess.run(
+            ["supabase", "status", "-o", "env"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return "", ""
+    vals: dict[str, str] = {}
+    for line in out.splitlines():
+        if "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        vals[k.strip()] = v.strip().strip('"')
+    return vals.get("API_URL", ""), vals.get("SERVICE_ROLE_KEY", "")
+
+
+_url = os.environ.get("SUPABASE_URL", "")
+_key = os.environ.get("SERVICE_KEY") or os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
+if not _url or not _key:
+    _du, _dk = _discover_local()
+    _url = _url or _du or "http://127.0.0.1:54321"
+    _key = _key or _dk
+
+URL = _url.rstrip("/")
+KEY = _key
 
 if not any(h in URL for h in ("127.0.0.1", "localhost")):
     sys.exit(f"REFUSING: SUPABASE_URL is not local ({URL}). This script is local-only.")

--- a/supabase/migrations/20260704000000_grant_service_role_rest_access.sql
+++ b/supabase/migrations/20260704000000_grant_service_role_rest_access.sql
@@ -1,0 +1,24 @@
+-- SB-224: give the service_role DML on public tables so the Supabase REST API
+-- (PostgREST) works in every environment.
+--
+-- Why this is needed: the FastAPI backend connects to Postgres directly as the
+-- superuser, so nothing ever exercised the service_role's *table* grants
+-- locally. The REST tooling (scripts/backup_database.py, restore_database.py,
+-- seed_local_users.py) connects through PostgREST as service_role, which needs
+-- table-level SELECT/INSERT/UPDATE/DELETE. Locally these were never granted
+-- (fresh `supabase db reset` left service_role with only TRUNCATE/REFERENCES/
+-- TRIGGER), so REST calls failed with "permission denied for table".
+--
+-- On Supabase-hosted prod service_role already holds these privileges, so this
+-- migration is a harmless re-grant there. service_role also bypasses RLS, so no
+-- RLS policy changes are implied. Sequences are covered for completeness even
+-- though current tables use UUID primary keys.
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO service_role;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO service_role;
+
+-- Future tables/sequences created in this schema inherit the same grants.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    GRANT USAGE, SELECT ON SEQUENCES TO service_role;


### PR DESCRIPTION
## Summary
Replaces the pg_dump-based `restore_prod_to_local.sh` (which **cannot reach prod on an IPv4-only network** — the direct DB host `db.<ref>.supabase.co` is IPv6-only, and the session pooler rejects the tenant) with a REST-over-HTTPS approach, mirroring how `missing-table` does it. All prod↔local data movement now goes through PostgREST + the service-role key, which is IPv4-fine.

## What's here
- **`scripts/backup_database.py`** — REST-dumps prod run-data (`user_sources`, `runs`, `splits`, `goals`, `metric_types`/`metric_entries`/`metric_goals`) to gzip JSON, paginating via `.range()`. OAuth tokens on `user_sources` are scrubbed to NULL before the dump ever hits disk.
- **`scripts/restore_database.py`** — local-only (refuses non-127.0.0.1/localhost). Clears run-data child→parent, reloads parent→child with **user-FK + parent-chain sanitization** (drops rows whose `user_id`/`source_id`/`run_id` don't resolve locally), and **upserts** `metric_types` reference data.
- **`scripts/restore_prod_to_local.sh`** — orchestrates: read prod creds via `op` → back up prod → `jt supabase sync-users stk` (so `silverbeer.io@gmail.com` gets its prod uid locally) → restore into local → `seed_local_users.py`.
- **`scripts/seed_local_users.py`** — now self-discovers local creds via `supabase status -o env` when env is unset.
- **`scripts/_db_env.py`** — shared env resolution.
- **Migration `…_grant_service_role_rest_access.sql`** — grants `service_role` table DML so PostgREST works in every environment.

## Why the grant migration?
The FastAPI backend connects to Postgres **directly as the superuser**, so nothing ever exercised `service_role`'s *table* grants locally. A fresh `supabase db reset` leaves `service_role` with only TRUNCATE/REFERENCES/TRIGGER — so REST calls (backup/restore/seed) failed with `permission denied for table`. On Supabase-hosted prod `service_role` already holds these privileges, so the migration is a harmless re-grant there. `service_role` bypasses RLS, so no policy changes are implied.

## Verification (end-to-end against local Supabase)
- Backup: dump + token scrub confirmed.
- Restore: clear reverse-order, insert, `metric_types` upsert (3→3, no dupes).
- Sanitize: synthetic dump with a foreign-user run → run dropped, and its split dropped via the parent chain; valid run+split inserted.
- Local DB returned to baseline after tests.

The prod half (backup) must be run by the user — `op` needs biometric auth and won't work in a non-interactive shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)