### PR TITLE
fix: hide 'none' equipment sentinel on exercise cards

### DIFF
--- a/frontend/src/components/ExercisePicker.vue
+++ b/frontend/src/components/ExercisePicker.vue
@@ -66,7 +66,7 @@
         <div class="mt-1 flex flex-wrap items-center gap-1 text-[10px]">
           <span class="tag">{{ ex.category }}</span>
           <span v-if="ex.movement_pattern" class="tag">{{ ex.movement_pattern }}</span>
-          <span v-for="eq in ex.equipment" :key="eq" class="tag-muted">{{ eq }}</span>
+          <span v-for="eq in realEquipment(ex)" :key="eq" class="tag-muted">{{ eq }}</span>
           <span v-if="ex.owner_id" class="tag-mine">Mine</span>
           <span v-if="ex.visibility === 'private'" class="tag-private">Private</span>
         </div>
@@ -178,6 +178,9 @@ const patternFacets = computed(() => {
 })
 
 const isSelected = (ex: Exercise): boolean => props.selectedKeys.includes(ex.key)
+
+// 'none' is a no-equipment sentinel in the seed — don't render it as a tag.
+const realEquipment = (ex: Exercise): string[] => ex.equipment.filter((e) => e !== 'none')
 
 const filtered = computed<Exercise[]>(() => {
   const q = query.value.trim().toLowerCase()

--- a/frontend/src/components/__tests__/ExercisePicker.test.ts
+++ b/frontend/src/components/__tests__/ExercisePicker.test.ts
@@ -103,6 +103,20 @@ describe('ExercisePicker', () => {
     expect(w.find('[data-testid="balance-nudge"]').exists()).toBe(false)
   })
 
+  it("does not render 'none' as an equipment tag", () => {
+    const ex = [make({ key: 'sprint_x', display_name: 'Sprint X', equipment: ['none'] })]
+    const w = mount(ExercisePicker, { props: { exercises: ex } })
+    expect(w.find('[data-testid="ex-sprint_x"]').text()).not.toContain('none')
+  })
+
+  it('renders real equipment tags', () => {
+    const ex = [make({ key: 'carry_x', display_name: 'Carry X', equipment: ['dumbbell', 'none'] })]
+    const w = mount(ExercisePicker, { props: { exercises: ex } })
+    const card = w.find('[data-testid="ex-carry_x"]').text()
+    expect(card).toContain('dumbbell')
+    expect(card).not.toContain('none')
+  })
+
   it('clicking a card emits toggle in select mode', async () => {
     const w = mount(ExercisePicker, { props: { exercises: catalog, mode: 'select' } })
     await w.find('[data-testid="ex-pushups"]').trigger('click')


### PR DESCRIPTION
The seed uses `equipment: ['none']` for bodyweight/no-kit moves; the picker card rendered every value, so a stray **none** tag showed (visible on /exercises). Filter `none` out — affects the Catalog view and the workout builder (both use ExercisePicker). +2 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)