### PR TITLE
feat: Admin tab v1 — issue coach invites + invite list (SB-223)

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -74,14 +74,16 @@ const auth = useAuthStore()
 const router = useRouter()
 const mobileMenuOpen = ref(false)
 
-const { isCoach, loadRoles } = useRoles()
+const { isCoach, isAdmin, loadRoles } = useRoles()
 const { myAthlete, loadMyAthlete } = useMyAthlete()
 
 // Coach link → coaches/admins (SB-189 P4-1). My Profile → linked athletes (SB-219).
+// Admin link → admins only (SB-223).
 const navLinks = computed(() => [
   { name: 'Dashboard', path: '/dashboard' },
   { name: 'Runs', path: '/runs' },
   ...(isCoach.value ? [{ name: 'Coach', path: '/coach' }] : []),
+  ...(isAdmin.value ? [{ name: 'Admin', path: '/admin' }] : []),
   ...(myAthlete.value ? [{ name: 'My Profile', path: '/profile' }] : []),
   { name: 'Settings', path: '/settings' },
 ])

--- a/frontend/src/composables/__tests__/useCoach.test.ts
+++ b/frontend/src/composables/__tests__/useCoach.test.ts
@@ -66,6 +66,45 @@ describe('useRoles / isCoach gating', () => {
     await loadRoles()
     expect(isCoach.value).toBe(false)
   })
