### PR TITLE
feat: TODAY tile shows non-running metrics only (SB-226)

### DIFF
--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -45,13 +45,13 @@
       </div>
 
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
-        <TodayCard :goals="metricGoals" :types="metricTypes" @create="showNewGoal = true" />
+        <TodayCard :goals="trainingGoals" :types="trainingTypes" @create="showNewGoal = true" />
         <QuickLog :types="metricTypes" @logged="loadMetricGoals" />
       </div>
 
       <NewGoalForm
         :show="showNewGoal"
-        :types="metricTypes"
+        :types="trainingTypes"
         @created="onGoalCreated"
         @cancel="showNewGoal = false"
       />
@@ -183,6 +183,18 @@ const {
   loadGoals: loadMetricGoals,
 } = useMetrics()
 const { unit } = useUserPreferences()
+
+// Split goals by domain (SB-226): running is owned by the SmashRun GOALS card
+// (+ the streak hero), so the native TODAY tile shows only non-running metrics
+// (push-ups, body-weight, cross-training). We also drop running_distance from
+// the "+ New goal" picker so the overlap can't be recreated.
+const NON_RUNNING_METRIC = 'running_distance'
+const trainingGoals = computed(() =>
+  metricGoals.value.filter((g) => g.goal.metric_key !== NON_RUNNING_METRIC),
+)
+const trainingTypes = computed(() =>
+  metricTypes.value.filter((t) => t.key !== NON_RUNNING_METRIC),
+)
 
 const showNewGoal = ref(false)
 const onGoalCreated = async () => {


### PR DESCRIPTION
Fixes SB-226. First slice of "split goal systems by domain."

## Problem
Two goal systems rendered at once and confused the user:
- **GOALS card** — SmashRun running goals (everyday + distance).
- **TODAY tile** — native metric goals, which *duplicated* running as `3×/wk`, `4×/mo`, `monthly`, and a **streak** row showing a nonsense **2581%** (streak 800 ÷ target 31).

Running is already fully covered by the GOALS card + streak hero, so the native running goals were pure noise.

## Change
Split by domain: **TODAY now shows only non-running native metrics** (push-ups, body-weight, cross-training). Filter `running_distance` out of:
- the goals passed to `TodayCard`, and
- the types passed to the "+ New goal" picker (so the overlap can't be recreated).

Done at a single `DashboardView` seam (`trainingGoals` / `trainingTypes` computeds). Also removes the buggy streak row for free. GOALS card + Goal history unchanged.

## Verify
SB user's 6 metric goals → 4 `running_distance` rows filtered out → TODAY shows Push-ups + Body weight only; no 2581% row.

Typecheck + build clean.

## Follow-up (in SB-226)
North-star (unify vs keep-split) is a later decision. Optional cleanup: delete the 4 inert native `running_distance` goals from prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)