### PR TITLE
fix(security): RLS owner-only — drop anon read hole on users/sync_history

### DIFF
--- a/supabase/migrations/20260704020000_rls_owner_only_no_anon_leak.sql
+++ b/supabase/migrations/20260704020000_rls_owner_only_no_anon_leak.sql
@@ -1,0 +1,44 @@
+-- Security fix: remove the `OR auth.uid() IS NULL` escape hatch from the RLS
+-- policies added in 20260704010000_fix_security_advisor.sql.
+--
+-- The problem: `auth.uid()` is NULL for the anon (unauthenticated) role, so
+-- `USING (user_id = auth.uid() OR auth.uid() IS NULL)` evaluates to TRUE for any
+-- anonymous caller — RLS then lets anon read the ENTIRE users table (every
+-- email) and all sync_history. On Supabase-hosted prod the anon role holds the
+-- default SELECT grant on public tables, and the anon key is public (it ships in
+-- the frontend bundle for supabase.auth.*), so this exposed all user emails to
+-- anyone. (Local dev didn't show it only because anon lacks the table grant.)
+--
+-- The clause was never needed: the backend uses the service-role key, which
+-- BYPASSES RLS entirely — it doesn't consult these policies at all. Removing the
+-- clause makes the policies genuinely owner-only. Authenticated users already
+-- resolve to their own row (auth.uid() = their uid); anon now matches nothing.
+--
+-- IDEMPOTENT: DROP IF EXISTS + CREATE. Safe to re-run; a no-op once applied.
+
+-- =====================================================
+-- users — owner-only
+-- =====================================================
+
+DROP POLICY IF EXISTS "Users can view their own profile" ON users;
+CREATE POLICY "Users can view their own profile"
+    ON users FOR SELECT
+    USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "Users can update their own profile" ON users;
+CREATE POLICY "Users can update their own profile"
+    ON users FOR UPDATE
+    USING (user_id = auth.uid());
+
+-- =====================================================
+-- sync_history — owner-only (via the user's sources)
+-- =====================================================
+
+DROP POLICY IF EXISTS "Users can view their own sync history" ON sync_history;
+CREATE POLICY "Users can view their own sync history"
+    ON sync_history FOR SELECT
+    USING (
+        source_id IN (
+            SELECT id FROM user_sources WHERE user_id = auth.uid()
+        )
+    );

--- a/supabase/migrations/20260704020000_rls_owner_only_no_anon_leak.sql
+++ b/supabase/migrations/20260704020000_rls_owner_only_no_anon_leak.sql
@@ -28,7 +28,8 @@ CREATE POLICY "Users can view their own profile"
 DROP POLICY IF EXISTS "Users can update their own profile" ON users;
 CREATE POLICY "Users can update their own profile"
     ON users FOR UPDATE
-    USING (user_id = auth.uid());
+    USING (user_id = auth.uid())
+    WITH CHECK (user_id = auth.uid());  -- explicit: post-update row stays owned
 
 -- =====================================================
 -- sync_history — owner-only (via the user's sources)


### PR DESCRIPTION
## Problem
`20260704010000_fix_security_advisor.sql` enabled RLS on `users` + `sync_history`, but every policy OR'd in `auth.uid() IS NULL`:

```sql
USING (user_id = auth.uid() OR auth.uid() IS NULL)
```

`auth.uid()` is **NULL for the anon role**, so the policy is `TRUE` for any unauthenticated caller. On Supabase-hosted prod, `anon` holds the default SELECT grant on public tables and the **anon key is public** (it ships in the frontend bundle for `supabase.auth.*`), so anyone could `GET /rest/v1/users?select=email` and read **every user's email** — plus all `sync_history`. (Local dev hid it only because anon lacks the table grant.)

The clause was never needed: the backend uses the **service-role key, which bypasses RLS entirely**. It only opened the anon door.

## Fix
Drop `OR auth.uid() IS NULL` from all three policies → genuinely owner-only.

## Verified locally (simulating prod's anon/authenticated grants)
| Caller | Rows | Expected |
|---|---|---|
| anon (null uid) | 0 | blocked ✓ |
| owner (own uid) | 1 | own row ✓ |
| stranger uid | 0 | blocked ✓ |
| service role | all | bypass intact ✓ |

Frontend never queries these tables via anon (backend API only) — no app impact. Idempotent (DROP IF EXISTS + CREATE).

Pre-existing exposure (prior migration codified prod's manual state); this closes it on prod + every fresh DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)