### PR TITLE
feat: edit an existing workout (SB-229)

### DIFF
--- a/backend/routes/workouts.py
+++ b/backend/routes/workouts.py
@@ -140,6 +140,28 @@ async def create_template(
     return WorkoutTemplate(**row)
 
 
+@router.patch("/templates/{template_id}", response_model=WorkoutTemplate)
+async def update_template(
+    template_id: UUID,
+    body: WorkoutTemplateCreate,
+    user_id: UUID = Depends(authenticate_request),
+    athlete_id: UUID | None = Depends(acting_athlete),
+) -> WorkoutTemplate:
+    supabase = get_supabase_client()
+    valid = ExercisesRepository(supabase).keys()
+    unknown = {i.exercise_key for i in body.items} - valid
+    if unknown:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, f"Unknown exercise(s): {sorted(unknown)}")
+
+    row = WorkoutTemplatesRepository(supabase).update(
+        user_id, template_id, body.model_dump(mode="json", exclude_none=True), athlete_id=athlete_id
+    )
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Template not found or not yours")
+    await invalidate_user(user_id)
+    return WorkoutTemplate(**row)
+
+
 @router.get("/templates", response_model=list[WorkoutTemplate])
 def list_templates(
     user_id: UUID = Depends(authenticate_request),

--- a/backend/tests/test_workout_repository.py
+++ b/backend/tests/test_workout_repository.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from src.shared.supabase_ops.workout_repository import (
     WorkoutSessionsRepository,
@@ -44,6 +44,13 @@ class _FakeQuery:
         self._mode, self._payload = "insert", payload
         return self
 
+    def update(self, payload: Any) -> _FakeQuery:
+        self._mode, self._payload = "update", payload
+        return self
+
+    def in_(self, *a: Any, **k: Any) -> _FakeQuery:
+        return self
+
     def delete(self) -> _FakeQuery:
         self._mode = "delete"
         return self
@@ -57,6 +64,11 @@ class _FakeQuery:
                 self.store.setdefault(self.table, []).append(row)
                 out.append(row)
             return SimpleNamespace(data=out)
+        if self._mode == "update":
+            rows = self.store.get(self.table, [])
+            for r in rows:
+                r.update(self._payload)
+            return SimpleNamespace(data=rows)
         if self._mode == "delete":
             data = self.store.get(self.table, [])
             self.store[self.table] = []
@@ -93,6 +105,35 @@ def test_template_create_round_trips_with_items():
     assert len(out["items"]) == 2
     assert all(i["user_id"] == str(user) for i in out["items"])
     assert all(i["template_id"] == out["id"] for i in out["items"])
+
+
+def test_template_update_replaces_items_and_fields():
+    supa = _FakeSupabase()
+    repo = WorkoutTemplatesRepository(supa)
+    user = uuid4()
+    out = repo.create(
+        user,
+        {
+            "name": "A",
+            "type": "circuit",
+            "rounds": 2,
+            "items": [{"exercise_key": "pushups", "position": 0, "target_reps": 10}],
+        },
+    )
+    upd = repo.update(
+        user,
+        UUID(out["id"]),
+        {
+            "name": "B",
+            "rounds": 3,
+            "items": [{"exercise_key": "plank", "position": 0, "target_duration_seconds": 60}],
+        },
+    )
+    assert upd is not None
+    assert upd["name"] == "B"
+    assert upd["rounds"] == 3
+    assert len(upd["items"]) == 1
+    assert upd["items"][0]["exercise_key"] == "plank"
 
 
 def test_session_create_round_trips_with_sets():

--- a/frontend/src/components/WorkoutTemplateCard.vue
+++ b/frontend/src/components/WorkoutTemplateCard.vue
@@ -15,6 +15,9 @@
         <button type="button" class="act" title="Print" aria-label="Print workout" @click="print">
           <Printer class="w-4 h-4" />
         </button>
+        <button type="button" class="act" title="Edit" aria-label="Edit workout" @click="$emit('edit')">
+          <Pencil class="w-4 h-4" />
+        </button>
         <button
           type="button"
           class="act hover:text-red-600 hover:bg-red-50"
@@ -67,7 +70,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { Printer, Repeat, Trash2 } from 'lucide-vue-next'
+import { Pencil, Printer, Repeat, Trash2 } from 'lucide-vue-next'
 import type { Exercise, TemplateItem, WorkoutSectionKey, WorkoutTemplate } from '@/types/workout'
 import { SECTIONS, fmtDuration, kgToLb, prettifyKey } from '@/utils/workoutPayload'
 
@@ -76,7 +79,7 @@ const props = defineProps<{
   exercises?: Exercise[]
 }>()
 
-defineEmits<{ (e: 'delete'): void }>()
+defineEmits<{ (e: 'edit'): void; (e: 'delete'): void }>()
 
 const byKey = computed<Record<string, Exercise>>(() => {
   const map: Record<string, Exercise> = {}

--- a/frontend/src/components/__tests__/WorkoutTemplateCard.test.ts
+++ b/frontend/src/components/__tests__/WorkoutTemplateCard.test.ts
@@ -80,9 +80,11 @@ describe('WorkoutTemplateCard', () => {
     expect(w.text()).toContain('1 min') // side_plank / bicep 60s
   })
 
-  it('numbers the main circuit and emits delete', async () => {
+  it('emits edit and delete from the header actions', async () => {
     const w = mount(WorkoutTemplateCard, { props: { template } })
+    await w.find('button[aria-label="Edit workout"]').trigger('click')
     await w.find('button[aria-label="Delete workout"]').trigger('click')
+    expect(w.emitted('edit')).toHaveLength(1)
     expect(w.emitted('delete')).toHaveLength(1)
   })
 })

--- a/frontend/src/composables/useWorkoutTemplates.ts
+++ b/frontend/src/composables/useWorkoutTemplates.ts
@@ -1,5 +1,5 @@
 import { apiCall } from '@/config/api'
-import type { WorkoutTemplateInput } from '@/types/workout'
+import type { WorkoutTemplate, WorkoutTemplateInput } from '@/types/workout'
 
 /**
  * Create a workout template on an athlete's account. The coach acts on the
@@ -12,6 +12,24 @@ export async function createTemplate(
 ): Promise<{ id: string }> {
   return apiCall<{ id: string }>('/workouts/templates', {
     method: 'POST',
+    body: JSON.stringify(payload),
+    headers: { 'X-Act-As-Athlete': athleteId },
+  })
+}
+
+export async function getTemplate(templateId: string, athleteId: string): Promise<WorkoutTemplate> {
+  return apiCall<WorkoutTemplate>(`/workouts/templates/${templateId}`, {
+    headers: { 'X-Act-As-Athlete': athleteId },
+  })
+}
+
+export async function updateTemplate(
+  templateId: string,
+  payload: WorkoutTemplateInput,
+  athleteId: string,
+): Promise<WorkoutTemplate> {
+  return apiCall<WorkoutTemplate>(`/workouts/templates/${templateId}`, {
+    method: 'PATCH',
     body: JSON.stringify(payload),
     headers: { 'X-Act-As-Athlete': athleteId },
   })

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -73,6 +73,12 @@ const router = createRouter({
       meta: { requiresAuth: true },
     },
     {
+      path: '/coach/:athleteId/build/:templateId',
+      name: 'workout-editor',
+      component: () => import('@/views/WorkoutBuilderView.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
       path: '/exercises',
       name: 'exercise-catalog',
       component: () => import('@/views/ExerciseCatalogView.vue'),

--- a/frontend/src/views/AthleteDetailView.vue
+++ b/frontend/src/views/AthleteDetailView.vue
@@ -55,6 +55,7 @@
           :key="t.id"
           :template="t"
           :exercises="exercises"
+          @edit="router.push(`/coach/${athleteId}/build/${t.id}`)"
           @delete="onDeleteTemplate(t.id)"
         />
       </div>
@@ -90,7 +91,7 @@
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
-import { RouterLink, useRoute } from 'vue-router'
+import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { useAthleteDetail } from '@/composables/useCoach'
 import { useExercises } from '@/composables/useExercises'
 import AthleteProfileForm from '@/components/AthleteProfileForm.vue'
@@ -100,6 +101,7 @@ import { deleteTemplate } from '@/composables/useWorkoutTemplates'
 import type { Athlete } from '@/types/coach'
 
 const route = useRoute()
+const router = useRouter()
 const athleteId = route.params.athleteId as string
 const { athlete, sessions, templates, loading, error, load } = useAthleteDetail(athleteId)
 const { exercises, load: loadExercises } = useExercises()

--- a/frontend/src/views/WorkoutBuilderView.vue
+++ b/frontend/src/views/WorkoutBuilderView.vue
@@ -4,7 +4,7 @@
       ← Back
     </RouterLink>
 
-    <h1 class="text-2xl font-bold text-gray-900 mt-4">Build workout</h1>
+    <h1 class="text-2xl font-bold text-gray-900 mt-4">{{ editingId ? 'Edit workout' : 'Build workout' }}</h1>
 
     <!-- Template meta -->
     <div class="bg-white rounded-2xl border border-gray-100 shadow-sm p-5 mt-4 space-y-3">
@@ -120,13 +120,14 @@ import { useRoute, useRouter } from 'vue-router'
 import ExercisePicker from '@/components/ExercisePicker.vue'
 import { useExercises } from '@/composables/useExercises'
 import { useRoles } from '@/composables/useCoach'
-import { createTemplate } from '@/composables/useWorkoutTemplates'
-import { SECTIONS, buildTemplatePayload } from '@/utils/workoutPayload'
+import { createTemplate, getTemplate, updateTemplate } from '@/composables/useWorkoutTemplates'
+import { SECTIONS, buildTemplatePayload, kgToLb } from '@/utils/workoutPayload'
 import type { BuilderItem, Exercise, WorkoutSectionKey, WorkoutType } from '@/types/workout'
 
 const route = useRoute()
 const router = useRouter()
 const athleteId = route.params.athleteId as string
+const editingId = (route.params.templateId as string | undefined) || null
 
 const { isCoach, loadRoles } = useRoles()
 const { exercises, load } = useExercises()
@@ -190,7 +191,8 @@ const save = async (): Promise<void> => {
   error.value = null
   try {
     const payload = buildTemplatePayload(name.value, type.value, rounds.value, items.value)
-    await createTemplate(payload, athleteId)
+    if (editingId) await updateTemplate(editingId, payload, athleteId)
+    else await createTemplate(payload, athleteId)
     router.push(`/coach/${athleteId}`)
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Failed to save workout'
@@ -199,6 +201,30 @@ const save = async (): Promise<void> => {
   }
 }
 
+// Load an existing template into the builder state (kg → lb, key → Exercise).
+const prefillFrom = (templateId: string): Promise<void> =>
+  getTemplate(templateId, athleteId).then((tpl) => {
+    name.value = tpl.name
+    type.value = tpl.type
+    rounds.value = tpl.rounds
+    const byKey = new Map(exercises.value.map((e) => [e.key, e]))
+    items.value = tpl.items
+      .slice()
+      .sort((a, b) => a.position - b.position)
+      .map((it) => ({
+        uid: nextUid++,
+        exercise: byKey.get(it.exercise_key) ?? ({ key: it.exercise_key, display_name: it.exercise_key, measures: [] } as unknown as Exercise),
+        section: it.section as WorkoutSectionKey,
+        reps: it.target_reps,
+        duration_s: it.target_duration_seconds,
+        load_lb: kgToLb(it.target_load_kg),
+        distance_m: it.target_distance_m,
+        rest_s: it.rest_seconds,
+        variant: it.variant,
+        notes: it.notes,
+      }))
+  })
+
 onMounted(async () => {
   await loadRoles()
   if (!isCoach.value) {
@@ -206,6 +232,7 @@ onMounted(async () => {
     return
   }
   await load()
+  if (editingId) await prefillFrom(editingId)
 })
 </script>
 

--- a/frontend/src/views/__tests__/WorkoutBuilderView.test.ts
+++ b/frontend/src/views/__tests__/WorkoutBuilderView.test.ts
@@ -3,11 +3,14 @@ import { mount, flushPromises } from '@vue/test-utils'
 
 const h = vi.hoisted(() => ({
   createTemplate: vi.fn(),
+  updateTemplate: vi.fn(),
+  getTemplate: vi.fn(),
   push: vi.fn(),
   replace: vi.fn(),
   isCoach: { value: true },
   loadRoles: vi.fn().mockResolvedValue(undefined),
   load: vi.fn().mockResolvedValue(undefined),
+  params: { athleteId: 'ath1' } as Record<string, string>,
 }))
 
 const catalog = [
@@ -34,9 +37,11 @@ vi.mock('@/composables/useCoach', () => ({
 }))
 vi.mock('@/composables/useWorkoutTemplates', () => ({
   createTemplate: (...a: unknown[]) => h.createTemplate(...a),
+  updateTemplate: (...a: unknown[]) => h.updateTemplate(...a),
+  getTemplate: (...a: unknown[]) => h.getTemplate(...a),
 }))
 vi.mock('vue-router', () => ({
-  useRoute: () => ({ params: { athleteId: 'ath1' } }),
+  useRoute: () => ({ params: h.params }),
   useRouter: () => ({ push: h.push, replace: h.replace }),
   RouterLink: { template: '<a><slot /></a>' },
 }))
@@ -44,6 +49,7 @@ vi.mock('vue-router', () => ({
 beforeEach(() => {
   vi.clearAllMocks()
   h.isCoach.value = true
+  h.params = { athleteId: 'ath1' }
 })
 
 async function mountBuilder() {
@@ -96,6 +102,46 @@ describe('WorkoutBuilderView', () => {
       target_load_kg: 4.5, // 10 lb
     })
     expect(h.push).toHaveBeenCalledWith('/coach/ath1')
+  })
+
+  it('edit mode: prefills from the template and saves via updateTemplate', async () => {
+    h.params = { athleteId: 'ath1', templateId: 't9' }
+    h.getTemplate.mockResolvedValue({
+      id: 't9',
+      name: 'Existing',
+      type: 'circuit',
+      rounds: 3,
+      source: null,
+      notes: null,
+      created_at: null,
+      items: [
+        {
+          id: 'i1',
+          exercise_key: 'pushups',
+          section: 'main',
+          position: 0,
+          target_reps: 15,
+          target_duration_seconds: null,
+          target_load_kg: null,
+          target_distance_m: null,
+          rest_seconds: null,
+          variant: null,
+          notes: null,
+        },
+      ],
+    })
+    h.updateTemplate.mockResolvedValue({ id: 't9' })
+    const w = await mountBuilder()
+
+    expect(w.text()).toContain('Edit workout')
+    expect(h.getTemplate).toHaveBeenCalledWith('t9', 'ath1')
+    expect(w.find('[data-testid="item-pushups"]').exists()).toBe(true) // prefilled
+
+    await w.find('[data-testid="save"]').trigger('click')
+    await flushPromises()
+    expect(h.updateTemplate).toHaveBeenCalledTimes(1)
+    expect(h.updateTemplate.mock.calls[0][0]).toBe('t9')
+    expect(h.createTemplate).not.toHaveBeenCalled()
   })
 
   it('removes an added item', async () => {

--- a/src/shared/supabase_ops/workout_repository.py
+++ b/src/shared/supabase_ops/workout_repository.py
@@ -169,6 +169,36 @@ class WorkoutTemplatesRepository:
         assert got is not None
         return got
 
+    def update(
+        self,
+        user_id: UUID,
+        template_id: UUID,
+        payload: dict[str, Any],
+        athlete_id: UUID | None = None,
+    ) -> dict[str, Any] | None:
+        """Update a template the caller owns and replace its items. None if not
+        found / not theirs."""
+        if self.get(user_id, template_id, athlete_id) is None:
+            return None
+
+        items: Sequence[dict[str, Any]] | None = payload.pop("items", None)
+        if payload:
+            self.supabase.table("workout_templates").update(payload).eq(
+                "id", str(template_id)
+            ).execute()
+
+        if items is not None:
+            # Replace the item set wholesale (simplest correct edit).
+            self.supabase.table("template_items").delete().eq(
+                "template_id", str(template_id)
+            ).execute()
+            if items:
+                owner = _owner_fields(user_id, athlete_id)
+                item_rows = [{**it, **owner, "template_id": str(template_id)} for it in items]
+                self.supabase.table("template_items").insert(item_rows).execute()
+
+        return self.get(user_id, template_id, athlete_id)
+
     def list(self, user_id: UUID, athlete_id: UUID | None = None) -> list[dict[str, Any]]:
         query = _scope(self.supabase.table("workout_templates").select("*"), user_id, athlete_id)
         templates = cast(list[dict[str, Any]], query.order("created_at", desc=True).execute().data)


### PR DESCRIPTION
Load a saved template back into the builder, change it, and save.

## Backend
- `WorkoutTemplatesRepository.update` — owner-scoped; updates fields + **replaces the item set** wholesale. `PATCH /workouts/templates/{id}` (act-as, validates exercise keys, 404 if not found/owned).
- Verified against the local DB (fields + items replaced; stranger → None) + a fake-client round-trip test.

## Frontend
- `getTemplate` / `updateTemplate` composables.
- The **builder accepts a `:templateId` param** — prefills name/type/rounds and items (**kg → lb**, key → Exercise), saves via **PATCH**; title → "Edit workout".
- **Edit** (pencil) action on the card → `/coach/:athleteId/build/:id`.

## Tests
Repo update round-trip; builder edit mode (prefill + save-via-update, not create); card edit/delete emits. Backend **207**, frontend **144** (no new failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)