### PR TITLE
feat: coach web session logger (SB-230)

### DIFF
--- a/frontend/src/components/WorkoutTemplateCard.vue
+++ b/frontend/src/components/WorkoutTemplateCard.vue
@@ -15,6 +15,16 @@
         </div>
       </div>
       <div class="flex items-center gap-1 shrink-0 print:hidden">
+        <button
+          type="button"
+          class="act hover:text-brand-600 hover:bg-brand-50"
+          title="Log this"
+          aria-label="Log this workout"
+          data-testid="log-this"
+          @click="$emit('log')"
+        >
+          <ClipboardCheck class="w-4 h-4" />
+        </button>
         <button type="button" class="act" title="Print" aria-label="Print workout" @click="print">
           <Printer class="w-4 h-4" />
         </button>
@@ -73,7 +83,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { Pencil, Printer, Repeat, Trash2 } from 'lucide-vue-next'
+import { ClipboardCheck, Pencil, Printer, Repeat, Trash2 } from 'lucide-vue-next'
 import type { Exercise, TemplateItem, WorkoutSectionKey, WorkoutTemplate } from '@/types/workout'
 import { SECTIONS, fmtDuration, kgToLb, prettifyKey } from '@/utils/workoutPayload'
 
@@ -82,7 +92,7 @@ const props = defineProps<{
   exercises?: Exercise[]
 }>()
 
