### PR TITLE
feat: show an athlete's workout templates on their page (SB-229)

### DIFF
--- a/frontend/src/components/WorkoutTemplateCard.vue
+++ b/frontend/src/components/WorkoutTemplateCard.vue
@@ -1,0 +1,70 @@
+<template>
+  <div class="bg-white rounded-2xl border border-gray-100 shadow-sm p-5">
+    <div class="flex items-center justify-between gap-2">
+      <h3 class="text-base font-semibold text-gray-900">{{ template.name }}</h3>
+      <span class="text-xs text-gray-500 whitespace-nowrap">
+        {{ template.type }} · {{ template.rounds }}× rounds
+      </span>
+    </div>
+    <p v-if="template.source" class="text-xs text-gray-400 mt-0.5">Coach: {{ template.source }}</p>
+
+    <div v-for="sec in sections" :key="sec.key" class="mt-3">
+      <h4 class="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">
+        {{ sec.label }}
+      </h4>
+      <ol class="space-y-1">
+        <li
+          v-for="item in sec.items"
+          :key="item.id"
+          class="flex items-baseline justify-between gap-3 text-sm"
+        >
+          <span class="text-gray-800">
+            {{ nameFor(item.exercise_key) }}
+            <span v-if="item.variant" class="text-gray-400">({{ item.variant }})</span>
+          </span>
+          <span class="text-xs text-gray-500 text-right whitespace-nowrap">{{ target(item) }}</span>
+        </li>
+      </ol>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { Exercise, TemplateItem, WorkoutSectionKey, WorkoutTemplate } from '@/types/workout'
+import { SECTIONS, kgToLb, prettifyKey } from '@/utils/workoutPayload'
+
+const props = defineProps<{
+  template: WorkoutTemplate
+  exercises?: Exercise[]
+}>()
+
+const byKey = computed<Record<string, Exercise>>(() => {
+  const map: Record<string, Exercise> = {}
+  for (const ex of props.exercises ?? []) map[ex.key] = ex
+  return map
+})
+
+const nameFor = (key: string): string => byKey.value[key]?.display_name ?? prettifyKey(key)
+
+// Only render sections that have items, in canonical order.
+const sections = computed(() =>
+  SECTIONS.map((s) => ({
+    ...s,
+    items: props.template.items
+      .filter((it) => it.section === (s.key as WorkoutSectionKey))
+      .sort((a, b) => a.position - b.position),
+  })).filter((s) => s.items.length > 0),
+)
+
+/** Compact target summary, e.g. "60s · 10 lb · rest 30s". */
+const target = (it: TemplateItem): string => {
+  const parts: string[] = []
+  if (it.target_reps != null) parts.push(`${it.target_reps} reps`)
+  if (it.target_duration_seconds != null) parts.push(`${it.target_duration_seconds}s`)
+  if (it.target_load_kg != null) parts.push(`${kgToLb(it.target_load_kg)} lb`)
+  if (it.target_distance_m != null) parts.push(`${it.target_distance_m} m`)
+  if (it.rest_seconds != null) parts.push(`rest ${it.rest_seconds}s`)
+  return parts.join(' · ')
+}
+</script>

