### PR TITLE
feat: exercise search/select component + catalog view (SB-228 D2)

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -83,6 +83,7 @@ const navLinks = computed(() => [
   { name: 'Dashboard', path: '/dashboard' },
   { name: 'Runs', path: '/runs' },
   ...(isCoach.value ? [{ name: 'Coach', path: '/coach' }] : []),
+  ...(isCoach.value ? [{ name: 'Catalog', path: '/exercises' }] : []),
   ...(isAdmin.value ? [{ name: 'Admin', path: '/admin' }] : []),
   ...(myAthlete.value ? [{ name: 'My Profile', path: '/profile' }] : []),
   { name: 'Settings', path: '/settings' },

--- a/frontend/src/components/ExercisePicker.vue
+++ b/frontend/src/components/ExercisePicker.vue
@@ -1,0 +1,260 @@
+<template>
+  <div class="space-y-4">
+    <!-- Search -->
+    <div class="relative">
+      <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+      <input
+        ref="searchEl"
+        v-model="query"
+        type="text"
+        placeholder="Search exercises… (name or alias)"
+        class="form-input w-full pl-9"
+        data-testid="exercise-search"
+      />
+    </div>
+
+    <!-- Balance nudge (programming assistant) -->
+    <div
+      v-for="msg in nudges"
+      :key="msg"
+      class="flex items-start gap-2 text-xs bg-amber-50 border border-amber-200 text-amber-800 rounded-lg px-3 py-2"
+      data-testid="balance-nudge"
+    >
+      <Scale class="w-3.5 h-3.5 mt-0.5 shrink-0" /> {{ msg }}
+    </div>
+
+    <!-- Facets -->
+    <div class="flex flex-wrap gap-1.5">
+      <button
+        v-for="opt in ownershipFacets"
+        :key="opt.value"
+        type="button"
+        class="chip"
+        :class="ownership === opt.value ? 'chip-on' : 'chip-off'"
+        @click="ownership = opt.value"
+      >
+        {{ opt.label }}
+      </button>
+      <span class="w-px bg-gray-200 mx-1" />
+      <button
+        v-for="p in patternFacets"
+        :key="p"
+        type="button"
+        class="chip"
+        :class="patternFilter === p ? 'chip-on' : 'chip-off'"
+        @click="patternFilter = patternFilter === p ? null : p"
+      >
+        {{ p }}
+      </button>
+    </div>
+
+    <!-- Results -->
+    <div v-if="filtered.length" class="grid grid-cols-1 sm:grid-cols-2 gap-2" data-testid="results">
+      <button
+        v-for="ex in filtered"
+        :key="ex.key"
+        type="button"
+        class="text-left rounded-xl border p-3 transition hover:border-brand-400"
+        :class="isSelected(ex) ? 'border-brand-500 bg-brand-50' : 'border-gray-200 bg-white'"
+        :data-testid="`ex-${ex.key}`"
+        @click="onCard(ex)"
+      >
+        <div class="flex items-start justify-between gap-2">
+          <span class="text-sm font-medium text-gray-900">{{ ex.display_name }}</span>
+          <Check v-if="isSelected(ex)" class="w-4 h-4 text-brand-600 shrink-0" />
+        </div>
+        <div class="mt-1 flex flex-wrap items-center gap-1 text-[10px]">
+          <span class="tag">{{ ex.category }}</span>
+          <span v-if="ex.movement_pattern" class="tag">{{ ex.movement_pattern }}</span>
+          <span v-for="eq in ex.equipment" :key="eq" class="tag-muted">{{ eq }}</span>
+          <span v-if="ex.owner_id" class="tag-mine">Mine</span>
+          <span v-if="ex.visibility === 'private'" class="tag-private">Private</span>
+        </div>
+        <p v-if="ex.cues.length" class="mt-1 text-[11px] text-gray-500 line-clamp-1">
+          {{ ex.cues.join(' · ') }}
+        </p>
+        <button
+          v-if="mode === 'manage' && ex.owner_id && ex.visibility === 'private'"
+          type="button"
+          class="mt-2 btn-secondary text-[11px]"
+          :data-testid="`publish-${ex.key}`"
+          @click.stop="$emit('publish', ex.key)"
+        >
+          Publish to library
+        </button>
+      </button>
+    </div>
+
+    <!-- Empty → create -->
+    <div
+      v-else
+      class="text-sm text-gray-500 bg-gray-50 border border-gray-200 rounded-xl p-4"
+      data-testid="empty"
+    >
+      No match<span v-if="query"> for "{{ query }}"</span>.
+      <button type="button" class="text-brand-600 font-medium" @click="openCreate">
+        Create a new exercise
+      </button>
+    </div>
+
+    <!-- Inline create -->
+    <form
+      v-if="showCreate"
+      class="bg-white border border-gray-200 rounded-xl p-4 space-y-3"
+      data-testid="create-form"
+      @submit.prevent="submitCreate"
+    >
+      <p class="text-xs font-semibold uppercase tracking-wide text-gray-400">New exercise</p>
+      <input
+        v-model="form.display_name"
+        required
+        placeholder="Name"
+        class="form-input w-full"
+        data-testid="create-name"
+      />
+      <div class="grid grid-cols-2 gap-2">
+        <select v-model="form.category" class="form-input" data-testid="create-category">
+          <option v-for="c in CATEGORIES" :key="c" :value="c">{{ c }}</option>
+        </select>
+        <select v-model="form.movement_pattern" class="form-input" data-testid="create-pattern">
+          <option :value="null">— movement —</option>
+          <option v-for="p in PATTERNS" :key="p" :value="p">{{ p }}</option>
+        </select>
+      </div>
+      <label class="flex items-center gap-2 text-xs text-gray-600">
+        <input v-model="publishNow" type="checkbox" data-testid="create-public" />
+        Add to the shared public library (otherwise private to you)
+      </label>
+      <button type="submit" class="btn-primary text-sm" data-testid="create-submit">
+        Create exercise
+      </button>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onMounted, ref } from 'vue'
+import { Check, Scale, Search } from 'lucide-vue-next'
+import type { Exercise, ExerciseCategory, ExerciseCreate, MovementPattern } from '@/types/workout'
+import { balanceNudges } from '@/utils/exerciseBalance'
+
+const props = withDefaults(
+  defineProps<{
+    exercises: Exercise[]
+    selectedKeys?: string[]
+    mode?: 'select' | 'manage'
+  }>(),
+  { selectedKeys: () => [], mode: 'select' },
+)
+
+const emit = defineEmits<{
+  (e: 'toggle', exercise: Exercise): void
+  (e: 'create', payload: ExerciseCreate): void
+  (e: 'publish', key: string): void
+}>()
+
+const CATEGORIES: ExerciseCategory[] = ['strength', 'speed', 'power', 'mobility', 'cardio', 'test']
+const PATTERNS: MovementPattern[] = [
+  'squat', 'hinge', 'lunge', 'push', 'pull', 'carry',
+  'rotation', 'anti_rotation', 'jump', 'sprint', 'isometric', 'mobility', 'other',
+]
+
+const searchEl = ref<HTMLInputElement | null>(null)
+const query = ref('')
+const ownership = ref<'all' | 'mine' | 'public'>('all')
+const patternFilter = ref<MovementPattern | null>(null)
+
+const ownershipFacets = [
+  { value: 'all' as const, label: 'All' },
+  { value: 'mine' as const, label: 'Mine' },
+  { value: 'public' as const, label: 'Public' },
+]
+
+// Only offer pattern chips actually present in the catalog.
+const patternFacets = computed(() => {
+  const present = new Set<MovementPattern>()
+  for (const ex of props.exercises) if (ex.movement_pattern) present.add(ex.movement_pattern)
+  return PATTERNS.filter((p) => present.has(p))
+})
+
+const isSelected = (ex: Exercise): boolean => props.selectedKeys.includes(ex.key)
+
+const filtered = computed<Exercise[]>(() => {
+  const q = query.value.trim().toLowerCase()
+  return props.exercises.filter((ex) => {
+    if (ownership.value === 'mine' && !ex.owner_id) return false
+    if (ownership.value === 'public' && ex.visibility !== 'public') return false
+    if (patternFilter.value && ex.movement_pattern !== patternFilter.value) return false
+    if (!q) return true
+    const hay = [ex.display_name, ...(ex.aliases ?? [])].map((s) => s.toLowerCase())
+    return hay.some((h) => h.includes(q))
+  })
+})
+
+const nudges = computed<string[]>(() => {
+  if (!props.selectedKeys.length) return []
+  const selected = props.exercises.filter((ex) => props.selectedKeys.includes(ex.key))
+  return balanceNudges(selected)
+})
+
+const onCard = (ex: Exercise): void => {
+  if (props.mode === 'select') emit('toggle', ex)
+}
+
+// --- inline create ---
+const showCreate = ref(false)
+const publishNow = ref(false)
+const form = ref<{
+  display_name: string
+  category: ExerciseCategory
+  movement_pattern: MovementPattern | null
+}>({ display_name: '', category: 'strength', movement_pattern: null })
+
+const openCreate = (): void => {
+  form.value.display_name = query.value
+  showCreate.value = true
+}
+
+const submitCreate = (): void => {
+  const payload: ExerciseCreate = {
+    display_name: form.value.display_name.trim(),
+    category: form.value.category,
+    movement_pattern: form.value.movement_pattern,
+    visibility: publishNow.value ? 'public' : 'private',
+  }
+  if (!payload.display_name) return
+  emit('create', payload)
+  showCreate.value = false
+  form.value = { display_name: '', category: 'strength', movement_pattern: null }
+  publishNow.value = false
+}
+
+onMounted(async () => {
+  await nextTick()
+  searchEl.value?.focus()
+})
+</script>
+
+<style scoped>
+.chip {
+  @apply px-2 py-0.5 rounded-full text-xs font-medium border transition;
+}
+.chip-on {
+  @apply bg-brand-600 text-white border-brand-600;
+}
+.chip-off {
+  @apply bg-white text-gray-600 border-gray-200 hover:border-gray-300;
+}
+.tag {
+  @apply px-1.5 py-0.5 rounded bg-gray-100 text-gray-600;
+}
+.tag-muted {
+  @apply px-1.5 py-0.5 rounded bg-gray-50 text-gray-400;
+}
+.tag-mine {
+  @apply px-1.5 py-0.5 rounded bg-blue-100 text-blue-700;
+}
+.tag-private {
+  @apply px-1.5 py-0.5 rounded bg-amber-100 text-amber-700;
+}
+</style>

--- a/frontend/src/components/__tests__/ExercisePicker.test.ts
+++ b/frontend/src/components/__tests__/ExercisePicker.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ExercisePicker from '../ExercisePicker.vue'
+import type { Exercise, MovementPattern } from '@/types/workout'
+
+const make = (over: Partial<Exercise>): Exercise => ({
+  key: 'k',
+  display_name: 'X',
+  category: 'strength',
+  measures: [],
+  is_benchmark: false,
+  owner_id: null,
+  visibility: 'public',
+  created_by: null,
+  forked_from: null,
+  aliases: [],
+  movement_pattern: null,
+  equipment: [],
+  body_region: [],
+  laterality: null,
+  difficulty: null,
+  tags: [],
+  media_url: null,
+  thumbnail_url: null,
+  cues: [],
+  instructions: null,
+  ...over,
+})
+
+const catalog: Exercise[] = [
+  make({ key: 'pushups', display_name: 'Push-ups', movement_pattern: 'push', aliases: ['press-up'] }),
+  make({ key: 'plank', display_name: 'Plank', movement_pattern: 'isometric' }),
+  make({
+    key: 'goblet_squat',
+    display_name: 'Goblet Squat',
+    movement_pattern: 'squat',
+    visibility: 'private',
+    owner_id: 'u1',
+    aliases: ['kb squat'],
+  }),
+]
+
+const byText = (w: ReturnType<typeof mount>, text: string) =>
+  w.findAll('button').find((b) => b.text() === text)!
+
+const setSearch = (w: ReturnType<typeof mount>, v: string) =>
+  w.find('[data-testid="exercise-search"]').setValue(v)
+
+describe('ExercisePicker', () => {
+  it('renders all exercises by default', () => {
+    const w = mount(ExercisePicker, { props: { exercises: catalog } })
+    expect(w.find('[data-testid="ex-pushups"]').exists()).toBe(true)
+    expect(w.find('[data-testid="ex-plank"]').exists()).toBe(true)
+    expect(w.find('[data-testid="ex-goblet_squat"]').exists()).toBe(true)
+  })
+
+  it('search filters by display name', async () => {
+    const w = mount(ExercisePicker, { props: { exercises: catalog } })
+    await setSearch(w, 'goblet')
+    expect(w.find('[data-testid="ex-goblet_squat"]').exists()).toBe(true)
+    expect(w.find('[data-testid="ex-pushups"]').exists()).toBe(false)
+  })
+
+  it('search matches aliases', async () => {
+    const w = mount(ExercisePicker, { props: { exercises: catalog } })
+    await setSearch(w, 'press-up')
+    expect(w.find('[data-testid="ex-pushups"]').exists()).toBe(true)
+    expect(w.find('[data-testid="ex-goblet_squat"]').exists()).toBe(false)
+  })
+
+  it('ownership facet Mine shows only owned exercises', async () => {
+    const w = mount(ExercisePicker, { props: { exercises: catalog } })
+    await byText(w, 'Mine').trigger('click')
+    expect(w.find('[data-testid="ex-goblet_squat"]').exists()).toBe(true)
+    expect(w.find('[data-testid="ex-pushups"]').exists()).toBe(false)
+  })
+
+  it('ownership facet Public excludes private exercises', async () => {
+    const w = mount(ExercisePicker, { props: { exercises: catalog } })
+    await byText(w, 'Public').trigger('click')
+    expect(w.find('[data-testid="ex-goblet_squat"]').exists()).toBe(false)
+    expect(w.find('[data-testid="ex-pushups"]').exists()).toBe(true)
+  })
+
+  it('pattern facet filters to that movement', async () => {
+    const w = mount(ExercisePicker, { props: { exercises: catalog } })
+    await byText(w, 'push').trigger('click')
+    expect(w.find('[data-testid="ex-pushups"]').exists()).toBe(true)
+    expect(w.find('[data-testid="ex-plank"]').exists()).toBe(false)
+  })
+
+  it('shows a balance nudge when the selection is imbalanced', () => {
+    const w = mount(ExercisePicker, {
+      props: { exercises: catalog, selectedKeys: ['pushups'] }, // push, no pull
+    })
+    const nudge = w.find('[data-testid="balance-nudge"]')
+    expect(nudge.exists()).toBe(true)
+    expect(nudge.text()).toMatch(/pull/i)
+  })
+
+  it('no nudge without a selection', () => {
+    const w = mount(ExercisePicker, { props: { exercises: catalog } })
+    expect(w.find('[data-testid="balance-nudge"]').exists()).toBe(false)
+  })
+
+  it('clicking a card emits toggle in select mode', async () => {
+    const w = mount(ExercisePicker, { props: { exercises: catalog, mode: 'select' } })
+    await w.find('[data-testid="ex-pushups"]').trigger('click')
+    expect(w.emitted('toggle')?.[0]?.[0]).toMatchObject({ key: 'pushups' })
+  })
+
+  it('manage mode shows Publish on own private exercises and emits publish', async () => {
+    const w = mount(ExercisePicker, { props: { exercises: catalog, mode: 'manage' } })
+    const pub = w.find('[data-testid="publish-goblet_squat"]')
+    expect(pub.exists()).toBe(true)
+    // public exercise has no publish button
+    expect(w.find('[data-testid="publish-pushups"]').exists()).toBe(false)
+    await pub.trigger('click')
+    expect(w.emitted('publish')?.[0]).toEqual(['goblet_squat'])
+  })
+
+  it('select mode has no publish buttons', () => {
+    const w = mount(ExercisePicker, { props: { exercises: catalog, mode: 'select' } })
+    expect(w.find('[data-testid="publish-goblet_squat"]').exists()).toBe(false)
+  })
+
+  it('empty search offers create; submitting emits a private create payload prefilled from the query', async () => {
+    const w = mount(ExercisePicker, { props: { exercises: catalog } })
+    await setSearch(w, 'zzz new move')
+    expect(w.find('[data-testid="empty"]').exists()).toBe(true)
+    await w.find('[data-testid="empty"] button').trigger('click')
+    expect(w.find('[data-testid="create-form"]').exists()).toBe(true)
+    expect((w.find('[data-testid="create-name"]').element as HTMLInputElement).value).toBe('zzz new move')
+    await w.find('[data-testid="create-submit"]').trigger('submit')
+    const payload = w.emitted('create')?.[0]?.[0] as Record<string, unknown>
+    expect(payload).toMatchObject({ display_name: 'zzz new move', visibility: 'private' })
+  })
+
+  it('create with the public checkbox emits a public payload', async () => {
+    const w = mount(ExercisePicker, { props: { exercises: catalog } })
+    await setSearch(w, 'brand new')
+    await w.find('[data-testid="empty"] button').trigger('click')
+    await w.find('[data-testid="create-public"]').setValue(true)
+    await w.find('[data-testid="create-submit"]').trigger('submit')
+    const payload = w.emitted('create')?.[0]?.[0] as Record<string, unknown>
+    expect(payload).toMatchObject({ visibility: 'public' })
+  })
+})

--- a/frontend/src/composables/__tests__/useExercises.test.ts
+++ b/frontend/src/composables/__tests__/useExercises.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const apiCallMock = vi.fn()
+vi.mock('@/config/api', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+}))
+
+// Fresh module per test (mirrors useCoach tests) so nothing leaks between cases.
+async function freshModule() {
+  vi.resetModules()
+  return import('../useExercises')
+}
+
+const exercise = (over: Record<string, unknown> = {}) => ({
+  key: 'pushups',
+  display_name: 'Push-ups',
+  category: 'strength',
+  visibility: 'public',
+  owner_id: null,
+  ...over,
+})
+
+beforeEach(() => apiCallMock.mockReset())
+
+describe('useExercises', () => {
+  it('load populates the catalog', async () => {
+    apiCallMock.mockResolvedValue([exercise()])
+    const { useExercises } = await freshModule()
+    const { exercises, load } = useExercises()
+    await load()
+    expect(apiCallMock).toHaveBeenCalledWith('/workouts/exercises')
+    expect(exercises.value).toHaveLength(1)
+  })
+
+  it('create POSTs and appends the new exercise', async () => {
+    const created = exercise({ key: 'goblet_squat', display_name: 'Goblet Squat', visibility: 'private', owner_id: 'u1' })
+    apiCallMock.mockResolvedValue(created)
+    const { useExercises } = await freshModule()
+    const { exercises, create } = useExercises()
+    const result = await create({ display_name: 'Goblet Squat', category: 'strength' })
+    expect(result).toEqual(created)
+    expect(exercises.value).toContainEqual(created)
+    const [path, opts] = apiCallMock.mock.calls[0]
+    expect(path).toBe('/workouts/exercises')
+    expect(opts.method).toBe('POST')
+  })
+
+  it('publish POSTs to the publish endpoint and updates the row in place', async () => {
+    const priv = exercise({ key: 'goblet_squat', visibility: 'private', owner_id: 'u1' })
+    const pub = { ...priv, visibility: 'public' }
+    apiCallMock.mockResolvedValueOnce([priv]).mockResolvedValueOnce(pub)
+    const { useExercises } = await freshModule()
+    const { exercises, load, publish } = useExercises()
+    await load() // seeds [priv]
+    const result = await publish('goblet_squat')
+    expect(apiCallMock).toHaveBeenLastCalledWith('/workouts/exercises/goblet_squat/publish', {
+      method: 'POST',
+    })
+    expect(result?.visibility).toBe('public')
+    expect(exercises.value.find((e) => e.key === 'goblet_squat')?.visibility).toBe('public')
+  })
+})

