### PR TITLE
feat: goal history view (target vs achieved per period) (SB-220)

### DIFF
--- a/backend/goals.py
+++ b/backend/goals.py
@@ -86,3 +86,60 @@ def build_goals_block(
         "yearly": render_goal(yearly_row, year_progress_km),
         "monthly": render_goal(monthly_row, month_progress_km),
     }
+
+
+def build_goal_history(
+    user_id: UUID,
+    source_id: UUID | None,
+    goals_repo: GoalsRepository,
+    runs_repo: RunsRepository,
+) -> list[dict[str, Any]]:
+    """Every past (and current) goal period with target vs *achieved*, in miles.
+
+    "Achieved" is recomputed from the user's own runs via the ``monthly_summary``
+    view, not the goals table's cached ``progress_km`` (which freezes a few days
+    into the next month and under-reports late-month runs). Monthly achieved is
+    that month's ``total_km``; yearly achieved is the sum of the year's months.
+
+    Returns one item per goal that has a target (goal_km set), newest period
+    first, each shaped as the GoalProgress payload plus ``year``/``month``/
+    ``period``/``hit`` so the frontend can group by year and badge hit/miss.
+    """
+    if source_id is None:
+        return []
+
+    # Exact per-month km from runs, plus per-year totals for yearly goals.
+    monthly_totals: dict[tuple[int, int], float] = {}
+    yearly_totals: dict[int, float] = {}
+    for row in runs_repo.get_monthly_stats(user_id, limit=1000):
+        year = int(row["start_year"])
+        month = int(row["start_month"])
+        total_km = float(row.get("total_km") or 0.0)
+        monthly_totals[(year, month)] = total_km
+        yearly_totals[year] = yearly_totals.get(year, 0.0) + total_km
+
+    history: list[dict[str, Any]] = []
+    for row in goals_repo.list_goals(user_id, source_id):
+        if row.get("goal_km") is None:
+            continue  # "no goal set" placeholder — skip
+        year = int(row["year"])
+        month = row.get("month")
+        if month is None:
+            achieved_km = yearly_totals.get(year, 0.0)
+        else:
+            achieved_km = monthly_totals.get((year, int(month)), 0.0)
+
+        rendered = render_goal(row, achieved_km)
+        if rendered is None:
+            continue
+        rendered.update(
+            {
+                "year": year,
+                "month": month,
+                "period": "year" if month is None else "month",
+                "hit": rendered["percent"] is not None and rendered["percent"] >= 100,
+            }
+        )
+        history.append(rendered)
+
+    return history

--- a/backend/routes/stats.py
+++ b/backend/routes/stats.py
@@ -12,7 +12,7 @@ from zoneinfo import ZoneInfo
 
 from backend.auth import authenticate_request
 from backend.cache import cached
-from backend.goals import build_goals_block
+from backend.goals import build_goal_history, build_goals_block
 from backend.splits_analysis import analyze_run, summarize
 from backend.streaks import Streak, compute_streaks
 from fastapi import APIRouter, Depends, Query
