### PR TITLE
feat: polish the workout template card + print/delete (SB-229)

### DIFF
--- a/frontend/src/components/WorkoutTemplateCard.vue
+++ b/frontend/src/components/WorkoutTemplateCard.vue
@@ -1,70 +1,134 @@
 <template>
-  <div class="bg-white rounded-2xl border border-gray-100 shadow-sm p-5">
-    <div class="flex items-center justify-between gap-2">
-      <h3 class="text-base font-semibold text-gray-900">{{ template.name }}</h3>
-      <span class="text-xs text-gray-500 whitespace-nowrap">
-        {{ template.type }} · {{ template.rounds }}× rounds
-      </span>
-    </div>
-    <p v-if="template.source" class="text-xs text-gray-400 mt-0.5">Coach: {{ template.source }}</p>
-
-    <div v-for="sec in sections" :key="sec.key" class="mt-3">
-      <h4 class="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">
-        {{ sec.label }}
-      </h4>
-      <ol class="space-y-1">
-        <li
-          v-for="item in sec.items"
-          :key="item.id"
-          class="flex items-baseline justify-between gap-3 text-sm"
-        >
-          <span class="text-gray-800">
-            {{ nameFor(item.exercise_key) }}
-            <span v-if="item.variant" class="text-gray-400">({{ item.variant }})</span>
+  <div class="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden print:shadow-none print:border-gray-300">
+    <!-- Header -->
+    <div class="flex items-start justify-between gap-3 p-5 border-b border-gray-100">
+      <div class="min-w-0">
+        <h3 class="text-lg font-bold text-gray-900 leading-tight">{{ template.name }}</h3>
+        <div class="mt-1.5 flex flex-wrap items-center gap-2">
+          <span class="inline-flex items-center gap-1 rounded-full bg-brand-50 px-2 py-0.5 text-xs font-semibold text-brand-700 capitalize">
+            <Repeat class="w-3 h-3" /> {{ template.type }} · {{ template.rounds }} {{ template.rounds === 1 ? 'round' : 'rounds' }}
           </span>
-          <span class="text-xs text-gray-500 text-right whitespace-nowrap">{{ target(item) }}</span>
-        </li>
-      </ol>
+          <span v-if="template.source" class="text-xs text-gray-400">Coached by {{ template.source }}</span>
+        </div>
+      </div>
+      <div class="flex items-center gap-1 shrink-0 print:hidden">
+        <button type="button" class="act" title="Print" aria-label="Print workout" @click="print">
+          <Printer class="w-4 h-4" />
+        </button>
+        <button
+          type="button"
+          class="act hover:text-red-600 hover:bg-red-50"
+          title="Delete"
+          aria-label="Delete workout"
+          @click="$emit('delete')"
+        >
+          <Trash2 class="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+
+    <!-- Sections -->
+    <div class="p-5 space-y-5">
+      <section v-for="sec in sections" :key="sec.key" class="border-l-2 pl-3" :class="sec.rule">
+        <h4 class="text-[11px] font-bold uppercase tracking-wider mb-1.5" :class="sec.label">
+          {{ sec.title }}
+          <span class="text-gray-300 font-medium">· {{ sec.items.length }}</span>
+        </h4>
+        <ul>
+          <li
+            v-for="(item, i) in sec.items"
+            :key="item.id"
+            class="group flex items-center justify-between gap-3 py-1.5 px-2 -mx-2 rounded-lg hover:bg-gray-50 transition-colors print:hover:bg-transparent"
+          >
+            <span class="flex items-center gap-2 min-w-0">
+              <span
+                v-if="sec.key === 'main'"
+                class="w-5 h-5 shrink-0 grid place-items-center rounded-full bg-brand-50 text-brand-700 text-[11px] font-semibold tabular-nums"
+              >
+                {{ i + 1 }}
+              </span>
+              <span class="text-sm text-gray-900 truncate">{{ nameFor(item.exercise_key) }}</span>
+              <span
+                v-if="item.variant"
+                class="shrink-0 rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 capitalize"
+              >
+                {{ item.variant }}
+              </span>
+            </span>
+            <span class="flex items-center gap-1.5 shrink-0">
+              <span v-for="p in pills(item)" :key="p.text" class="pill" :class="p.cls">{{ p.text }}</span>
+            </span>
+          </li>
+        </ul>
+      </section>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { Printer, Repeat, Trash2 } from 'lucide-vue-next'
 import type { Exercise, TemplateItem, WorkoutSectionKey, WorkoutTemplate } from '@/types/workout'
-import { SECTIONS, kgToLb, prettifyKey } from '@/utils/workoutPayload'
+import { SECTIONS, fmtDuration, kgToLb, prettifyKey } from '@/utils/workoutPayload'
 
 const props = defineProps<{
   template: WorkoutTemplate
   exercises?: Exercise[]
 }>()
 