--- a/frontend/src/components/__tests__/WorkoutTemplateCard.test.ts
+++ b/frontend/src/components/__tests__/WorkoutTemplateCard.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import WorkoutTemplateCard from '../WorkoutTemplateCard.vue'
+import type { Exercise, TemplateItem, WorkoutTemplate } from '@/types/workout'
+
+const ti = (over: Partial<TemplateItem>): TemplateItem => ({
+  id: Math.random().toString(),
+  exercise_key: 'x',
+  section: 'main',
+  position: 0,
+  target_reps: null,
+  target_duration_seconds: null,
+  target_load_kg: null,
+  target_distance_m: null,
+  rest_seconds: null,
+  variant: null,
+  notes: null,
+  ...over,
+})
+
+const template: WorkoutTemplate = {
+  id: 't1',
+  name: 'Monday - Circuit',
+  type: 'circuit',
+  rounds: 2,
+  source: 'Matthew',
+  notes: null,
+  created_at: null,
+  items: [
+    ti({ exercise_key: 'easy_jog', section: 'warmup', position: 0, target_duration_seconds: 480 }),
+    ti({ exercise_key: 'bicep_curl', section: 'main', position: 2, target_load_kg: 4.54, target_duration_seconds: 60 }),
+    ti({ exercise_key: 'side_plank', section: 'main', position: 1, variant: 'left', target_duration_seconds: 60 }),
+  ],
+}
+
+const exercises: Exercise[] = [
+  { key: 'bicep_curl', display_name: 'Bicep curls', measures: [] } as unknown as Exercise,
+]
+
+describe('WorkoutTemplateCard', () => {
+  it('renders name, type and rounds', () => {
+    const w = mount(WorkoutTemplateCard, { props: { template } })
+    expect(w.text()).toContain('Monday - Circuit')
+    expect(w.text()).toContain('circuit')
+    expect(w.text()).toContain('2× rounds')
+  })
+
+  it('groups items under section headings in canonical order', () => {
+    const w = mount(WorkoutTemplateCard, { props: { template } })
+    const text = w.text()
+    expect(text).toContain('Warm-up')
+    expect(text).toContain('Main')
+    // warm-up heading appears before main
+    expect(text.indexOf('Warm-up')).toBeLessThan(text.indexOf('Main'))
+  })
+
+  it('sorts items within a section by position', () => {
+    const w = mount(WorkoutTemplateCard, { props: { template } })
+    const text = w.text()
+    // side_plank (pos 1) before bicep_curl (pos 2); no catalog → prettified keys
+    expect(text.indexOf('Side plank')).toBeLessThan(text.indexOf('Bicep curl'))
+  })
+
+  it('uses the catalog display name, falls back to a prettified key', () => {
+    const w = mount(WorkoutTemplateCard, { props: { template, exercises } })
+    expect(w.text()).toContain('Bicep curls') // from catalog
+    expect(w.text()).toContain('Side plank') // prettified from side_plank
+    expect(w.text()).not.toContain('side_plank')
+  })
+
+  it('shows load in lb (kg → lb) and the variant', () => {
+    const w = mount(WorkoutTemplateCard, { props: { template } })
+    expect(w.text()).toContain('10 lb') // 4.54 kg → 10 lb
+    expect(w.text()).toContain('(left)')
+  })
+})

