### PR TITLE
feat: Sync now force-refreshes goals, bypassing staleness TTL (SB-222)

### DIFF
--- a/backend/routes/sync.py
+++ b/backend/routes/sync.py
@@ -89,9 +89,13 @@ def run_user_sync(
     since: date | None = None,
     until: date | None = None,
     full: bool = False,
+    force_goals: bool = False,
 ) -> dict[str, Any]:
     """Synchronous core sync routine — invoked by both the HTTP endpoint and
     the K8s CronJob entry point in ``backend/jobs/sync_runs.py``.
+
+    ``force_goals=True`` re-fetches current goals ignoring their staleness TTL;
+    the HTTP "Sync now" sets it, the cron path leaves it False.
     """
     if full:
         since_date = date(2010, 1, 1)
@@ -150,6 +154,7 @@ def run_user_sync(
                 api=api,
                 goals_repo=goals_repo,
                 settings=settings,
+                force=force_goals,
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning(f"Goal sync failed for source {source_id}: {exc}")
@@ -222,6 +227,7 @@ def sync_current_goals(
     api: SmashRunAPIClient,
     goals_repo: GoalsRepository,
     settings: Settings,
+    force: bool = False,
 ) -> None:
     """Refresh current-year and current-month goals from SmashRun if stale.
 
@@ -230,6 +236,10 @@ def sync_current_goals(
     so we don't re-fetch the same goal every sync. Periods with no goal set on
     SmashRun are recorded as "absent" via :meth:`GoalsRepository.mark_absent`
     so we don't keep hammering the API.
+
+    ``force=True`` (a user-triggered "Sync now") ignores the TTL and always
+    re-fetches, so a goal set *after* an "absent" mark shows up immediately
+    instead of waiting out the staleness window. The cron path leaves it False.
     """
     today = date.today()
     yearly_ttl = timedelta(days=settings.goal_yearly_staleness_days)
@@ -244,7 +254,7 @@ def sync_current_goals(
         label = f"{year}" if month is None else f"{year}/{month}"
         existing = goals_repo.get_by_period(user_id, source_id, year, month)
 
-        if not goals_repo.is_stale(existing, ttl):
+        if not force and not goals_repo.is_stale(existing, ttl):
             logger.debug(f"Goal {label} is fresh, skipping fetch")
             continue
 
@@ -270,7 +280,10 @@ async def sync_user(
     until = date.fromisoformat(body["until"]) if body.get("until") else None
     full = bool(body.get("full"))
 
-    result = run_user_sync(user_id, since=since, until=until, full=full)
+    # This endpoint is always a user-initiated "Sync now", so force a goal
+    # re-fetch — a goal set after an "absent" mark should appear immediately,
+    # not wait out the staleness TTL (that TTL only guards the cron path).
+    result = run_user_sync(user_id, since=since, until=until, full=full, force_goals=True)
     await invalidate_user(user_id)
     return result
 

--- a/backend/tests/test_sync_goals.py
+++ b/backend/tests/test_sync_goals.py
@@ -60,6 +60,26 @@ def test_fresh_row_skips_api_call() -> None:
     repo.mark_absent.assert_not_called()
 
 
+def test_force_refetches_even_when_fresh() -> None:
+    """force=True (a user 'Sync now') ignores the TTL and re-fetches anyway,
+    so a goal set after an 'absent' mark shows up immediately (SB-222)."""
+    user_id, source_id = uuid4(), uuid4()
+    now = datetime.now(UTC)
+    api = MagicMock()
+    api.get_goal.side_effect = [
+        Goal(year=now.year, goal_km=1000.0, progress_km=500.0),
+        Goal(year=now.year, month=now.month, goal_km=80.0, progress_km=20.0),
+    ]
+    repo = MagicMock()
+    repo.get_by_period.return_value = {"fetched_at": now.isoformat()}
+    repo.is_stale.return_value = False  # fresh — would normally skip
+
+    sync_current_goals(user_id, source_id, api, repo, _settings(), force=True)
+
+    assert api.get_goal.call_count == 2  # both periods fetched despite freshness
+    assert repo.upsert.call_count == 2
+
+
 def test_smashrun_returns_none_marks_absent() -> None:
     """SmashRun reports no goal set → mark_absent so we don't re-fetch."""
     user_id, source_id = uuid4(), uuid4()
@@ -110,6 +130,36 @@ def test_run_user_sync_swallows_goal_failure() -> None:
 
     assert result["runs_synced"] == 0
     assert result["message"] == "Sync completed"
+
+
+def test_run_user_sync_threads_force_goals() -> None:
+    """run_user_sync(force_goals=True) passes force=True to sync_current_goals;
+    the default leaves it False (cron path keeps the TTL)."""
+    user_id, source_id = uuid4(), uuid4()
+
+    token_repo = MagicMock()
+    token_repo.get_source_id_for_user.return_value = source_id
+    token_repo.get_user_tokens.return_value = {"access_token": "tok", "refresh_token": "ref"}
+    token_repo.is_token_expired.return_value = False
+
+    api = MagicMock()
+    api.get_all_activities_since.return_value = []
+    api_ctx = MagicMock()
+    api_ctx.__enter__ = MagicMock(return_value=api)
+    api_ctx.__exit__ = MagicMock(return_value=False)
+
+    for force_goals, expected in [(True, True), (False, False)]:
+        goal_sync = MagicMock()
+        with (
+            patch("backend.routes.sync.get_supabase_client", return_value=MagicMock()),
+            patch("backend.routes.sync.RunsRepository"),
+            patch("backend.routes.sync.TokenRepository", return_value=token_repo),
+            patch("backend.routes.sync.GoalsRepository"),
+            patch("backend.routes.sync.SmashRunAPIClient", return_value=api_ctx),
+            patch("backend.routes.sync.sync_current_goals", goal_sync),
+        ):
+            run_user_sync(user_id, force_goals=force_goals)
+        assert goal_sync.call_args.kwargs["force"] is expected
 
 
 def test_settings_drive_per_period_ttl() -> None:


### PR DESCRIPTION
Fixes SB-222.

## Problem
Manual **Sync now** respected the goal staleness TTL (`goal_monthly_staleness_days`=3), so a monthly goal set *after* an "absent" mark stayed hidden for up to 3 days. Hit live 2026-07-02: the July 125-mi goal didn't show because July was marked absent on Jul 1 and stayed "fresh".

## Fix
Thread a `force` flag through the goal-refresh path:
- `sync_current_goals(..., force=False)` — skips `is_stale` when `force=True`, always re-fetching.
- `run_user_sync(..., force_goals=False)` — passes it through.
- `POST /sync-user` (always a user-initiated "Sync now") sets `force_goals=True`.

The cron path (`jobs/sync_runs.py` → `run_user_sync(user_id)`) keeps the default `False`, so the TTL still guards automated syncs — no extra SmashRun API load on the schedule.

No frontend change: the Sync button already calls `/sync-user`, which now forces goals server-side.

## Tests
- `force=True` re-fetches both periods even when fresh.
- `run_user_sync` threads `force_goals` both ways (True→force, False→TTL).
- Backend suite: 195 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)