### PR TITLE
fix: include items when listing workout templates (SB-229)

### DIFF
--- a/src/shared/supabase_ops/workout_repository.py
+++ b/src/shared/supabase_ops/workout_repository.py
@@ -171,8 +171,26 @@ class WorkoutTemplatesRepository:
 
     def list(self, user_id: UUID, athlete_id: UUID | None = None) -> list[dict[str, Any]]:
         query = _scope(self.supabase.table("workout_templates").select("*"), user_id, athlete_id)
-        result = query.order("created_at", desc=True).execute()
-        return cast(list[dict[str, Any]], result.data)
+        templates = cast(list[dict[str, Any]], query.order("created_at", desc=True).execute().data)
+        if not templates:
+            return templates
+
+        # Attach items in one batched query (so callers can render the full plan
+        # without an extra GET per template).
+        ids = [t["id"] for t in templates]
+        items = (
+            self.supabase.table("template_items")
+            .select("*")
+            .in_("template_id", ids)
+            .order("position")
+            .execute()
+        )
+        by_template: dict[str, list[dict[str, Any]]] = {}
+        for it in cast(list[dict[str, Any]], items.data):
+            by_template.setdefault(it["template_id"], []).append(it)
+        for t in templates:
+            t["items"] = by_template.get(t["id"], [])
+        return templates
 
     def get(
         self, user_id: UUID, template_id: UUID, athlete_id: UUID | None = None


### PR DESCRIPTION
`GET /workouts/templates` returned bare template rows (no items), so the athlete page's workout card showed only the **header** — no exercises (see Gabe's 'Monday - Circuit'). `list()` now batch-fetches `template_items` for the listed templates and nests them (one query, grouped by template_id), matching `get()`. The card renders the full plan inline.

Verified live; backend suite 206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)