+
+  it('isAdmin tracks is_admin only (not coach role)', async () => {
+    apiCallMock.mockResolvedValue({ roles: ['coach'], is_admin: false })
+    const { useRoles } = await freshModule()
+    const { isAdmin, loadRoles } = useRoles()
+    expect(isAdmin.value).toBe(false)
+    await loadRoles()
+    expect(isAdmin.value).toBe(false) // coach but not admin
+  })
+
+  it('isAdmin is true for an admin', async () => {
+    apiCallMock.mockResolvedValue({ roles: [], is_admin: true })
+    const { useRoles } = await freshModule()
+    const { isAdmin, loadRoles } = useRoles()
+    await loadRoles()
+    expect(isAdmin.value).toBe(true)
+  })
+})
+
+describe('coach invites (admin)', () => {
+  it('inviteCoach POSTs email + grant_role=coach and returns the invite', async () => {
+    const invite = { id: 'i1', token: 'tok123', email: 'c@x.com', grant_role: 'coach' }
+    apiCallMock.mockResolvedValue(invite)
+    const { inviteCoach } = await freshModule()
+    const result = await inviteCoach('c@x.com')
+    expect(result).toEqual(invite)
+    const [path, opts] = apiCallMock.mock.calls[0]
+    expect(path).toBe('/invites')
+    expect(opts.method).toBe('POST')
+    expect(JSON.parse(opts.body)).toEqual({ email: 'c@x.com', grant_role: 'coach' })
+  })
+
+  it('listInvites GETs /invites', async () => {
+    apiCallMock.mockResolvedValue([{ id: 'i1', token: 't', email: 'c@x.com' }])
+    const { listInvites } = await freshModule()
+    const result = await listInvites()
+    expect(apiCallMock).toHaveBeenCalledWith('/invites')
+    expect(result).toHaveLength(1)
+  })
 })
 
 describe('useCoach roster', () => {

--- a/frontend/src/composables/useCoach.ts
+++ b/frontend/src/composables/useCoach.ts
@@ -4,6 +4,7 @@ import type {
   Athlete,
   AthleteCreate,
   AthleteProfileUpdate,
+  Invite,
   MyRoles,
   WorkoutSession,
 } from '@/types/coach'
@@ -16,6 +17,8 @@ const rolesLoaded = ref(false)
 const isCoach = computed(
   () => !!roles.value && (roles.value.roles.includes('coach') || roles.value.is_admin),
 )
+
+const isAdmin = computed(() => !!roles.value?.is_admin)
 
 async function loadRoles(force = false): Promise<void> {
   if (rolesLoaded.value && !force) return
@@ -69,6 +72,20 @@ export async function inviteAthlete(email: string, athleteId: string): Promise<{
     method: 'POST',
     body: JSON.stringify({ email, athlete_id: athleteId }),
   })
+}
+
+/** Issue a coach invite (admin-only). Redeeming grants the coach role. Returns
+ *  the invite incl. token; the caller builds the /signup?invite=<token> link. */
+export async function inviteCoach(email: string): Promise<Invite> {
+  return apiCall<Invite>('/invites', {
+    method: 'POST',
+    body: JSON.stringify({ email, grant_role: 'coach' }),
+  })
+}
+
+/** List invites the caller has issued (admin-only). */
+export async function listInvites(): Promise<Invite[]> {
+  return apiCall<Invite[]>('/invites')
 }
 
 /** Add an existing user (by email) as a coach of the athlete. 404 if the email
@@ -145,5 +162,5 @@ export function useAthleteDetail(athleteId: string) {
 }
 
 export function useRoles() {
-  return { roles, isCoach, loadRoles }
+  return { roles, isCoach, isAdmin, loadRoles }
 }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -55,6 +55,12 @@ const router = createRouter({
       meta: { requiresAuth: true },
     },
     {
+      path: '/admin',
+      name: 'admin',
+      component: () => import('@/views/AdminView.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
       path: '/coach/:athleteId',
       name: 'athlete-detail',
       component: () => import('@/views/AthleteDetailView.vue'),

--- a/frontend/src/types/coach.ts
+++ b/frontend/src/types/coach.ts
@@ -3,6 +3,19 @@ export interface MyRoles {
   is_admin: boolean
 }
 
+export interface Invite {
+  id: string
+  token: string
+  email: string
+  created_by: string | null
+  expires_at: string
+  grant_role: string | null
+  athlete_id: string | null
+  redeemed_at: string | null
+  redeemed_by: string | null
+  created_at: string
+}
+
 export interface AthleteProfile {
   sport: string | null
   position: string | null

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -1,0 +1,174 @@
+<template>
+  <div class="container-app py-8">
+    <div class="mb-6">
+      <h1 class="text-2xl font-bold text-gray-900">Admin</h1>
+      <p class="text-sm text-gray-500 mt-1">Issue coach invites and review issued invites.</p>
+    </div>
+
+    <!-- Issue a coach invite -->
+    <div class="bg-white rounded-2xl border border-gray-100 shadow-sm p-6 space-y-4 mb-6">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-400">Invite a coach</h2>
+      <form class="flex flex-wrap items-center gap-2" @submit.prevent="doInvite">
+        <input
+          v-model="inviteEmail"
+          type="email"
+          required
+          placeholder="coach's email"
+          class="form-input flex-1 min-w-48"
+        />
+        <button type="submit" :disabled="inviting" class="btn-primary text-sm">
+          {{ inviting ? 'Inviting…' : 'Invite coach' }}
+        </button>
+      </form>
+
+      <div
+        v-if="inviteLink"
+        class="text-xs text-gray-600 bg-gray-50 border border-gray-200 rounded-lg p-3"
+      >
+        <p class="mb-1 font-medium text-gray-700">Send this link:</p>
+        <div class="flex items-center gap-2">
+          <code class="flex-1 break-all">{{ inviteLink }}</code>
+          <button type="button" class="btn-secondary text-xs" @click="copy(inviteLink)">
+            {{ copiedLink === inviteLink ? 'Copied' : 'Copy' }}
+          </button>
+        </div>
+      </div>
+
+      <div
+        v-if="error"
+        class="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-3 py-2"
+      >
+        {{ error }}
+      </div>
+    </div>
+
+    <!-- Issued invites -->
+    <div class="bg-white rounded-2xl border border-gray-100 shadow-sm p-6">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-400 mb-4">
+        Issued invites
+      </h2>
+
+      <div v-if="loading" class="space-y-2">
+        <div v-for="i in 3" :key="i" class="h-10 bg-gray-50 rounded-lg animate-pulse" />
+      </div>
+
+      <p v-else-if="invites.length === 0" class="text-sm text-gray-500">No invites issued yet.</p>
+
+      <table v-else class="w-full text-sm">
+        <thead>
+          <tr class="text-left text-xs uppercase tracking-wide text-gray-400 border-b border-gray-100">
+            <th class="py-2 pr-2 font-medium">Email</th>
+            <th class="py-2 px-2 font-medium">Role</th>
+            <th class="py-2 px-2 font-medium">Status</th>
+            <th class="py-2 px-2 font-medium">Expires</th>
+            <th class="py-2 pl-2 font-medium text-right">Link</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="inv in invites" :key="inv.id" class="border-b border-gray-50 last:border-0">
+            <td class="py-2 pr-2 text-gray-800 break-all">{{ inv.email }}</td>
+            <td class="py-2 px-2 text-gray-600">{{ inv.grant_role ?? 'athlete' }}</td>
+            <td class="py-2 px-2">
+              <span :class="statusClass(inv)">{{ statusLabel(inv) }}</span>
+            </td>
+            <td class="py-2 px-2 text-gray-500 whitespace-nowrap">{{ formatDate(inv.expires_at) }}</td>
+            <td class="py-2 pl-2 text-right">
+              <button
+                v-if="statusLabel(inv) === 'Pending'"
+                type="button"
+                class="btn-secondary text-xs"
+                @click="copy(linkFor(inv))"
+              >
+                {{ copiedLink === linkFor(inv) ? 'Copied' : 'Copy' }}
+              </button>
+              <span v-else class="text-gray-300">—</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { inviteCoach, listInvites, useRoles } from '@/composables/useCoach'
+import type { Invite } from '@/types/coach'
+
+const router = useRouter()
+const { isAdmin, loadRoles } = useRoles()
+
+const inviteEmail = ref('')
+const inviting = ref(false)
+const inviteLink = ref('')
+const copiedLink = ref('')
+
+const invites = ref<Invite[]>([])
+const loading = ref(true)
+const error = ref<string | null>(null)
+
+const linkFor = (inv: Invite): string => `${window.location.origin}/signup?invite=${inv.token}`
+
+const copy = async (text: string) => {
+  await navigator.clipboard?.writeText(text)
+  copiedLink.value = text
+  setTimeout(() => (copiedLink.value = ''), 2000)
+}
+
+const statusLabel = (inv: Invite): string => {
+  if (inv.redeemed_at) return 'Redeemed'
+  if (new Date(inv.expires_at).getTime() < Date.now()) return 'Expired'
+  return 'Pending'
+}
+
+const statusClass = (inv: Invite): string => {
+  const base = 'inline-block px-1.5 py-0.5 rounded text-[10px] font-medium '
+  const s = statusLabel(inv)
+  if (s === 'Redeemed') return base + 'bg-green-100 text-green-700'
+  if (s === 'Expired') return base + 'bg-gray-100 text-gray-500'
+  return base + 'bg-blue-100 text-blue-700'
+}
+
+const formatDate = (iso: string): string =>
+  new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+
+const loadList = async () => {
+  loading.value = true
+  error.value = null
+  try {
+    invites.value = await listInvites()
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to load invites'
+  } finally {
+    loading.value = false
+  }
+}
+
+const doInvite = async () => {
+  inviting.value = true
+  error.value = null
+  inviteLink.value = ''
+  try {
+    const invite = await inviteCoach(inviteEmail.value)
+    inviteLink.value = linkFor(invite)
+    inviteEmail.value = ''
+    await loadList()
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to create invite'
+  } finally {
+    inviting.value = false
+  }
+}
+
+onMounted(async () => {
+  // Admin-only page: the nav link is hidden for non-admins, but guard direct
+  // URL access too. Roles are cached app-wide; refetch to be safe, then bounce.
+  await loadRoles()
+  if (!isAdmin.value) {
+    router.replace('/dashboard')
+    return
+  }
+  await loadList()
+})
+</script>

--- a/frontend/src/views/__tests__/AdminView.test.ts
+++ b/frontend/src/views/__tests__/AdminView.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import AdminView from '../AdminView.vue'
+
+// Hoisted mocks (vi.mock is hoisted above imports).
+const h = vi.hoisted(() => ({
+  inviteCoach: vi.fn(),
+  listInvites: vi.fn(),
+  loadRoles: vi.fn().mockResolvedValue(undefined),
+  replace: vi.fn(),
+  isAdmin: { value: true },
+}))
+
+vi.mock('@/composables/useCoach', () => ({
+  useRoles: () => ({ isAdmin: h.isAdmin, loadRoles: h.loadRoles }),
+  inviteCoach: (...a: unknown[]) => h.inviteCoach(...a),
+  listInvites: () => h.listInvites(),
+}))
+
+vi.mock('vue-router', () => ({ useRouter: () => ({ replace: h.replace }) }))
+
+const invite = (over: Record<string, unknown> = {}) => ({
+  id: 'i1',
+  token: 'tok123',
+  email: 'coach@x.com',
+  created_by: 'admin',
+  expires_at: '2099-01-01T00:00:00Z',
+  grant_role: 'coach',
+  athlete_id: null,
+  redeemed_at: null,
+  redeemed_by: null,
+  created_at: '2026-07-01T00:00:00Z',
+  ...over,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.isAdmin.value = true
+  h.listInvites.mockResolvedValue([])
+})
+
+describe('AdminView', () => {
+  it('redirects non-admins to the dashboard', async () => {
+    h.isAdmin.value = false
+    mount(AdminView)
+    await flushPromises()
+    expect(h.replace).toHaveBeenCalledWith('/dashboard')
+    expect(h.listInvites).not.toHaveBeenCalled()
+  })
+
+  it('renders the invite form and issued invites for an admin', async () => {
+    h.listInvites.mockResolvedValue([invite(), invite({ id: 'i2', email: 'b@x.com', redeemed_at: '2026-07-02T00:00:00Z' })])
+    const w = mount(AdminView)
+    await flushPromises()
+    expect(h.replace).not.toHaveBeenCalled()
+    expect(w.text()).toContain('Invite a coach')
+    expect(w.text()).toContain('coach@x.com')
+    expect(w.text()).toContain('Pending') // active invite
+    expect(w.text()).toContain('Redeemed') // redeemed invite
+  })
+
+  it('issues a coach invite and shows the copyable link', async () => {
+    h.inviteCoach.mockResolvedValue(invite({ token: 'newtok' }))
+    const w = mount(AdminView)
+    await flushPromises()
+
+    await w.find('input[type="email"]').setValue('coach@x.com')
+    await w.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(h.inviteCoach).toHaveBeenCalledWith('coach@x.com')
+    expect(w.text()).toContain('/signup?invite=newtok')
+    // list refreshed after issuing (once on mount, once after invite)
+    expect(h.listInvites).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
Fixes SB-223.

## Summary
Admin-only tab that completes the onboarding loop: athletes are invited from the coach view (SB-219); **coaches get invited from Admin**. Backend already supports this — `POST /invites {grant_role:"coach"}` (no `athlete_id`) is admin-gated, and `GET /invites` lists the caller's invites. This is the frontend.

## Changes
- **useCoach**: `isAdmin` computed (exported from `useRoles`), `inviteCoach(email)` → `POST /invites {grant_role:"coach"}`, `listInvites()` → `GET /invites`; `Invite` type.
- **AppHeader**: Admin nav link gated on `isAdmin` (desktop + mobile), riding the existing refetch-roles-on-login watch.
- **router**: `/admin` route (`requiresAuth`).
- **AdminView**: issue a coach invite → copyable `/signup?invite=<token>` link; a table of issued invites (email · role · **Pending/Redeemed/Expired** · expiry · copy-link for pending). In-view admin guard redirects non-admins (nav link is already hidden for them).

## Tests
- `useCoach`: `isAdmin` (admin-only, not coach), `inviteCoach` payload, `listInvites`.
- `AdminView`: non-admin redirect, admin renders form + invites, issuing shows the link + refreshes the list.
- Typecheck + build clean. +7 new passing tests, no new failures.

## Later (noted in SB-223)
User/role management (list-users + revoke), all-athletes overview, sync/health.

🤖 Generated with [Claude Code](https://claude.com/claude-code)