--- a/frontend/src/composables/useExercises.ts
+++ b/frontend/src/composables/useExercises.ts
@@ -1,0 +1,57 @@
+import { ref } from 'vue'
+import { apiCall } from '@/config/api'
+import type { Exercise, ExerciseCreate } from '@/types/workout'
+
+/**
+ * The exercise catalog: the public library + the caller's own private exercises
+ * (backend `GET /workouts/exercises` returns exactly the visible set). Small
+ * enough to load once and search/filter client-side.
+ */
+export function useExercises() {
+  const exercises = ref<Exercise[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const load = async (): Promise<void> => {
+    loading.value = true
+    error.value = null
+    try {
+      exercises.value = await apiCall<Exercise[]>('/workouts/exercises')
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load exercises'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  const create = async (payload: ExerciseCreate): Promise<Exercise | null> => {
+    error.value = null
+    try {
+      const created = await apiCall<Exercise>('/workouts/exercises', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      })
+      exercises.value = [...exercises.value, created]
+      return created
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to create exercise'
+      return null
+    }
+  }
+
+  const publish = async (key: string): Promise<Exercise | null> => {
+    error.value = null
+    try {
+      const updated = await apiCall<Exercise>(`/workouts/exercises/${key}/publish`, {
+        method: 'POST',
+      })
+      exercises.value = exercises.value.map((e) => (e.key === key ? updated : e))
+      return updated
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to publish exercise'
+      return null
+    }
+  }
+
+  return { exercises, loading, error, load, create, publish }
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -67,6 +67,12 @@ const router = createRouter({
       meta: { requiresAuth: true },
     },
     {
+      path: '/exercises',
+      name: 'exercise-catalog',
+      component: () => import('@/views/ExerciseCatalogView.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
       path: '/profile',
       name: 'my-profile',
       component: () => import('@/views/MyProfileView.vue'),

--- a/frontend/src/types/workout.ts
+++ b/frontend/src/types/workout.ts
@@ -1,0 +1,52 @@
+export type ExerciseVisibility = 'private' | 'public'
+
+export type MovementPattern =
+  | 'squat'
+  | 'hinge'
+  | 'lunge'
+  | 'push'
+  | 'pull'
+  | 'carry'
+  | 'rotation'
+  | 'anti_rotation'
+  | 'jump'
+  | 'sprint'
+  | 'isometric'
+  | 'mobility'
+  | 'other'
+
+export type ExerciseCategory = 'strength' | 'speed' | 'power' | 'mobility' | 'cardio' | 'test'
+
+export interface Exercise {
+  key: string
+  display_name: string
+  category: ExerciseCategory
+  measures: string[]
+  is_benchmark: boolean
+  owner_id: string | null // null = canonical library
+  visibility: ExerciseVisibility
+  created_by: string | null
+  forked_from: string | null
+  aliases: string[]
+  movement_pattern: MovementPattern | null
+  equipment: string[]
+  body_region: string[]
+  laterality: string | null
+  difficulty: string | null
+  tags: string[]
+  media_url: string | null
+  thumbnail_url: string | null
+  cues: string[]
+  instructions: string | null
+}
+
+export interface ExerciseCreate {
+  display_name: string
+  category: ExerciseCategory
+  measures?: string[]
+  visibility?: ExerciseVisibility
+  aliases?: string[]
+  movement_pattern?: MovementPattern | null
+  equipment?: string[]
+  cues?: string[]
+}

--- a/frontend/src/utils/__tests__/exerciseBalance.test.ts
+++ b/frontend/src/utils/__tests__/exerciseBalance.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { patternCounts, balanceNudges } from '@/utils/exerciseBalance'
+import type { Exercise, MovementPattern } from '@/types/workout'
+
+const ex = (movement_pattern: MovementPattern | null, key = 'k'): Exercise => ({
+  key,
+  display_name: 'X',
+  category: 'strength',
+  measures: [],
+  is_benchmark: false,
+  owner_id: null,
+  visibility: 'public',
+  created_by: null,
+  forked_from: null,
+  aliases: [],
+  movement_pattern,
+  equipment: [],
+  body_region: [],
+  laterality: null,
+  difficulty: null,
+  tags: [],
+  media_url: null,
+  thumbnail_url: null,
+  cues: [],
+  instructions: null,
+})
+
+describe('patternCounts', () => {
+  it('counts by movement pattern, ignoring nulls', () => {
+    const counts = patternCounts([ex('push', 'a'), ex('push', 'b'), ex('pull', 'c'), ex(null, 'd')])
+    expect(counts).toEqual({ push: 2, pull: 1 })
+  })
+})
+
+describe('balanceNudges', () => {
+  it('nudges push without pull', () => {
+    const n = balanceNudges([ex('push')])
+    expect(n).toHaveLength(1)
+    expect(n[0]).toMatch(/pull/i)
+  })
+
+  it('no push/pull nudge when both present', () => {
+    const n = balanceNudges([ex('push', 'a'), ex('pull', 'b')])
+    expect(n.join(' ')).not.toMatch(/no pull/i)
+  })
+
+  it('nudges squat without hinge', () => {
+    expect(balanceNudges([ex('squat')])[0]).toMatch(/hinge/i)
+  })
+
+  it('empty selection → no nudges', () => {
+    expect(balanceNudges([])).toEqual([])
+  })
+
+  it('balanced selection → no nudges', () => {
+    const n = balanceNudges([ex('push', 'a'), ex('pull', 'b'), ex('squat', 'c'), ex('hinge', 'd')])
+    expect(n).toEqual([])
+  })
+})

--- a/frontend/src/utils/exerciseBalance.ts
+++ b/frontend/src/utils/exerciseBalance.ts
@@ -1,0 +1,39 @@
+import type { Exercise, MovementPattern } from '@/types/workout'
+
+/**
+ * Balance nudges — the "programming assistant" heart of the exercise picker.
+ *
+ * Given the exercises already chosen for a workout, flag obvious movement-pattern
+ * imbalances so the coach builds a balanced session. Pure + deterministic so it's
+ * trivially testable and reusable (component + any future analysis).
+ */
+
+/** Count selected exercises per movement pattern (nulls ignored). */
+export function patternCounts(exercises: Exercise[]): Record<string, number> {
+  const counts: Record<string, number> = {}
+  for (const ex of exercises) {
+    const p = ex.movement_pattern
+    if (p) counts[p] = (counts[p] ?? 0) + 1
+  }
+  return counts
+}
+
+// Complementary pairs: if you program the first with none of the second, nudge.
+const PAIRS: ReadonlyArray<readonly [MovementPattern, MovementPattern, string]> = [
+  ['push', 'pull', 'You have push but no pull — add a pull to balance the shoulders.'],
+  ['squat', 'hinge', 'Squat but no hinge — add a hinge (glutes/hamstrings).'],
+  ['anti_rotation', 'rotation', 'Anti-rotation but no rotation — consider a rotational movement.'],
+]
+
+/**
+ * Nudges for the current selection. Empty when balanced (or too few to judge).
+ * Only fires when the first pattern is present and its complement is absent.
+ */
+export function balanceNudges(exercises: Exercise[]): string[] {
+  const counts = patternCounts(exercises)
+  const nudges: string[] = []
+  for (const [a, b, message] of PAIRS) {
+    if ((counts[a] ?? 0) > 0 && (counts[b] ?? 0) === 0) nudges.push(message)
+  }
+  return nudges
+}

--- a/frontend/src/views/ExerciseCatalogView.vue
+++ b/frontend/src/views/ExerciseCatalogView.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="container-app py-8">
+    <div class="mb-6">
+      <h1 class="text-2xl font-bold text-gray-900">Exercise catalog</h1>
+      <p class="text-sm text-gray-500 mt-1">
+        The shared library plus your own exercises. Search before adding — keep the catalog clean.
+      </p>
+    </div>
+
+    <div v-if="loading" class="text-sm text-gray-500">Loading catalog…</div>
+    <div
+      v-else-if="error"
+      class="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-700"
+    >
+      {{ error }}
+    </div>
+
+    <ExercisePicker
+      v-else
+      :exercises="exercises"
+      mode="manage"
+      @create="onCreate"
+      @publish="onPublish"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import ExercisePicker from '@/components/ExercisePicker.vue'
+import { useExercises } from '@/composables/useExercises'
+import { useRoles } from '@/composables/useCoach'
+import type { ExerciseCreate } from '@/types/workout'
+
+const router = useRouter()
+const { isCoach, loadRoles } = useRoles()
+const { exercises, loading, error, load, create, publish } = useExercises()
+
+const onCreate = async (payload: ExerciseCreate) => {
+  await create(payload)
+}
+const onPublish = async (key: string) => {
+  await publish(key)
+}
+
+onMounted(async () => {
+  // Coach/admin only — the nav link is hidden for others, but guard direct URLs.
+  await loadRoles()
+  if (!isCoach.value) {
+    router.replace('/dashboard')
+    return
+  }
+  await load()
+})
+</script>


### PR DESCRIPTION
Completes **SB-228** (D2 — the innovative search/select component). Consumes the D1 catalog API (#137).

## The component — a programming assistant, not a dropdown
`ExercisePicker.vue`:
- **Fuzzy search** over name + aliases.
- **Facet chips**: ownership (Mine/Public) + movement pattern (only patterns present in the catalog).
- **Visual cards**: category, movement pattern, equipment, cues, Private/Mine badges; multi-select emits `toggle`.
- **Inline create** (search-first dedup): empty results → "Create" → mini form, **private by default** with a "publish to public library" checkbox.
- Presentational — takes the catalog as a prop, emits `toggle`/`create`/`publish` — so it's **fully unit-testable without the API**.

## Balance nudge (the innovative bit)
`utils/exerciseBalance.ts` derives movement-pattern imbalances from the current selection — "push but no pull — add a pull". Pure + tested.

## Surfaces
- `useExercises` composable: load (visible catalog) / create / publish.
- `ExerciseCatalogView` + `/exercises` route + **Catalog** nav link (coach-gated, in-view redirect for non-coaches) — a real page to browse/create/publish, and the picker's home until the workout builder (SB-229) embeds it.

## Tests (22)
- `exerciseBalance`: pattern counts, push/pull + squat/hinge nudges, balanced/empty.
- `useExercises`: load / create-append / publish-in-place.
- `ExercisePicker`: search by name + alias, ownership + pattern facets, balance nudge shown/hidden, toggle emit (select mode), publish button visibility + emit (manage mode), empty→create emitting private vs public payloads.

Typecheck + build clean. Full frontend suite: **121 passed** (added 22), no new failures (the 7 reds are the pre-existing `useUserPreferences`/`useSync`, green in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)