+defineEmits<{ (e: 'delete'): void }>()
+
 const byKey = computed<Record<string, Exercise>>(() => {
   const map: Record<string, Exercise> = {}
   for (const ex of props.exercises ?? []) map[ex.key] = ex
   return map
 })
-
 const nameFor = (key: string): string => byKey.value[key]?.display_name ?? prettifyKey(key)
 
-// Only render sections that have items, in canonical order.
+// Per-section accent (subtle): warm-up amber, main navy, cool-down sky.
+const ACCENT: Record<WorkoutSectionKey, { rule: string; label: string }> = {
+  warmup: { rule: 'border-amber-300', label: 'text-amber-600' },
+  main: { rule: 'border-brand-400', label: 'text-brand-700' },
+  cooldown: { rule: 'border-sky-300', label: 'text-sky-600' },
+}
+
 const sections = computed(() =>
   SECTIONS.map((s) => ({
-    ...s,
+    key: s.key,
+    title: s.label,
+    ...ACCENT[s.key],
     items: props.template.items
-      .filter((it) => it.section === (s.key as WorkoutSectionKey))
+      .filter((it) => it.section === s.key)
       .sort((a, b) => a.position - b.position),
   })).filter((s) => s.items.length > 0),
 )
 
-/** Compact target summary, e.g. "60s · 10 lb · rest 30s". */
-const target = (it: TemplateItem): string => {
-  const parts: string[] = []
-  if (it.target_reps != null) parts.push(`${it.target_reps} reps`)
-  if (it.target_duration_seconds != null) parts.push(`${it.target_duration_seconds}s`)
-  if (it.target_load_kg != null) parts.push(`${kgToLb(it.target_load_kg)} lb`)
-  if (it.target_distance_m != null) parts.push(`${it.target_distance_m} m`)
-  if (it.rest_seconds != null) parts.push(`rest ${it.rest_seconds}s`)
-  return parts.join(' · ')
+interface Pill {
+  text: string
+  cls: string
 }
+const pills = (it: TemplateItem): Pill[] => {
+  const out: Pill[] = []
+  const base = 'bg-gray-100 text-gray-600'
+  if (it.target_reps != null) out.push({ text: `${it.target_reps} reps`, cls: base })
+  if (it.target_duration_seconds != null)
+    out.push({ text: fmtDuration(it.target_duration_seconds), cls: base })
+  if (it.target_load_kg != null)
+    out.push({ text: `${kgToLb(it.target_load_kg)} lb`, cls: 'bg-amber-50 text-amber-700' })
+  if (it.target_distance_m != null) out.push({ text: `${it.target_distance_m} m`, cls: base })
+  if (it.rest_seconds != null)
+    out.push({ text: `rest ${fmtDuration(it.rest_seconds)}`, cls: 'bg-gray-50 text-gray-400' })
+  return out
+}
+
+const print = (): void => window.print()
 </script>
+
+<style scoped>
+.act {
+  @apply p-1.5 rounded-lg text-gray-400 hover:bg-gray-100 hover:text-gray-700 transition-colors;
+}
+.pill {
+  @apply rounded-md px-1.5 py-0.5 text-[11px] font-medium tabular-nums whitespace-nowrap;
+}
+</style>

--- a/frontend/src/components/__tests__/WorkoutTemplateCard.test.ts
+++ b/frontend/src/components/__tests__/WorkoutTemplateCard.test.ts
@@ -42,7 +42,7 @@ describe('WorkoutTemplateCard', () => {
     const w = mount(WorkoutTemplateCard, { props: { template } })
     expect(w.text()).toContain('Monday - Circuit')
     expect(w.text()).toContain('circuit')
-    expect(w.text()).toContain('2× rounds')
+    expect(w.text()).toContain('2 rounds')
   })
 
   it('groups items under section headings in canonical order', () => {
@@ -68,9 +68,21 @@ describe('WorkoutTemplateCard', () => {
     expect(w.text()).not.toContain('side_plank')
   })
 
-  it('shows load in lb (kg → lb) and the variant', () => {
+  it('shows load in lb (kg → lb) and the variant chip', () => {
     const w = mount(WorkoutTemplateCard, { props: { template } })
     expect(w.text()).toContain('10 lb') // 4.54 kg → 10 lb
-    expect(w.text()).toContain('(left)')
+    expect(w.text()).toContain('left') // variant chip
+  })
+
+  it('formats durations (480s → 8 min, 60s → 1 min)', () => {
+    const w = mount(WorkoutTemplateCard, { props: { template } })
+    expect(w.text()).toContain('8 min') // easy_jog 480s
+    expect(w.text()).toContain('1 min') // side_plank / bicep 60s
+  })
+
+  it('numbers the main circuit and emits delete', async () => {
+    const w = mount(WorkoutTemplateCard, { props: { template } })
+    await w.find('button[aria-label="Delete workout"]').trigger('click')
+    expect(w.emitted('delete')).toHaveLength(1)
   })
 })

--- a/frontend/src/composables/useWorkoutTemplates.ts
+++ b/frontend/src/composables/useWorkoutTemplates.ts
@@ -16,3 +16,10 @@ export async function createTemplate(
     headers: { 'X-Act-As-Athlete': athleteId },
   })
 }
+
+export async function deleteTemplate(templateId: string, athleteId: string): Promise<void> {
+  await apiCall(`/workouts/templates/${templateId}`, {
+    method: 'DELETE',
+    headers: { 'X-Act-As-Athlete': athleteId },
+  })
+}

--- a/frontend/src/utils/__tests__/workoutPayload.test.ts
+++ b/frontend/src/utils/__tests__/workoutPayload.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { lbToKg, buildTemplatePayload } from '@/utils/workoutPayload'
+import { lbToKg, buildTemplatePayload, fmtDuration } from '@/utils/workoutPayload'
 import type { BuilderItem, Exercise, WorkoutSectionKey } from '@/types/workout'
 
 const ex = (key: string, measures: string[] = []): Exercise => ({
@@ -47,6 +47,19 @@ describe('lbToKg', () => {
   })
   it('passes null through', () => {
     expect(lbToKg(null)).toBeNull()
+  })
+})
+
+describe('fmtDuration', () => {
+  it('shows whole minutes as "N min"', () => {
+    expect(fmtDuration(480)).toBe('8 min')
+    expect(fmtDuration(60)).toBe('1 min')
+  })
+  it('shows mm:ss for non-round minutes', () => {
+    expect(fmtDuration(90)).toBe('1:30')
+  })
+  it('shows seconds under a minute', () => {
+    expect(fmtDuration(45)).toBe('45s')
   })
 })
 

--- a/frontend/src/utils/workoutPayload.ts
+++ b/frontend/src/utils/workoutPayload.ts
@@ -32,6 +32,13 @@ export function prettifyKey(key: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1)
 }
 