-defineEmits<{ (e: 'edit'): void; (e: 'delete'): void }>()
+defineEmits<{ (e: 'edit'): void; (e: 'delete'): void; (e: 'log'): void }>()
 
 const byKey = computed<Record<string, Exercise>>(() => {
   const map: Record<string, Exercise> = {}

--- a/frontend/src/composables/useWorkoutSessions.ts
+++ b/frontend/src/composables/useWorkoutSessions.ts
@@ -1,0 +1,18 @@
+import { apiCall } from '@/config/api'
+import type { WorkoutSessionInput } from '@/types/workout'
+
+/**
+ * Log a completed workout session on an athlete's account. The coach acts on
+ * the athlete's behalf via X-Act-As-Athlete (the backend verifies the coach
+ * actually coaches that athlete). Mirrors useWorkoutTemplates.createTemplate.
+ */
+export async function createSession(
+  payload: WorkoutSessionInput,
+  athleteId: string,
+): Promise<{ id: string }> {
+  return apiCall<{ id: string }>('/workouts/sessions', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+    headers: { 'X-Act-As-Athlete': athleteId },
+  })
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -79,6 +79,18 @@ const router = createRouter({
       meta: { requiresAuth: true },
     },
     {
+      path: '/coach/:athleteId/log',
+      name: 'workout-logger',
+      component: () => import('@/views/WorkoutSessionLoggerView.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/coach/:athleteId/log/:templateId',
+      name: 'workout-logger-template',
+      component: () => import('@/views/WorkoutSessionLoggerView.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
       path: '/exercises',
       name: 'exercise-catalog',
       component: () => import('@/views/ExerciseCatalogView.vue'),

--- a/frontend/src/types/workout.ts
+++ b/frontend/src/types/workout.ts
@@ -112,3 +112,56 @@ export interface BuilderItem {
   variant: string | null
   notes: string | null
 }
+
+// --------------------------------------------------------------------------- //
+// Session logging (the actual performance — SB-230)
+// --------------------------------------------------------------------------- //
+
+/** One logged set in the API payload. Only the used dimensions are filled. */
+export interface SessionSetInput {
+  exercise_key: string
+  round_number?: number | null
+  set_index?: number | null
+  variant?: string | null
+  reps?: number | null
+  duration_seconds?: number | null
+  load_kg?: number | null
+  distance_m?: number | null
+  time_seconds?: number | null
+  rpe?: number | null
+  notes?: string | null
+}
+
+export interface WorkoutSessionInput {
+  session_date: string
+  template_id?: string | null
+  type: WorkoutType
+  total_minutes?: number | null
+  how_felt?: string | null
+  notes?: string | null
+  sets: SessionSetInput[]
+}
+
+/**
+ * One attempt of an exercise while logging — a single set. A 40-dash logged
+ * three times is three attempts on one row (each its own set_index/time).
+ * Loads are entered in lb (US coach), stored as kg.
+ */
+export interface LoggerAttempt {
+  reps: number | null
+  duration_s: number | null
+  load_lb: number | null
+  distance_m: number | null
+  time_seconds: number | null
+  rpe: number | null
+}
+
+/** One exercise being logged, with one or more attempts (sets). */
+export interface LoggerRow {
+  uid: number
+  exercise: Exercise
+  round_number: number | null
+  variant: string | null
+  notes: string | null
+  attempts: LoggerAttempt[]
+}

--- a/frontend/src/utils/__tests__/sessionPayload.test.ts
+++ b/frontend/src/utils/__tests__/sessionPayload.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest'
+import {
+  blankAttempt,
+  buildSessionPayload,
+  templateToRows,
+  type SessionMeta,
+} from '@/utils/sessionPayload'
+import type { Exercise, LoggerAttempt, LoggerRow, WorkoutTemplate } from '@/types/workout'
+
+const ex = (key: string, measures: string[] = []): Exercise => ({
+  key,
+  display_name: key,
+  category: 'strength',
+  measures,
+  is_benchmark: false,
+  owner_id: null,
+  visibility: 'public',
+  created_by: null,
+  forked_from: null,
+  aliases: [],
+  movement_pattern: null,
+  equipment: [],
+  body_region: [],
+  laterality: null,
+  difficulty: null,
+  tags: [],
+  media_url: null,
+  thumbnail_url: null,
+  cues: [],
+  instructions: null,
+})
+
+let uid = 0
+const attempt = (over: Partial<LoggerAttempt> = {}): LoggerAttempt => ({ ...blankAttempt(), ...over })
+const row = (key: string, over: Partial<LoggerRow> = {}): LoggerRow => ({
+  uid: uid++,
+  exercise: ex(key),
+  round_number: null,
+  variant: null,
+  notes: null,
+  attempts: [blankAttempt()],
+  ...over,
+})
+
+const meta: SessionMeta = {
+  session_date: '2026-07-06',
+  type: 'circuit',
+  total_minutes: 45,
+  how_felt: 'good',
+  notes: '  solid  ',
+  template_id: 't1',
+}
+
+describe('buildSessionPayload', () => {
+  it('carries session meta and trims notes', () => {
+    const p = buildSessionPayload(meta, [row('pushups', { attempts: [attempt({ reps: 10 })] })])
+    expect(p).toMatchObject({
+      session_date: '2026-07-06',
+      type: 'circuit',
+      total_minutes: 45,
+      how_felt: 'good',
+      notes: 'solid',
+      template_id: 't1',
+    })
+  })
+
+  it('converts load lb → kg per attempt', () => {
+    const p = buildSessionPayload(meta, [row('carry', { attempts: [attempt({ load_lb: 10 })] })])
+    expect(p.sets[0].load_kg).toBe(4.5)
+  })
+
+  it('logs multiple attempts as sets with a 1-based set_index and time each', () => {
+    const dash = row('40_yard_dash', {
+      attempts: [
+        attempt({ time_seconds: 5.4 }),
+        attempt({ time_seconds: 5.2 }),
+        attempt({ time_seconds: 5.3 }),
+      ],
+    })
+    const p = buildSessionPayload(meta, [dash])
+    expect(p.sets).toHaveLength(3)
+    expect(p.sets.map((s) => [s.set_index, s.time_seconds])).toEqual([
+      [1, 5.4],
+      [2, 5.2],
+      [3, 5.3],
+    ])
+    expect(p.sets.every((s) => s.exercise_key === '40_yard_dash')).toBe(true)
+  })
+
+  it('single attempt gets a null set_index', () => {
+    const p = buildSessionPayload(meta, [row('pushups', { attempts: [attempt({ reps: 12 })] })])
+    expect(p.sets).toHaveLength(1)
+    expect(p.sets[0].set_index).toBeNull()
+    expect(p.sets[0].reps).toBe(12)
+  })
+
+  it('drops empty attempts and fully-empty rows', () => {
+    const p = buildSessionPayload(meta, [
+      row('pushups', { attempts: [attempt({ reps: 8 }), attempt()] }), // 2nd empty
+      row('plank', { attempts: [attempt()] }), // all empty → dropped
+    ])
+    expect(p.sets).toHaveLength(1)
+    expect(p.sets[0].exercise_key).toBe('pushups')
+    expect(p.sets[0].set_index).toBeNull() // only one non-empty attempt survived
+  })
+
+  it('carries round_number + trims variant, notes on first set only', () => {
+    const p = buildSessionPayload(meta, [
+      row('pushups', {
+        round_number: 2,
+        variant: '  left  ',
+        notes: '  felt strong  ',
+        attempts: [attempt({ reps: 10 }), attempt({ reps: 9 })],
+      }),
+    ])
+    expect(p.sets[0]).toMatchObject({ round_number: 2, variant: 'left', notes: 'felt strong' })
+    expect(p.sets[1].notes).toBeNull()
+  })
+})
+
+describe('templateToRows', () => {
+  const tpl: WorkoutTemplate = {
+    id: 't1',
+    name: 'Monday - Circuit',
+    type: 'circuit',
+    rounds: 3,
+    source: null,
+    notes: null,
+    created_at: null,
+    items: [
+      { id: 'i2', exercise_key: 'plank', section: 'main', position: 1, target_reps: null, target_duration_seconds: 60, target_load_kg: null, target_distance_m: null, rest_seconds: null, variant: 'front', notes: null },
+      { id: 'i1', exercise_key: 'pushups', section: 'main', position: 0, target_reps: 15, target_duration_seconds: null, target_load_kg: null, target_distance_m: null, rest_seconds: null, variant: null, notes: null },
+    ],
+  }
+
+  it('prefills rows ordered by position, one blank attempt each, catalog name resolved', () => {
+    const byKey = new Map([['pushups', ex('pushups', ['reps'])]])
+    const rows = templateToRows(tpl, byKey, 10)
+    expect(rows.map((r) => r.exercise.key)).toEqual(['pushups', 'plank'])
+    expect(rows[0].uid).toBe(10)
+    expect(rows[1].uid).toBe(11)
+    expect(rows[0].exercise.measures).toEqual(['reps']) // resolved from catalog
+    expect(rows[1].exercise.display_name).toBe('plank') // fallback (not in catalog)
+    expect(rows[1].variant).toBe('front') // carried from template item
+    expect(rows.every((r) => r.attempts.length === 1)).toBe(true)
+  })
+})

--- a/frontend/src/utils/sessionPayload.ts
+++ b/frontend/src/utils/sessionPayload.ts
@@ -1,0 +1,117 @@
+import type {
+  Exercise,
+  LoggerAttempt,
+  LoggerRow,
+  SessionSetInput,
+  WorkoutSessionInput,
+  WorkoutTemplate,
+  WorkoutType,
+} from '@/types/workout'
+import { lbToKg } from '@/utils/workoutPayload'
+
+/** Felt options: emoji shown to the coach → stored how_felt string. */
+export const FELT_OPTIONS: { emoji: string; value: string; label: string }[] = [
+  { emoji: '☺', value: 'good', label: 'Good' },
+  { emoji: '😐', value: 'ok', label: 'OK' },
+  { emoji: '☹', value: 'rough', label: 'Rough' },
+]
+
+/** Today as an ISO date (YYYY-MM-DD), the default session_date. */
+export function todayISO(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+/** A fresh empty attempt (one set of an exercise). */
+export function blankAttempt(): LoggerAttempt {
+  return {
+    reps: null,
+    duration_s: null,
+    load_lb: null,
+    distance_m: null,
+    time_seconds: null,
+    rpe: null,
+  }
+}
+
+/** An attempt with no measurable value — dropped from the payload. */
+function isEmptyAttempt(a: LoggerAttempt): boolean {
+  return (
+    a.reps == null &&
+    a.duration_s == null &&
+    a.load_lb == null &&
+    a.distance_m == null &&
+    a.time_seconds == null &&
+    a.rpe == null
+  )
+}
+
+export interface SessionMeta {
+  session_date: string
+  type: WorkoutType
+  total_minutes: number | null
+  how_felt: string | null
+  notes: string | null
+  template_id: string | null
+}
+
+/**
+ * Turn the logger's local rows into the API payload. Each non-empty attempt
+ * becomes a set with a 1-based set_index within its row; loads convert lb → kg.
+ * Rows whose attempts are all empty are dropped. Pure + deterministic.
+ */
+export function buildSessionPayload(meta: SessionMeta, rows: LoggerRow[]): WorkoutSessionInput {
+  const sets: SessionSetInput[] = []
+  for (const row of rows) {
+    const filled = row.attempts.filter((a) => !isEmptyAttempt(a))
+    const multi = filled.length > 1
+    filled.forEach((a, i) => {
+      sets.push({
+        exercise_key: row.exercise.key,
+        round_number: row.round_number,
+        set_index: multi ? i + 1 : null,
+        variant: row.variant?.trim() || null,
+        reps: a.reps,
+        duration_seconds: a.duration_s,
+        load_kg: lbToKg(a.load_lb),
+        distance_m: a.distance_m,
+        time_seconds: a.time_seconds,
+        rpe: a.rpe,
+        notes: i === 0 ? row.notes?.trim() || null : null,
+      })
+    })
+  }
+  return {
+    session_date: meta.session_date,
+    template_id: meta.template_id,
+    type: meta.type,
+    total_minutes: meta.total_minutes,
+    how_felt: meta.how_felt,
+    notes: meta.notes?.trim() || null,
+    sets,
+  }
+}
+
+/**
+ * Prefill logger rows from a template's items (ordered by position), one blank
+ * attempt each. The coach logs actuals against the prescription. `byKey` maps
+ * exercise_key → catalog Exercise (for display name + which measures to show).
+ */
+export function templateToRows(
+  tpl: WorkoutTemplate,
+  byKey: Map<string, Exercise>,
+  startUid: number,
+): LoggerRow[] {
+  return tpl.items
+    .slice()
+    .sort((a, b) => a.position - b.position)
+    .map((it, i) => ({
+      uid: startUid + i,
+      exercise:
+        byKey.get(it.exercise_key) ??
+        ({ key: it.exercise_key, display_name: it.exercise_key, measures: [] } as unknown as Exercise),
+      round_number: null,
+      variant: it.variant,
+      notes: null,
+      attempts: [blankAttempt()],
+    }))
+}

--- a/frontend/src/views/AthleteDetailView.vue
+++ b/frontend/src/views/AthleteDetailView.vue
@@ -26,6 +26,9 @@
           <RouterLink :to="`/coach/${athlete.id}/build`" class="btn-primary text-sm">
             + Build workout
           </RouterLink>
+          <RouterLink :to="`/coach/${athlete.id}/log`" class="btn-secondary text-sm" data-testid="log-workout">
+            Log workout
+          </RouterLink>
         </div>
       </div>
 
@@ -56,6 +59,7 @@
           :template="t"
           :exercises="exercises"
           @edit="router.push(`/coach/${athleteId}/build/${t.id}`)"
+          @log="router.push(`/coach/${athleteId}/log/${t.id}`)"
           @delete="onDeleteTemplate(t.id)"
         />
       </div>

--- a/frontend/src/views/WorkoutSessionLoggerView.vue
+++ b/frontend/src/views/WorkoutSessionLoggerView.vue
@@ -1,0 +1,325 @@
+<template>
+  <div class="container-app py-8">
+    <RouterLink :to="`/coach/${athleteId}`" class="text-sm text-brand-600 hover:text-brand-700">
+      ← Back
+    </RouterLink>
+
+    <h1 class="text-2xl font-bold text-gray-900 mt-4">Log workout</h1>
+    <p v-if="templateName" class="text-sm text-gray-500 mt-1" data-testid="from-template">
+      From <span class="font-medium text-gray-700">{{ templateName }}</span>
+    </p>
+
+    <!-- Session meta -->
+    <div class="bg-white rounded-2xl border border-gray-100 shadow-sm p-5 mt-4 space-y-3">
+      <div class="grid grid-cols-2 gap-3">
+        <label class="flex flex-col gap-1 text-sm text-gray-600">
+          Date
+          <input v-model="sessionDate" type="date" class="form-input" data-testid="session-date" />
+        </label>
+        <label class="flex flex-col gap-1 text-sm text-gray-600">
+          Total minutes
+          <input
+            v-model.number="totalMinutes"
+            type="number"
+            min="0"
+            class="form-input"
+            data-testid="total-minutes"
+          />
+        </label>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <span class="text-sm text-gray-600">Felt</span>
+        <button
+          v-for="f in FELT_OPTIONS"
+          :key="f.value"
+          type="button"
+          class="felt"
+          :class="howFelt === f.value ? 'felt-on' : 'felt-off'"
+          :data-testid="`felt-${f.value}`"
+          :aria-label="f.label"
+          @click="howFelt = howFelt === f.value ? null : f.value"
+        >
+          {{ f.emoji }}
+        </button>
+      </div>
+
+      <textarea
+        v-model="notes"
+        placeholder="Session notes (optional)"
+        rows="2"
+        class="form-input w-full"
+        data-testid="session-notes"
+      />
+    </div>
+
+    <!-- Logged exercises -->
+    <div
+      v-for="row in rows"
+      :key="row.uid"
+      class="bg-white rounded-xl border border-gray-200 p-3 mt-3"
+      :data-testid="`row-${row.exercise.key}`"
+    >
+      <div class="flex items-start justify-between gap-2">
+        <span class="text-sm font-medium text-gray-900">{{ row.exercise.display_name }}</span>
+        <button
+          type="button"
+          class="icon-btn text-red-500"
+          :data-testid="`remove-${row.exercise.key}`"
+          title="Remove"
+          @click="removeRow(row)"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div class="mt-2 flex flex-wrap gap-2 text-xs">
+        <label class="field">
+          Round
+          <input v-model.number="row.round_number" type="number" min="1" class="w-14 num"
+            :data-testid="`round-${row.exercise.key}`" />
+        </label>
+        <label class="field">
+          Variant
+          <input v-model="row.variant" placeholder="e.g. left" class="w-20 num"
+            :data-testid="`variant-${row.exercise.key}`" />
+        </label>
+      </div>
+
+      <!-- Attempts (sets) -->
+      <div
+        v-for="(a, i) in row.attempts"
+        :key="i"
+        class="mt-2 flex flex-wrap items-center gap-2 text-xs"
+        :data-testid="`attempt-${row.exercise.key}-${i}`"
+      >
+        <span v-if="row.attempts.length > 1" class="w-8 text-gray-400 tabular-nums">#{{ i + 1 }}</span>
+        <label v-for="f in fieldsFor(row)" :key="f.model" class="field">
+          {{ f.label }}
+          <input
+            v-model.number="a[f.model]"
+            type="number"
+            min="0"
+            step="any"
+            class="w-16 num"
+            :data-testid="`${f.model}-${row.exercise.key}-${i}`"
+          />
+        </label>
+        <label class="field">
+          RPE
+          <input v-model.number="a.rpe" type="number" min="1" max="10" class="w-12 num"
+            :data-testid="`rpe-${row.exercise.key}-${i}`" />
+        </label>
+        <button
+          v-if="row.attempts.length > 1"
+          type="button"
+          class="icon-btn text-gray-400"
+          :data-testid="`remove-set-${row.exercise.key}-${i}`"
+          title="Remove set"
+          @click="removeAttempt(row, i)"
+        >
+          ✕
+        </button>
+      </div>
+
+      <button
+        type="button"
+        class="btn-secondary text-xs mt-2"
+        :data-testid="`add-set-${row.exercise.key}`"
+        @click="row.attempts.push(blankAttempt())"
+      >
+        + Add set
+      </button>
+    </div>
+
+    <!-- Add exercise -->
+    <div class="mt-4">
+      <button
+        type="button"
+        class="btn-secondary text-xs"
+        data-testid="add-exercise"
+        @click="picking = !picking"
+      >
+        {{ picking ? 'Done adding' : '+ Add exercise' }}
+      </button>
+      <ExercisePicker
+        v-if="picking"
+        :exercises="exercises"
+        :selected-keys="rowKeys"
+        mode="select"
+        class="bg-gray-50 rounded-xl p-3 mt-2"
+        @toggle="onPick"
+      />
+    </div>
+
+    <!-- Save -->
+    <div class="mt-6 flex items-center gap-3">
+      <button
+        type="button"
+        class="btn-primary"
+        :disabled="!canSave || saving"
+        data-testid="save"
+        @click="save"
+      >
+        {{ saving ? 'Saving…' : 'Save session' }}
+      </button>
+      <span v-if="error" class="text-sm text-red-600">{{ error }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import ExercisePicker from '@/components/ExercisePicker.vue'
+import { useExercises } from '@/composables/useExercises'
+import { useRoles } from '@/composables/useCoach'
+import { getTemplate } from '@/composables/useWorkoutTemplates'
+import { createSession } from '@/composables/useWorkoutSessions'
+import {
+  FELT_OPTIONS,
+  blankAttempt,
+  buildSessionPayload,
+  templateToRows,
+  todayISO,
+} from '@/utils/sessionPayload'
+import type { Exercise, LoggerRow, WorkoutType } from '@/types/workout'
+
+const route = useRoute()
+const router = useRouter()
+const athleteId = route.params.athleteId as string
+const templateId = (route.params.templateId as string | undefined) || null
+
+const { isCoach, loadRoles } = useRoles()
+const { exercises, load } = useExercises()
+
+const sessionDate = ref(todayISO())
+const totalMinutes = ref<number | null>(null)
+const howFelt = ref<string | null>(null)
+const notes = ref<string | null>(null)
+const rows = ref<LoggerRow[]>([])
+const templateName = ref<string | null>(null)
+const sessionType = ref<WorkoutType>('circuit')
+const picking = ref(false)
+const saving = ref(false)
+const error = ref<string | null>(null)
+
+let nextUid = 1
+
+const rowKeys = computed(() => rows.value.map((r) => r.exercise.key))
+
+// Which numeric fields to show per attempt — the exercise's own measures, or a
+// reps + time fallback when the catalog carries none. RPE is always shown.
+interface FieldDef {
+  measure: string
+  label: string
+  model: 'reps' | 'duration_s' | 'load_lb' | 'distance_m' | 'time_seconds'
+}
+const FIELD_DEFS: FieldDef[] = [
+  { measure: 'reps', label: 'Reps', model: 'reps' },
+  { measure: 'duration_s', label: 'Secs', model: 'duration_s' },
+  { measure: 'load_kg', label: 'Load(lb)', model: 'load_lb' },
+  { measure: 'distance_m', label: 'Dist(m)', model: 'distance_m' },
+  { measure: 'time_seconds', label: 'Time(s)', model: 'time_seconds' },
+]
+const FALLBACK: FieldDef[] = [FIELD_DEFS[0], FIELD_DEFS[4]] // reps + time
+
+const fieldsFor = (row: LoggerRow): FieldDef[] => {
+  const shown = FIELD_DEFS.filter((f) => row.exercise.measures.includes(f.measure))
+  return shown.length ? shown : FALLBACK
+}
+
+const onPick = (ex: Exercise): void => {
+  const existing = rows.value.find((r) => r.exercise.key === ex.key)
+  if (existing) {
+    removeRow(existing) // toggle off
+    return
+  }
+  rows.value.push({
+    uid: nextUid++,
+    exercise: ex,
+    round_number: null,
+    variant: null,
+    notes: null,
+    attempts: [blankAttempt()],
+  })
+}
+
+const removeRow = (row: LoggerRow): void => {
+  rows.value = rows.value.filter((r) => r.uid !== row.uid)
+}
+
+const removeAttempt = (row: LoggerRow, i: number): void => {
+  row.attempts.splice(i, 1)
+}
+
+const payload = computed(() =>
+  buildSessionPayload(
+    {
+      session_date: sessionDate.value,
+      type: sessionType.value,
+      total_minutes: totalMinutes.value,
+      how_felt: howFelt.value,
+      notes: notes.value,
+      template_id: templateId,
+    },
+    rows.value,
+  ),
+)
+
+const canSave = computed(() => sessionDate.value.length > 0 && payload.value.sets.length > 0)
+
+const save = async (): Promise<void> => {
+  if (!canSave.value) return
+  saving.value = true
+  error.value = null
+  try {
+    await createSession(payload.value, athleteId)
+    router.push(`/coach/${athleteId}`)
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to save session'
+  } finally {
+    saving.value = false
+  }
+}
+
+const prefillFrom = (id: string): Promise<void> =>
+  getTemplate(id, athleteId).then((tpl) => {
+    templateName.value = tpl.name
+    sessionType.value = tpl.type
+    const byKey = new Map(exercises.value.map((e) => [e.key, e]))
+    rows.value = templateToRows(tpl, byKey, nextUid)
+    nextUid += rows.value.length
+  })
+
+onMounted(async () => {
+  await loadRoles()
+  if (!isCoach.value) {
+    router.replace('/dashboard')
+    return
+  }
+  await load()
+  if (templateId) await prefillFrom(templateId)
+})
+</script>
+
+<style scoped>
+.field {
+  @apply inline-flex items-center gap-1 text-gray-600;
+}
+.num {
+  @apply border border-gray-200 rounded px-1.5 py-0.5 text-xs;
+}
+.icon-btn {
+  @apply px-1.5 py-0.5 rounded hover:bg-gray-100 text-gray-500 text-sm;
+}
+.felt {
+  @apply w-9 h-9 rounded-full text-lg grid place-items-center border transition-colors;
+}
+.felt-on {
+  @apply border-brand-400 bg-brand-50;
+}
+.felt-off {
+  @apply border-gray-200 hover:bg-gray-50;
+}
+</style>

--- a/frontend/src/views/__tests__/WorkoutSessionLoggerView.test.ts
+++ b/frontend/src/views/__tests__/WorkoutSessionLoggerView.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+const h = vi.hoisted(() => ({
+  createSession: vi.fn(),
+  getTemplate: vi.fn(),
+  push: vi.fn(),
+  replace: vi.fn(),
+  isCoach: { value: true },
+  loadRoles: vi.fn().mockResolvedValue(undefined),
+  load: vi.fn().mockResolvedValue(undefined),
+  params: { athleteId: 'ath1' } as Record<string, string>,
+}))
+
+const catalog = [
+  {
+    key: 'pushups', display_name: 'Push-ups', category: 'strength', measures: ['reps', 'duration_s'],
+    is_benchmark: false, owner_id: null, visibility: 'public', created_by: null, forked_from: null,
+    aliases: [], movement_pattern: 'push', equipment: [], body_region: [], laterality: null,
+    difficulty: null, tags: [], media_url: null, thumbnail_url: null, cues: [], instructions: null,
+  },
+  {
+    key: 'farmers_carry', display_name: "Farmer's carry", category: 'strength', measures: ['duration_s', 'load_kg'],
+    is_benchmark: false, owner_id: null, visibility: 'public', created_by: null, forked_from: null,
+    aliases: [], movement_pattern: 'carry', equipment: ['dumbbell'], body_region: [], laterality: null,
+    difficulty: null, tags: [], media_url: null, thumbnail_url: null, cues: [], instructions: null,
+  },
+  {
+    key: '40_yard_dash', display_name: '40-yard dash', category: 'test', measures: ['time_seconds'],
+    is_benchmark: true, owner_id: null, visibility: 'public', created_by: null, forked_from: null,
+    aliases: [], movement_pattern: 'sprint', equipment: [], body_region: [], laterality: null,
+    difficulty: null, tags: [], media_url: null, thumbnail_url: null, cues: [], instructions: null,
+  },
+]
+
+vi.mock('@/composables/useExercises', async () => {
+  const { ref } = await import('vue')
+  return { useExercises: () => ({ exercises: ref(catalog), load: h.load, loading: ref(false), error: ref(null) }) }
+})
+vi.mock('@/composables/useCoach', () => ({
+  useRoles: () => ({ isCoach: h.isCoach, loadRoles: h.loadRoles }),
+}))
+vi.mock('@/composables/useWorkoutTemplates', () => ({
+  getTemplate: (...a: unknown[]) => h.getTemplate(...a),
+}))
+vi.mock('@/composables/useWorkoutSessions', () => ({
+  createSession: (...a: unknown[]) => h.createSession(...a),
+}))
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: h.params }),
+  useRouter: () => ({ push: h.push, replace: h.replace }),
+  RouterLink: { template: '<a><slot /></a>' },
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.isCoach.value = true
+  h.params = { athleteId: 'ath1' }
+})
+
+async function mountLogger() {
+  const View = (await import('../WorkoutSessionLoggerView.vue')).default
+  const w = mount(View, { global: { stubs: { RouterLink: true } } })
+  await flushPromises()
+  return w
+}
+
+describe('WorkoutSessionLoggerView', () => {
+  it('redirects non-coaches', async () => {
+    h.isCoach.value = false
+    await mountLogger()
+    expect(h.replace).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('adds an exercise via the picker', async () => {
+    const w = await mountLogger()
+    await w.find('[data-testid="add-exercise"]').trigger('click')
+    await w.find('[data-testid="ex-pushups"]').trigger('click')
+    expect(w.find('[data-testid="row-pushups"]').exists()).toBe(true)
+  })
+
+  it('save is disabled until a set has a value', async () => {
+    const w = await mountLogger()
+    expect((w.find('[data-testid="save"]').element as HTMLButtonElement).disabled).toBe(true)
+    await w.find('[data-testid="add-exercise"]').trigger('click')
+    await w.find('[data-testid="ex-pushups"]').trigger('click')
+    // row added but no value yet → still disabled
+    expect((w.find('[data-testid="save"]').element as HTMLButtonElement).disabled).toBe(true)
+    await w.find('[data-testid="reps-pushups-0"]').setValue(12)
+    expect((w.find('[data-testid="save"]').element as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('saves a session with act-as and lb→kg conversion', async () => {
+    h.createSession.mockResolvedValue({ id: 's1' })
+    const w = await mountLogger()
+    await w.find('[data-testid="add-exercise"]').trigger('click')
+    await w.find('[data-testid="ex-farmers_carry"]').trigger('click')
+    await w.find('[data-testid="load_lb-farmers_carry-0"]').setValue(10)
+    await w.find('[data-testid="save"]').trigger('click')
+    await flushPromises()
+
+    expect(h.createSession).toHaveBeenCalledTimes(1)
+    const [payload, athleteId] = h.createSession.mock.calls[0]
+    expect(athleteId).toBe('ath1')
+    expect(payload.sets[0]).toMatchObject({ exercise_key: 'farmers_carry', load_kg: 4.5 })
+    expect(h.push).toHaveBeenCalledWith('/coach/ath1')
+  })
+
+  it('logs a benchmark three times — three sets with time + set_index', async () => {
+    h.createSession.mockResolvedValue({ id: 's2' })
+    const w = await mountLogger()
+    await w.find('[data-testid="add-exercise"]').trigger('click')
+    await w.find('[data-testid="ex-40_yard_dash"]').trigger('click')
+    await w.find('[data-testid="add-set-40_yard_dash"]').trigger('click')
+    await w.find('[data-testid="add-set-40_yard_dash"]').trigger('click')
+    await w.find('[data-testid="time_seconds-40_yard_dash-0"]').setValue(5.4)
+    await w.find('[data-testid="time_seconds-40_yard_dash-1"]').setValue(5.2)
+    await w.find('[data-testid="time_seconds-40_yard_dash-2"]').setValue(5.3)
+    await w.find('[data-testid="save"]').trigger('click')
+    await flushPromises()
+
+    const [payload] = h.createSession.mock.calls[0]
+    expect(payload.sets).toHaveLength(3)
+    expect(payload.sets.map((s: { set_index: number; time_seconds: number }) => [s.set_index, s.time_seconds])).toEqual([
+      [1, 5.4],
+      [2, 5.2],
+      [3, 5.3],
+    ])
+  })
+
+  it('from a template: prefills rows and posts template_id', async () => {
+    h.params = { athleteId: 'ath1', templateId: 't9' }
+    h.getTemplate.mockResolvedValue({
+      id: 't9',
+      name: 'Monday - Circuit',
+      type: 'circuit',
+      rounds: 3,
+      source: null,
+      notes: null,
+      created_at: null,
+      items: [
+        { id: 'i1', exercise_key: 'pushups', section: 'main', position: 0, target_reps: 15, target_duration_seconds: null, target_load_kg: null, target_distance_m: null, rest_seconds: null, variant: null, notes: null },
+      ],
+    })
+    h.createSession.mockResolvedValue({ id: 's3' })
+    const w = await mountLogger()
+
+    expect(h.getTemplate).toHaveBeenCalledWith('t9', 'ath1')
+    expect(w.find('[data-testid="from-template"]').text()).toContain('Monday - Circuit')
+    expect(w.find('[data-testid="row-pushups"]').exists()).toBe(true)
+
+    await w.find('[data-testid="reps-pushups-0"]').setValue(14)
+    await w.find('[data-testid="save"]').trigger('click')
+    await flushPromises()
+    const [payload] = h.createSession.mock.calls[0]
+    expect(payload.template_id).toBe('t9')
+    expect(payload.sets[0]).toMatchObject({ exercise_key: 'pushups', reps: 14 })
+  })
+
+  it('removes an added row', async () => {
+    const w = await mountLogger()
+    await w.find('[data-testid="add-exercise"]').trigger('click')
+    await w.find('[data-testid="ex-pushups"]').trigger('click')
+    expect(w.find('[data-testid="row-pushups"]').exists()).toBe(true)
+    await w.find('[data-testid="remove-pushups"]').trigger('click')
+    expect(w.find('[data-testid="row-pushups"]').exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Coach web UI to **log a completed workout session** for an athlete (SB-230, part of SB-189 Athlete Training Tracker) — complements the voice/CLI `log-workout` skill (SB-192). Backend (SB-191) was already done; this is the frontend.

## What's new
- **`WorkoutSessionLoggerView`** — routes `/coach/:athleteId/log` and `/coach/:athleteId/log/:templateId`. Coach-gated (in-view redirect, mirrors the builder).
  - Session meta: date (default today), **Felt emoji** (☺😐☹ → `how_felt`), total minutes, notes.
  - **From a template**: prefills rows from the template's items to log actuals against; or freeform-add via `ExercisePicker`.
  - **Per exercise**: actual sets — reps / secs / load(lb) / distance / time / RPE + round number / variant. **"+ Add set"** supports multiple attempts (e.g. 40-dash × 3 → three sets, each with `set_index` + `time_seconds`).
  - Save → `POST /workouts/sessions` with `X-Act-As-Athlete` → back to the athlete page.
- **`buildSessionPayload` / `templateToRows`** (pure util): flatten attempts → sets, drop empty attempts/rows, lb → kg, 1-based `set_index` only when an exercise has >1 attempt.
- **`createSession`** composable (act-as POST).
- **Entry points**: "Log workout" button on the athlete page + "Log this" (clipboard) action on `WorkoutTemplateCard`.
- Session logger + template types on the frontend.

## Testing
- `npm run type-check` ✅ · `npm run build` ✅
- New: `sessionPayload.test.ts` (payload util) + `WorkoutSessionLoggerView.test.ts` (mocked composables/router: add-via-picker, lb→kg, benchmark ×3 → 3 sets with time+set_index, template prefill + `template_id`, coach gate, remove).
- Full frontend suite: only the 7 pre-existing failures (`useUserPreferences`, `useSync` — pass in CI); no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)