### PR TITLE
fix: print a single workout on its own page (SB-229)

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -41,3 +41,28 @@
     @apply block text-sm font-semibold text-gray-700 mb-1;
   }
 }
+
+/* Print a single workout card on its own page. The card's Print button adds
+   `printing-card` to <body> and `print-target` to the card being printed, so a
+   normal browser print (whole page) is unaffected. */
+@media print {
+  body.printing-card * {
+    visibility: hidden;
+  }
+  body.printing-card .print-target,
+  body.printing-card .print-target * {
+    visibility: visible;
+  }
+  body.printing-card .print-target {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    box-shadow: none !important;
+    border: none !important;
+    page-break-inside: avoid;
+  }
+  @page {
+    margin: 14mm;
+  }
+}

--- a/frontend/src/components/WorkoutTemplateCard.vue
+++ b/frontend/src/components/WorkoutTemplateCard.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden print:shadow-none print:border-gray-300">
+  <div
+    ref="rootEl"
+    class="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden print:shadow-none print:border-gray-300"
+  >
     <!-- Header -->
     <div class="flex items-start justify-between gap-3 p-5 border-b border-gray-100">
       <div class="min-w-0">
@@ -69,7 +72,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { Pencil, Printer, Repeat, Trash2 } from 'lucide-vue-next'
 import type { Exercise, TemplateItem, WorkoutSectionKey, WorkoutTemplate } from '@/types/workout'
 import { SECTIONS, fmtDuration, kgToLb, prettifyKey } from '@/utils/workoutPayload'
@@ -124,7 +127,25 @@ const pills = (it: TemplateItem): Pill[] => {
   return out
 }
 
-const print = (): void => window.print()
+const rootEl = ref<HTMLElement | null>(null)
+
+// Print just this card on its own page: mark it + <body>, print, then clean up.
+const print = (): void => {
+  const el = rootEl.value
+  if (!el) {
+    window.print()
+    return
+  }
+  document.body.classList.add('printing-card')
+  el.classList.add('print-target')
+  const cleanup = (): void => {
+    document.body.classList.remove('printing-card')
+    el.classList.remove('print-target')
+    window.removeEventListener('afterprint', cleanup)
+  }
+  window.addEventListener('afterprint', cleanup)
+  window.print()
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
The card's **Print** used `window.print()`, which printed the **whole page** (nav + every workout). Now it isolates the clicked workout:

- Print marks `<body>.printing-card` + the card `.print-target`; an `@media print` rule hides everything else and positions the card at the top → prints **alone on one page** (`page-break-inside: avoid`, 14mm margins). Cleaned up on `afterprint`.
- A normal browser print (whole page) is unaffected.

(Basis for SB-231's designed take-home layouts.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)