+/** Human duration: 480→"8 min", 60→"1 min", 90→"1:30", 45→"45s". */
+export function fmtDuration(seconds: number): string {
+  if (seconds % 60 === 0) return `${seconds / 60} min`
+  if (seconds > 60) return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, '0')}`
+  return `${seconds}s`
+}
+
 /**
  * Turn the builder's local items into the API payload:
  * ordered by section (warm-up → main → cool-down) then within-section order,

--- a/frontend/src/views/AthleteDetailView.vue
+++ b/frontend/src/views/AthleteDetailView.vue
@@ -55,6 +55,7 @@
           :key="t.id"
           :template="t"
           :exercises="exercises"
+          @delete="onDeleteTemplate(t.id)"
         />
       </div>
 
@@ -95,18 +96,24 @@ import { useExercises } from '@/composables/useExercises'
 import AthleteProfileForm from '@/components/AthleteProfileForm.vue'
 import AthleteAccessPanel from '@/components/AthleteAccessPanel.vue'
 import WorkoutTemplateCard from '@/components/WorkoutTemplateCard.vue'
+import { deleteTemplate } from '@/composables/useWorkoutTemplates'
 import type { Athlete } from '@/types/coach'
 
 const route = useRoute()
-const { athlete, sessions, templates, loading, error, load } = useAthleteDetail(
-  route.params.athleteId as string,
-)
+const athleteId = route.params.athleteId as string
+const { athlete, sessions, templates, loading, error, load } = useAthleteDetail(athleteId)
 const { exercises, load: loadExercises } = useExercises()
 
 const editing = ref(false)
 const onSaved = (updated: Athlete) => {
   athlete.value = updated
   editing.value = false
+}
+
+const onDeleteTemplate = async (id: string) => {
+  if (!confirm('Delete this workout?')) return
+  await deleteTemplate(id, athleteId)
+  templates.value = templates.value.filter((t) => t.id !== id)
 }
 
 onMounted(async () => {


### PR DESCRIPTION
UX pass on the inline workout card (direction from the ui-ux-pro-max engine, adapted to STK's navy brand).

- **Header**: bold title, `circuit · 2 rounds` brand pill, "Coached by X" byline, **Print** / **Delete** icon actions (Lucide).
- **Sections**: subtle left accent + colored label (warm-up amber · main navy · cool-down sky) + item count.
- **Rows**: main circuit **numbered** as a sequence; targets as small **pills** (time/reps/distance gray, **load amber**) with tabular figures; **variant chip**; hover highlight; **print-friendly** (`print:*` resets).
- **Human durations**: 480s → **8 min**, 60s → **1 min**, 90s → **1:30**.
- **Print** = `window.print()`; **Delete** = `DELETE /workouts/templates/:id` (act-as) with confirm + optimistic removal.

Tests: fmtDuration + card (badge, grouping/order, name lookup, kg→lb, duration, variant chip, delete emit). Frontend 143 (no new failures).

**Edit** (load a template back into the builder) is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)