--- a/frontend/src/composables/__tests__/useCoach.test.ts
+++ b/frontend/src/composables/__tests__/useCoach.test.ts
@@ -151,6 +151,7 @@ describe('useAthleteDetail act-as', () => {
     apiCallMock.mockImplementation((path: string) => {
       if (path === '/athletes/a1') return Promise.resolve(athlete)
       if (path.startsWith('/workouts/sessions')) return Promise.resolve([{ id: 's1', athlete_id: 'a1', session_date: '2026-07-01', type: 'circuit', total_minutes: 30, how_felt: 'good', notes: null, sets: [] }])
+      if (path.startsWith('/workouts/templates')) return Promise.resolve([])
       return Promise.reject(new Error('unexpected ' + path))
     })
     const { useAthleteDetail } = await freshModule()

--- a/frontend/src/composables/useCoach.ts
+++ b/frontend/src/composables/useCoach.ts
@@ -8,6 +8,7 @@ import type {
   MyRoles,
   WorkoutSession,
 } from '@/types/coach'
+import type { WorkoutTemplate } from '@/types/workout'
 
 // Roles are shared app-wide (the nav gates the Coach link on them), so cache
 // them in module scope — one fetch feeds AppHeader and every coach view.
@@ -136,6 +137,7 @@ export function useCoach() {
 export function useAthleteDetail(athleteId: string) {
   const athlete = ref<Athlete | null>(null)
   const sessions = ref<WorkoutSession[]>([])
+  const templates = ref<WorkoutTemplate[]>([])
   const loading = ref(false)
   const error = ref<string | null>(null)
 
@@ -143,14 +145,18 @@ export function useAthleteDetail(athleteId: string) {
     loading.value = true
     error.value = null
     try {
-      const [a, s] = await Promise.all([
+      const [a, s, t] = await Promise.all([
         apiCall<Athlete>(`/athletes/${athleteId}`),
         apiCall<WorkoutSession[]>('/workouts/sessions?limit=50', {
+          headers: actAs(athleteId),
+        }),
+        apiCall<WorkoutTemplate[]>('/workouts/templates', {
           headers: actAs(athleteId),
         }),
       ])
       athlete.value = a
       sessions.value = s
+      templates.value = t
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to load athlete'
     } finally {
@@ -158,7 +164,7 @@ export function useAthleteDetail(athleteId: string) {
     }
   }
 
-  return { athlete, sessions, loading, error, load }
+  return { athlete, sessions, templates, loading, error, load }
 }
 
 export function useRoles() {

--- a/frontend/src/types/workout.ts
+++ b/frontend/src/types/workout.ts
@@ -74,6 +74,31 @@ export interface WorkoutTemplateInput {
   items: TemplateItemInput[]
 }
 
+export interface TemplateItem {
+  id: string
+  exercise_key: string
+  section: string
+  position: number
+  target_reps: number | null
+  target_duration_seconds: number | null
+  target_load_kg: number | null
+  target_distance_m: number | null
+  rest_seconds: number | null
+  variant: string | null
+  notes: string | null
+}
+
+export interface WorkoutTemplate {
+  id: string
+  name: string
+  type: WorkoutType
+  rounds: number
+  source: string | null
+  notes: string | null
+  items: TemplateItem[]
+  created_at: string | null
+}
+
 /** One row while building — loads are entered in lb (US coach), stored as kg. */
 export interface BuilderItem {
   uid: number

--- a/frontend/src/utils/workoutPayload.ts
+++ b/frontend/src/utils/workoutPayload.ts
@@ -21,6 +21,17 @@ export function lbToKg(lb: number | null): number | null {
   return lb == null ? null : Math.round(lb * LB_TO_KG * 10) / 10
 }
 
+/** Canonical kg → lb for display (whole lb), or null. */
+export function kgToLb(kg: number | null | undefined): number | null {
+  return kg == null ? null : Math.round(kg / LB_TO_KG)
+}
+
+/** slug key → readable fallback name ("bear_crawl" → "Bear crawl"). */
+export function prettifyKey(key: string): string {
+  const s = key.replace(/_/g, ' ')
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
 /**
  * Turn the builder's local items into the API payload:
  * ordered by section (warm-up → main → cool-down) then within-section order,

--- a/frontend/src/views/AthleteDetailView.vue
+++ b/frontend/src/views/AthleteDetailView.vue
@@ -35,6 +35,29 @@
 
       <AthleteAccessPanel :athlete="athlete" class="mb-6" />
 
+      <div class="flex items-center justify-between mb-2">
+        <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wide">
+          Workouts ({{ templates.length }})
+        </h2>
+        <RouterLink :to="`/coach/${athlete.id}/build`" class="text-xs font-medium text-brand-600">
+          + New
+        </RouterLink>
+      </div>
+      <div
+        v-if="templates.length === 0"
+        class="bg-white rounded-xl border border-gray-100 shadow-sm p-6 text-center text-gray-500 text-sm mb-6"
+      >
+        No workouts yet. Click <span class="font-semibold">+ Build workout</span> to create one.
+      </div>
+      <div v-else class="space-y-3 mb-6">
+        <WorkoutTemplateCard
+          v-for="t in templates"
+          :key="t.id"
+          :template="t"
+          :exercises="exercises"
+        />
+      </div>
+
       <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-2">
         Recent sessions ({{ sessions.length }})
       </h2>
@@ -68,12 +91,17 @@
 import { onMounted, ref } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
 import { useAthleteDetail } from '@/composables/useCoach'
+import { useExercises } from '@/composables/useExercises'
 import AthleteProfileForm from '@/components/AthleteProfileForm.vue'
 import AthleteAccessPanel from '@/components/AthleteAccessPanel.vue'
+import WorkoutTemplateCard from '@/components/WorkoutTemplateCard.vue'
 import type { Athlete } from '@/types/coach'
 
 const route = useRoute()
-const { athlete, sessions, loading, error, load } = useAthleteDetail(route.params.athleteId as string)
+const { athlete, sessions, templates, loading, error, load } = useAthleteDetail(
+  route.params.athleteId as string,
+)
+const { exercises, load: loadExercises } = useExercises()
 
 const editing = ref(false)
 const onSaved = (updated: Athlete) => {
@@ -81,5 +109,7 @@ const onSaved = (updated: Athlete) => {
   editing.value = false
 }
 
-onMounted(load)
+onMounted(async () => {
+  await Promise.all([load(), loadExercises()])
+})
 </script>


### PR DESCRIPTION
The builder saved templates but nothing displayed them (the athlete page only listed sessions), so a coach couldn't *see* the workout they built. Adds a **Workouts** section.

- `useAthleteDetail` also loads `/workouts/templates` (act-as).
- **WorkoutTemplateCard**: template grouped by section (warm-up/main/cool-down, in order, sorted by position); exercise **display name from the catalog** (falls back to a prettified key); compact target summary with load in **lb** (kg → lb).
- Athlete page: Workouts list + "+ New" / empty-state → builder; loads the catalog for name lookup.

Now "Monday - Circuit" (built for Gabe) shows on his page. Tests: 5 card tests + updated useAthleteDetail mock. Frontend 138 (no new failures).

Next: **SB-231** printable take-home renders these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)