### PR TITLE
fix: logger Time field for benchmarks (time_s measure token)

### DIFF
--- a/frontend/src/views/WorkoutSessionLoggerView.vue
+++ b/frontend/src/views/WorkoutSessionLoggerView.vue
@@ -220,7 +220,7 @@ const FIELD_DEFS: FieldDef[] = [
   { measure: 'duration_s', label: 'Secs', model: 'duration_s' },
   { measure: 'load_kg', label: 'Load(lb)', model: 'load_lb' },
   { measure: 'distance_m', label: 'Dist(m)', model: 'distance_m' },
-  { measure: 'time_seconds', label: 'Time(s)', model: 'time_seconds' },
+  { measure: 'time_s', label: 'Time(s)', model: 'time_seconds' },
 ]
 const FALLBACK: FieldDef[] = [FIELD_DEFS[0], FIELD_DEFS[4]] // reps + time
 

--- a/frontend/src/views/__tests__/WorkoutSessionLoggerView.test.ts
+++ b/frontend/src/views/__tests__/WorkoutSessionLoggerView.test.ts
@@ -26,7 +26,7 @@ const catalog = [
     difficulty: null, tags: [], media_url: null, thumbnail_url: null, cues: [], instructions: null,
   },
   {
-    key: '40_yard_dash', display_name: '40-yard dash', category: 'test', measures: ['time_seconds'],
+    key: '40yd_dash', display_name: '40-yard dash', category: 'test', measures: ['distance_m', 'time_s'],
     is_benchmark: true, owner_id: null, visibility: 'public', created_by: null, forked_from: null,
     aliases: [], movement_pattern: 'sprint', equipment: [], body_region: [], laterality: null,
     difficulty: null, tags: [], media_url: null, thumbnail_url: null, cues: [], instructions: null,
@@ -110,12 +110,12 @@ describe('WorkoutSessionLoggerView', () => {
     h.createSession.mockResolvedValue({ id: 's2' })
     const w = await mountLogger()
     await w.find('[data-testid="add-exercise"]').trigger('click')
-    await w.find('[data-testid="ex-40_yard_dash"]').trigger('click')
-    await w.find('[data-testid="add-set-40_yard_dash"]').trigger('click')
-    await w.find('[data-testid="add-set-40_yard_dash"]').trigger('click')
-    await w.find('[data-testid="time_seconds-40_yard_dash-0"]').setValue(5.4)
-    await w.find('[data-testid="time_seconds-40_yard_dash-1"]').setValue(5.2)
-    await w.find('[data-testid="time_seconds-40_yard_dash-2"]').setValue(5.3)
+    await w.find('[data-testid="ex-40yd_dash"]').trigger('click')
+    await w.find('[data-testid="add-set-40yd_dash"]').trigger('click')
+    await w.find('[data-testid="add-set-40yd_dash"]').trigger('click')
+    await w.find('[data-testid="time_seconds-40yd_dash-0"]').setValue(5.4)
+    await w.find('[data-testid="time_seconds-40yd_dash-1"]').setValue(5.2)
+    await w.find('[data-testid="time_seconds-40yd_dash-2"]').setValue(5.3)
     await w.find('[data-testid="save"]').trigger('click')
     await flushPromises()
 


### PR DESCRIPTION
## Problem
The SB-230 session logger never rendered the **Time** input for a timed benchmark. The seed catalog tags timed tests with the measure token **`time_s`** (e.g. `40yd_dash → ['distance_m','time_s']`), but the logger's field map gated the Time input on `time_seconds`. For `40yd_dash` the `distance_m` token matched (so no fallback fired) and `time_s` didn't → the Time field was hidden, making the core "40-dash × 3, each a set with `time_seconds`" flow unreachable in the UI.

The original component test masked this by using a made-up mock catalog (`measures: ['time_seconds']`) instead of the real seed tokens.

## Fix
- Map measure `time_s` → the `time_seconds` model field (the set **column** stays `time_seconds`; only the measures **token** was wrong).
- Component test mock now uses the real seed tokens (`['distance_m','time_s']`, key `40yd_dash`), so the benchmark ×3 test genuinely exercises Time-field rendering.

## Testing
- `npm run type-check` ✅ · `npm run build` ✅ · logger + payload suites ✅ (14 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)