@@ -233,6 +233,32 @@ async def get_goals(
     GoalProgress structure.
     """
     return await _goals(user_id)
+
+
+@cached(ttl=60, key_prefix="stats:goals:history")
+async def _goals_history(user_id: UUID) -> list[dict[str, Any]]:
+    supabase = get_supabase_client()
+    token_repo = TokenRepository(supabase)
+    goals_repo = GoalsRepository(supabase)
+    runs_repo = RunsRepository(supabase)
+
+    source_id = token_repo.get_source_id_for_user(user_id, "smashrun")
+    return build_goal_history(user_id, source_id, goals_repo, runs_repo)
+
+
+@router.get("/goals/history")
+async def get_goals_history(
+    user_id: UUID = Depends(authenticate_request),
+) -> list[dict[str, Any]]:
+    """Full goal history — every past/current period with target vs achieved.
+
+    One item per goal that has a target, newest period first. "Achieved" is
+    recomputed from the user's runs (the ``monthly_summary`` view), so closed
+    months are exact rather than frozen at the goals table's cached progress.
+    Each item carries ``year``/``month``/``period``/``hit`` for grouping and
+    hit/miss badging in the UI.
+    """
+    return await _goals_history(user_id)
 
 
 @router.get("/splits")

--- a/backend/tests/test_goals_module.py
+++ b/backend/tests/test_goals_module.py
@@ -7,7 +7,12 @@ from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
-from backend.goals import build_goals_block, km_to_miles, render_goal
+from backend.goals import (
+    build_goal_history,
+    build_goals_block,
+    km_to_miles,
+    render_goal,
+)
 
 
 def test_km_to_miles() -> None:
@@ -118,3 +123,123 @@ def test_build_goals_block_progress_from_run_stats() -> None:
 
     assert result["yearly"]["progress_mi"] == pytest.approx(km_to_miles(1026.5), abs=0.1)
     assert result["monthly"]["progress_mi"] == pytest.approx(km_to_miles(125.2), abs=0.1)
+
+
+# --- build_goal_history (SB-220) ---------------------------------------------
+
+
+def _monthly_stats() -> list[dict]:
+    """monthly_summary rows: exact per-month km from runs."""
+    return [
+        {"start_year": 2026, "start_month": 6, "total_km": 209.5},  # hit (goal 202)
+        {"start_year": 2026, "start_month": 5, "total_km": 190.0},  # missed (goal 201.2)
+        {"start_year": 2025, "start_month": 12, "total_km": 100.0},
+    ]
+
+
+def test_build_goal_history_no_source_returns_empty() -> None:
+    repo, runs_repo = MagicMock(), MagicMock()
+    assert build_goal_history(uuid4(), None, repo, runs_repo) == []
+    repo.list_goals.assert_not_called()
+
+
+def test_build_goal_history_achieved_from_runs_not_cached_progress() -> None:
+    """Achieved is the monthly_summary total, not the goals row's stale progress_km."""
+    user_id, source_id = uuid4(), uuid4()
+    repo = MagicMock()
+    repo.list_goals.return_value = [
+        {"year": 2026, "month": 6, "goal_km": 200.0, "progress_km": 5.0, "fetched_at": "Z"},
+    ]
+    runs_repo = MagicMock()
+    runs_repo.get_monthly_stats.return_value = _monthly_stats()
+
+    history = build_goal_history(user_id, source_id, repo, runs_repo)
+
+    assert len(history) == 1
+    item = history[0]
+    # progress reflects the 209.5 km run total, NOT the cached 5.0 km.
+    assert item["progress_mi"] == pytest.approx(km_to_miles(209.5), abs=0.1)
+    assert item["year"] == 2026
+    assert item["month"] == 6
+    assert item["period"] == "month"
+    assert item["hit"] is True  # 209.5 km >= 200 km target
+
+
+def test_build_goal_history_hit_and_miss_badges() -> None:
+    user_id, source_id = uuid4(), uuid4()
+    repo = MagicMock()
+    # goal_km chosen so achieved (km) lands just above / below target.
+    repo.list_goals.return_value = [
+        {
+            "year": 2026,
+            "month": 6,
+            "goal_km": 200.0,
+            "progress_km": 0,
+            "fetched_at": "Z",
+        },  # 209.5 -> hit
+        {
+            "year": 2026,
+            "month": 5,
+            "goal_km": 200.0,
+            "progress_km": 0,
+            "fetched_at": "Z",
+        },  # 190.0 -> miss
+    ]
+    runs_repo = MagicMock()
+    runs_repo.get_monthly_stats.return_value = _monthly_stats()
+
+    history = build_goal_history(user_id, source_id, repo, runs_repo)
+
+    by_month = {h["month"]: h for h in history}
+    assert by_month[6]["hit"] is True
+    assert by_month[5]["hit"] is False
+
+
+def test_build_goal_history_yearly_sums_months() -> None:
+    """A yearly goal's achieved = sum of that year's monthly run totals."""
+    user_id, source_id = uuid4(), uuid4()
+    repo = MagicMock()
+    repo.list_goals.return_value = [
+        {"year": 2026, "month": None, "goal_km": 1000.0, "progress_km": 0, "fetched_at": "Z"},
+    ]
+    runs_repo = MagicMock()
+    runs_repo.get_monthly_stats.return_value = _monthly_stats()
+
+    history = build_goal_history(user_id, source_id, repo, runs_repo)
+
+    assert history[0]["period"] == "year"
+    assert history[0]["month"] is None
+    # 2026 months only: 209.5 + 190.0 = 399.5 km (2025 excluded)
+    assert history[0]["progress_mi"] == pytest.approx(km_to_miles(399.5), abs=0.1)
+
+
+def test_build_goal_history_skips_placeholder_rows() -> None:
+    """Rows with null goal_km (mark_absent placeholder) are omitted."""
+    user_id, source_id = uuid4(), uuid4()
+    repo = MagicMock()
+    repo.list_goals.return_value = [
+        {"year": 2026, "month": 6, "goal_km": None, "progress_km": None, "fetched_at": "Z"},
+        {"year": 2026, "month": 5, "goal_km": 200.0, "progress_km": 0, "fetched_at": "Z"},
+    ]
+    runs_repo = MagicMock()
+    runs_repo.get_monthly_stats.return_value = _monthly_stats()
+
+    history = build_goal_history(user_id, source_id, repo, runs_repo)
+
+    assert [h["month"] for h in history] == [5]
+
+
+def test_build_goal_history_missing_month_total_is_zero() -> None:
+    """A goal for a month with no runs shows 0 achieved, not a crash."""
+    user_id, source_id = uuid4(), uuid4()
+    repo = MagicMock()
+    repo.list_goals.return_value = [
+        {"year": 2026, "month": 3, "goal_km": 200.0, "progress_km": 0, "fetched_at": "Z"},
+    ]
+    runs_repo = MagicMock()
+    runs_repo.get_monthly_stats.return_value = _monthly_stats()  # no March row
+
+    history = build_goal_history(user_id, source_id, repo, runs_repo)
+
+    assert history[0]["progress_mi"] == 0.0
+    assert history[0]["hit"] is False

--- a/backend/tests/test_goals_repository.py
+++ b/backend/tests/test_goals_repository.py
@@ -1,11 +1,59 @@
 """Tests for GoalsRepository staleness logic."""
 
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
 from src.shared.models import Goal
 from src.shared.supabase_ops import GoalsRepository
+
+
+class _FakeQuery:
+    """Self-returning PostgREST query stub; records calls, returns preset data."""
+
+    def __init__(self, data: list[dict]) -> None:
+        self._data = data
+        self.calls: list[tuple] = []
+
+    def table(self, name: str) -> "_FakeQuery":
+        self.calls.append(("table", name))
+        return self
+
+    def select(self, *a: object) -> "_FakeQuery":
+        return self
+
+    def eq(self, col: str, val: object) -> "_FakeQuery":
+        self.calls.append(("eq", col, val))
+        return self
+
+    def order(self, col: str, desc: bool = False) -> "_FakeQuery":
+        self.calls.append(("order", col, desc))
+        return self
+
+    def execute(self) -> SimpleNamespace:
+        return SimpleNamespace(data=self._data)
+
+
+def test_list_goals_orders_by_period_desc() -> None:
+    """list_goals filters by user+source and orders year desc, month desc."""
+    rows = [
+        {"year": 2026, "month": None, "goal_km": 1000.0},
+        {"year": 2026, "month": 6, "goal_km": 200.0},
+    ]
+    fake = _FakeQuery(rows)
+    repo = GoalsRepository(fake)  # type: ignore[arg-type]
+    user_id, source_id = uuid4(), uuid4()
+
+    result = repo.list_goals(user_id, source_id)
+
+    assert result == rows
+    assert ("table", "goals") in fake.calls
+    assert ("eq", "user_id", str(user_id)) in fake.calls
+    assert ("eq", "source_id", str(source_id)) in fake.calls
+    assert ("order", "year", True) in fake.calls
+    assert ("order", "month", True) in fake.calls
 
 
 @pytest.fixture

--- a/backend/tests/test_stats_goals.py
+++ b/backend/tests/test_stats_goals.py
@@ -126,3 +126,61 @@ async def test_goals_uses_current_year_month_in_ny_tz(user_id: str) -> None:
     monthly_call = goals_repo.get_by_period.call_args_list[1]
     assert yearly_call.args[2] == 2026 and yearly_call.args[3] is None
     assert monthly_call.args[2] == 2026 and monthly_call.args[3] == 5
+
+
+# --- GET /stats/goals/history (SB-220) ---------------------------------------
+
+
+async def _call_history(user_id: str) -> list[dict]:
+    from backend.routes.stats import _goals_history
+
+    return await _goals_history(UUID(user_id))
+
+
+@pytest.mark.asyncio
+async def test_goals_history_returns_periods_with_achieved(user_id: str) -> None:
+    """History lists each stored goal with achieved recomputed from runs."""
+    source_id = uuid4()
+    token_repo = MagicMock()
+    token_repo.get_source_id_for_user.return_value = source_id
+
+    goals_repo = MagicMock()
+    goals_repo.list_goals.return_value = [
+        {"year": 2026, "month": None, "goal_km": 1000.0, "progress_km": 0, "fetched_at": "Z"},
+        {"year": 2026, "month": 6, "goal_km": 200.0, "progress_km": 0, "fetched_at": "Z"},
+    ]
+    runs_repo = MagicMock()
+    runs_repo.get_monthly_stats.return_value = [
+        {"start_year": 2026, "start_month": 6, "total_km": 209.5},
+    ]
+
+    with (
+        patch("backend.routes.stats.get_supabase_client"),
+        patch("backend.routes.stats.TokenRepository", return_value=token_repo),
+        patch("backend.routes.stats.GoalsRepository", return_value=goals_repo),
+        patch("backend.routes.stats.RunsRepository", return_value=runs_repo),
+    ):
+        result = await _call_history(user_id)
+
+    assert [(r["period"], r["month"]) for r in result] == [("year", None), ("month", 6)]
+    june = next(r for r in result if r["month"] == 6)
+    assert june["hit"] is True  # 209.5 km >= 200 km
+
+
+@pytest.mark.asyncio
+async def test_goals_history_empty_when_no_source(user_id: str) -> None:
+    token_repo = MagicMock()
+    token_repo.get_source_id_for_user.return_value = None
+    goals_repo = MagicMock()
+    runs_repo = MagicMock()
+
+    with (
+        patch("backend.routes.stats.get_supabase_client"),
+        patch("backend.routes.stats.TokenRepository", return_value=token_repo),
+        patch("backend.routes.stats.GoalsRepository", return_value=goals_repo),
+        patch("backend.routes.stats.RunsRepository", return_value=runs_repo),
+    ):
+        result = await _call_history(user_id)
+
+    assert result == []
+    goals_repo.list_goals.assert_not_called()

--- a/frontend/src/components/GoalHistory.vue
+++ b/frontend/src/components/GoalHistory.vue
@@ -1,0 +1,158 @@
+<template>
+  <div class="bg-white rounded-2xl shadow-md border border-gray-100">
+    <!-- Header / toggle -->
+    <button
+      type="button"
+      class="w-full flex items-center justify-between gap-2 p-6 text-left"
+      :aria-expanded="open"
+      @click="toggle"
+    >
+      <span class="inline-flex items-center gap-2">
+        <History class="w-4 h-4 text-gray-700" />
+        <span class="text-sm font-semibold uppercase tracking-wide text-gray-700">
+          Goal history
+        </span>
+      </span>
+      <ChevronDown
+        class="w-4 h-4 text-gray-400 transition-transform duration-200"
+        :class="{ 'rotate-180': open }"
+      />
+    </button>
+
+    <div v-if="open" class="px-6 pb-6">
+      <div v-if="loading" class="text-sm text-gray-500 py-2">Loading history…</div>
+      <div v-else-if="!groups.length" class="text-sm text-gray-500 py-2">
+        No past goals yet.
+      </div>
+
+      <div v-else class="space-y-6">
+        <div v-for="g in groups" :key="g.year">
+          <!-- Year header (yearly goal, if any) -->
+          <div class="flex items-center justify-between gap-2 mb-2 pb-1 border-b border-gray-100">
+            <span class="inline-flex items-center gap-1.5 text-sm font-semibold text-gray-900">
+              <Target class="w-4 h-4 text-brand-600" /> {{ g.year }}
+            </span>
+            <span v-if="g.yearly" class="inline-flex items-center gap-2 text-xs">
+              <span class="font-medium text-gray-900 whitespace-nowrap">
+                {{ g.yearly.progress_mi.toFixed(0) }} / {{ g.yearly.goal_mi.toFixed(0) }} mi
+              </span>
+              <span :class="badgeClass(g.yearly)">{{ badgeLabel(g.yearly) }}</span>
+            </span>
+          </div>
+
+          <!-- Month rows -->
+          <ul class="divide-y divide-gray-50">
+            <li
+              v-for="m in g.months"
+              :key="m.month ?? 0"
+              class="flex items-center gap-3 py-2"
+            >
+              <span class="w-10 shrink-0 text-xs font-medium text-gray-600">
+                {{ monthLabel(m.month) }}
+              </span>
+
+              <div class="flex-1 min-w-0">
+                <div class="w-full bg-gray-200 rounded-full h-1.5 overflow-hidden">
+                  <div
+                    class="h-1.5 rounded-full"
+                    :class="barClass(m)"
+                    :style="{ width: Math.min(pct(m), 100) + '%' }"
+                  ></div>
+                </div>
+              </div>
+
+              <span class="w-24 shrink-0 text-right text-xs text-gray-700 whitespace-nowrap tabular-nums">
+                {{ m.progress_mi.toFixed(0) }} / {{ m.goal_mi.toFixed(0) }} mi
+              </span>
+              <span class="w-16 shrink-0 text-right text-xs tabular-nums" :class="pctColor(m)">
+                {{ pct(m).toFixed(0) }}%
+              </span>
+              <span class="w-16 shrink-0 text-right">
+                <span :class="badgeClass(m)">{{ badgeLabel(m) }}</span>
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { ChevronDown, History, Target } from 'lucide-vue-next'
+import type { GoalHistoryItem } from '@/types/runs'
+
+const props = defineProps<{
+  items: GoalHistoryItem[]
+  loading: boolean
+}>()
+
+const emit = defineEmits<{ (e: 'expand'): void }>()
+
+const open = ref(false)
+const toggle = (): void => {
+  open.value = !open.value
+  if (open.value) emit('expand') // parent lazy-loads; composable no-ops if already loaded
+}
+
+const MONTHS = ['', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+const monthLabel = (m: number | null): string => (m ? MONTHS[m] : '')
+
+const now = new Date()
+const currentYear = now.getFullYear()
+const currentMonth = now.getMonth() + 1
+
+/** A period still in progress (this month / this year) — don't badge it "Missed". */
+const isCurrent = (it: GoalHistoryItem): boolean =>
+  it.year === currentYear && (it.period === 'year' || it.month === currentMonth)
+
+const pct = (it: GoalHistoryItem): number =>
+  it.goal_mi > 0 ? (it.progress_mi / it.goal_mi) * 100 : 0
+
+interface YearGroup {
+  year: number
+  yearly: GoalHistoryItem | null
+  months: GoalHistoryItem[]
+}
+
+const groups = computed((): YearGroup[] => {
+  const byYear = new Map<number, YearGroup>()
+  for (const it of props.items) {
+    let g = byYear.get(it.year)
+    if (!g) {
+      g = { year: it.year, yearly: null, months: [] }
+      byYear.set(it.year, g)
+    }
+    if (it.period === 'year') g.yearly = it
+    else g.months.push(it)
+  }
+  // Backend already orders year desc, month desc — preserve insertion order.
+  return [...byYear.values()]
+})
+
+const badgeLabel = (it: GoalHistoryItem): string => {
+  if (it.hit) return 'Hit'
+  if (isCurrent(it)) return 'Active'
+  return 'Missed'
+}
+
+const badgeClass = (it: GoalHistoryItem): string => {
+  const base = 'inline-block px-1.5 py-0.5 rounded text-[10px] font-medium '
+  if (it.hit) return base + 'bg-green-100 text-green-700'
+  if (isCurrent(it)) return base + 'bg-blue-100 text-blue-700'
+  return base + 'bg-amber-100 text-amber-700'
+}
+
+const pctColor = (it: GoalHistoryItem): string => {
+  if (it.hit) return 'text-green-600'
+  if (isCurrent(it)) return 'text-gray-500'
+  return 'text-amber-600'
+}
+
+const barClass = (it: GoalHistoryItem): string => {
+  if (it.hit) return 'bg-green-500'
+  if (isCurrent(it)) return 'bg-blue-500'
+  return 'bg-amber-500'
+}
+</script>

--- a/frontend/src/components/__tests__/GoalHistory.test.ts
+++ b/frontend/src/components/__tests__/GoalHistory.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import GoalHistory from '../GoalHistory.vue'
+import type { GoalHistoryItem } from '@/types/runs'
+
+// Fixed "now" so the current-period ("Active") logic is deterministic:
+// June 2026 is the current month.
+const FIXED_NOW = new Date('2026-06-15T12:00:00Z')
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(FIXED_NOW)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+const item = (over: Partial<GoalHistoryItem>): GoalHistoryItem => ({
+  goal_mi: 200,
+  progress_mi: 200,
+  percent: 100,
+  text: null,
+  fetched_at: null,
+  year: 2026,
+  month: 5,
+  period: 'month',
+  hit: true,
+  ...over,
+})
+
+const sample: GoalHistoryItem[] = [
+  item({ period: 'year', month: null, goal_mi: 1200, progress_mi: 690, percent: 57.5, hit: false }),
+  item({ month: 6, goal_mi: 130, progress_mi: 60, percent: 46, hit: false }), // current → Active
+  item({ month: 5, goal_mi: 125, progress_mi: 125.3, percent: 100.2, hit: true }), // Hit
+  item({ month: 4, goal_mi: 121, progress_mi: 110, percent: 90.9, hit: false }), // Missed
+]
+
+describe('GoalHistory', () => {
+  it('is collapsed initially and shows no rows', () => {
+    const w = mount(GoalHistory, { props: { items: sample, loading: false } })
+    expect(w.text()).toContain('Goal history')
+    expect(w.text()).not.toContain('May')
+  })
+
+  it('emits expand on first open (parent lazy-loads)', async () => {
+    const w = mount(GoalHistory, { props: { items: [], loading: false } })
+    await w.find('button').trigger('click')
+    expect(w.emitted('expand')).toHaveLength(1)
+  })
+
+  it('groups by year and renders month rows when open', async () => {
+    const w = mount(GoalHistory, { props: { items: sample, loading: false } })
+    await w.find('button').trigger('click')
+    const text = w.text()
+    expect(text).toContain('2026')
+    expect(text).toContain('Apr')
+    expect(text).toContain('May')
+    expect(text).toContain('Jun')
+  })
+
+  it('badges hit / missed / active correctly', async () => {
+    const w = mount(GoalHistory, { props: { items: sample, loading: false } })
+    await w.find('button').trigger('click')
+    const text = w.text()
+    expect(text).toContain('Hit') // May
+    expect(text).toContain('Missed') // April (past, not reached)
+    expect(text).toContain('Active') // June (current month, in progress)
+  })
+
+  it('shows loading state', async () => {
+    const w = mount(GoalHistory, { props: { items: [], loading: true } })
+    await w.find('button').trigger('click')
+    expect(w.text()).toContain('Loading')
+  })
+
+  it('shows empty state when no goals and not loading', async () => {
+    const w = mount(GoalHistory, { props: { items: [], loading: false } })
+    await w.find('button').trigger('click')
+    expect(w.text()).toContain('No past goals')
+  })
+})

--- a/frontend/src/composables/useGoalHistory.ts
+++ b/frontend/src/composables/useGoalHistory.ts
@@ -1,0 +1,32 @@
+import { ref } from 'vue'
+import { apiCall } from '@/config/api'
+import type { GoalHistoryItem } from '@/types/runs'
+
+/**
+ * Full goal history (past monthly + yearly goals, target vs achieved).
+ *
+ * Lazy: `load` no-ops after the first successful fetch so re-opening the
+ * collapsible section doesn't refetch. Data rarely changes within a session.
+ */
+export function useGoalHistory() {
+  const items = ref<GoalHistoryItem[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  const loaded = ref(false)
+
+  const load = async (): Promise<void> => {
+    if (loaded.value || loading.value) return
+    loading.value = true
+    error.value = null
+    try {
+      items.value = await apiCall<GoalHistoryItem[]>('/stats/goals/history')
+      loaded.value = true
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load goal history'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { items, loading, error, loaded, load }
+}

--- a/frontend/src/types/runs.ts
+++ b/frontend/src/types/runs.ts
@@ -99,3 +99,10 @@ export interface GoalsData {
   yearly: GoalProgress | null
   monthly: GoalProgress | null
 }
+
+export interface GoalHistoryItem extends GoalProgress {
+  year: number
+  month: number | null
+  period: 'year' | 'month'
+  hit: boolean
+}

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -36,6 +36,14 @@
         />
       </div>
 
+      <div class="mb-6">
+        <GoalHistory
+          :items="goalHistory"
+          :loading="goalHistoryLoading"
+          @expand="loadGoalHistory"
+        />
+      </div>
+
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
         <TodayCard :goals="metricGoals" :types="metricTypes" @create="showNewGoal = true" />
         <QuickLog :types="metricTypes" @logged="loadMetricGoals" />
@@ -124,6 +132,7 @@ import StreakHeatmap from '@/components/StreakHeatmap.vue'
 import PersonalBestsCard from '@/components/PersonalBestsCard.vue'
 import MonthlyDistanceChart from '@/components/MonthlyDistanceChart.vue'
 import GoalsCard from '@/components/GoalsCard.vue'
+import GoalHistory from '@/components/GoalHistory.vue'
 import TodayCard from '@/components/TodayCard.vue'
 import QuickLog from '@/components/QuickLog.vue'
 import NewGoalForm from '@/components/NewGoalForm.vue'
@@ -132,6 +141,7 @@ import { useMetrics } from '@/composables/useMetrics'
 import { useRecentRuns } from '@/composables/useRecentRuns'
 import { useMonthlyStats } from '@/composables/useMonthlyStats'
 import { useGoals } from '@/composables/useGoals'
+import { useGoalHistory } from '@/composables/useGoalHistory'
 import { useUserPreferences } from '@/composables/useUserPreferences'
 import { useAuthStore } from '@/stores/auth'
 import {
@@ -161,6 +171,11 @@ const {
 } = useRecentRuns(100)
 const { months, loading: monthlyLoading, error: monthlyError, load: loadMonthly } = useMonthlyStats(12)
 const { goals, error: goalsError, load: loadGoals } = useGoals()
+const {
+  items: goalHistory,
+  loading: goalHistoryLoading,
+  load: loadGoalHistory,
+} = useGoalHistory()
 const {
   types: metricTypes,
   goals: metricGoals,

--- a/src/shared/supabase_ops/goals_repository.py
+++ b/src/shared/supabase_ops/goals_repository.py
@@ -61,6 +61,38 @@ class GoalsRepository:
         data_list = cast(list[dict[str, Any]], result.data)
         return data_list[0] if data_list else None
 
+    def list_goals(
+        self,
+        user_id: UUID,
+        source_id: UUID,
+    ) -> list[dict[str, Any]]:
+        """
+        List every stored goal row for a user+source, newest period first.
+
+        Ordered year desc, then month desc. A yearly goal (month IS NULL) sorts
+        before that year's monthly goals (Postgres puts NULLs first on DESC), so
+        each year's summary row leads its months — handy for a grouped history
+        view. Rows with a null goal_km (the "no goal set" placeholder written by
+        mark_absent) are included; callers decide whether to show them.
+
+        Args:
+            user_id: User UUID
+            source_id: Source UUID
+
+        Returns:
+            All goal rows for the user+source, ordered by period descending.
+        """
+        result = (
+            self.supabase.table("goals")
+            .select("*")
+            .eq("user_id", str(user_id))
+            .eq("source_id", str(source_id))
+            .order("year", desc=True)
+            .order("month", desc=True)
+            .execute()
+        )
+        return cast(list[dict[str, Any]], result.data)
+
     def is_stale(
         self,
         row: dict[str, Any] | None,


### PR DESCRIPTION
Fixes SB-220.

## Summary
The dashboard only showed the *current* yearly + monthly goal — the trail was invisible. Adds a collapsible **Goal history** section: every stored goal period with **target vs achieved** and a hit/miss badge, grouped by year.

## Accuracy: achieved recomputed from runs
"Achieved" comes from the `monthly_summary` view (monthly = that month's `total_km`; yearly = sum of its months), **not** the goals table's cached `progress_km` — which freezes a few days into the next month and under-reports late-month runs. So closed months are exact.

## Backend
- `GoalsRepository.list_goals()` — all goal rows for a user+source, period desc (yearly leads its months).
- `goals.build_goal_history()` — per-period target/achieved in miles + `year`/`month`/`period`/`hit`, reusing `render_goal`; skips `mark_absent` placeholder rows.
- `GET /stats/goals/history` — cached, JWT-gated.

## Frontend
- `GoalHistory.vue` — collapsible, grouped by year, per-month progress bar + **Hit / Missed / Active** badge (current period shows Active, not Missed).
- `useGoalHistory` composable — lazy-loads on first expand (no-op thereafter).

## Tests
- Repo `list_goals` (filters + ordering); `build_goal_history` (achieved-from-runs beats cached, hit/miss, yearly-sum, placeholder skip, missing-month → 0); `/stats/goals/history` route (periods + achieved, empty when no source); `GoalHistory` component (collapse, lazy-expand emit, grouping, badges, loading/empty).
- Backend suite: 193 passed. Frontend GoalHistory: 6/6.
- Verified `build_goal_history` against real local data — 5 periods, exact achieved (Apr/May hit, Jun 96.8% missed, yearly 57.5%).

Note: `useUserPreferences` / `useSync` frontend tests are red on `main` (pre-existing, unrelated; not gated by CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)