### PR TITLE
feat: edit an existing catalog exercise — admin any / coach own (SB-259)

### DIFF
--- a/backend/routes/workouts.py
+++ b/backend/routes/workouts.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from datetime import date
 from uuid import UUID
 
-from backend.admin import require_athlete_access
+from backend.admin import is_admin, require_athlete_access
 from backend.auth import authenticate_request
 from backend.cache import invalidate_user
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
@@ -88,9 +88,12 @@ def update_exercise(
     body: ExerciseUpdate,
     user_id: UUID = Depends(authenticate_request),
 ) -> Exercise:
-    """Patch an exercise the caller owns (404 if not found or not theirs)."""
+    """Patch an exercise. A coach may patch only their own; an admin may patch
+    any, including the canonical library (404 if not found or not permitted)."""
     patch = body.model_dump(exclude_none=True, mode="json")
-    row = ExercisesRepository(get_supabase_client()).update(user_id, key, patch)
+    row = ExercisesRepository(get_supabase_client()).update(
+        user_id, key, patch, is_admin=is_admin(user_id)
+    )
     if row is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Exercise not found or not yours")
     return Exercise(**row)

--- a/backend/tests/test_exercise_catalog.py
+++ b/backend/tests/test_exercise_catalog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -127,6 +128,7 @@ def test_update_exercise_patches_owned() -> None:
     body = ExerciseUpdate(cues=["Chest up"])
     with (
         patch("backend.routes.workouts.get_supabase_client"),
+        patch("backend.routes.workouts.is_admin", return_value=False),
         patch("backend.routes.workouts.ExercisesRepository", return_value=repo),
     ):
         from backend.routes.workouts import update_exercise
@@ -135,6 +137,55 @@ def test_update_exercise_patches_owned() -> None:
 
     assert result.cues == ["Chest up"]
     assert repo.update.call_args.args[2] == {"cues": ["Chest up"]}  # only patched field
+    # A non-admin coach edits as owner-scoped.
+    assert repo.update.call_args.kwargs["is_admin"] is False
+
+
+def test_update_exercise_admin_patches_any() -> None:
+    """An admin patches even a canonical (owner_id NULL) exercise — is_admin
+    flows to the repo so the owner filter is dropped."""
+    uid = uuid4()
+    repo = _repo()
+    repo.update.return_value = {
+        "key": "pushups",
+        "display_name": "Push-ups",
+        "category": "strength",
+        "cues": ["Elbows in"],
+    }
+    body = ExerciseUpdate(cues=["Elbows in"])
+    with (
+        patch("backend.routes.workouts.get_supabase_client"),
+        patch("backend.routes.workouts.is_admin", return_value=True),
+        patch("backend.routes.workouts.ExercisesRepository", return_value=repo),
+    ):
+        from backend.routes.workouts import update_exercise
+
+        result = update_exercise(key="pushups", body=body, user_id=uid)
+
+    assert result.cues == ["Elbows in"]
+    assert repo.update.call_args.kwargs["is_admin"] is True
+
+
+def test_repo_update_admin_skips_owner_filter() -> None:
+    """The repo drops the owner_id eq() when is_admin — verify via a spy query."""
+    query = MagicMock()
+    query.update.return_value = query
+    query.eq.return_value = query
+    query.execute.return_value = SimpleNamespace(data=[{"key": "pushups"}])
+    supabase = MagicMock()
+    supabase.table.return_value = query
+
+    repo = ExercisesRepository(supabase)
+    uid = uuid4()
+
+    repo.update(uid, "pushups", {"cues": ["x"]}, is_admin=True)
+    admin_eq_cols = [c.args[0] for c in query.eq.call_args_list]
+    assert "owner_id" not in admin_eq_cols  # admin: no owner scoping
+
+    query.eq.reset_mock()
+    repo.update(uid, "pushups", {"cues": ["x"]}, is_admin=False)
+    coach_eq_cols = [c.args[0] for c in query.eq.call_args_list]
+    assert "owner_id" in coach_eq_cols  # coach: owner-scoped
 
 
 def test_delete_exercise_404_when_not_owned() -> None:

--- a/frontend/src/components/ExerciseEditForm.vue
+++ b/frontend/src/components/ExerciseEditForm.vue
@@ -1,0 +1,135 @@
+<template>
+  <form
+    class="bg-white border border-brand-200 rounded-xl p-4 space-y-3 shadow-sm"
+    data-testid="edit-form"
+    @submit.prevent="submit"
+  >
+    <div class="flex items-center justify-between">
+      <p class="text-xs font-semibold uppercase tracking-wide text-brand-500">
+        Edit · {{ exercise.display_name }}
+      </p>
+      <span v-if="exercise.owner_id == null" class="tag-canonical" data-testid="canonical-badge">
+        Canonical
+      </span>
+    </div>
+
+    <input
+      v-model="form.display_name"
+      required
+      placeholder="Name"
+      class="form-input w-full"
+      data-testid="edit-name"
+    />
+
+    <div class="grid grid-cols-2 gap-2">
+      <select v-model="form.category" class="form-input" data-testid="edit-category">
+        <option v-for="c in CATEGORIES" :key="c" :value="c">{{ c }}</option>
+      </select>
+      <select v-model="form.movement_pattern" class="form-input" data-testid="edit-pattern">
+        <option :value="null">— movement —</option>
+        <option v-for="p in PATTERNS" :key="p" :value="p">{{ p }}</option>
+      </select>
+    </div>
+
+    <div class="grid grid-cols-2 gap-2">
+      <select v-model="form.difficulty" class="form-input" data-testid="edit-difficulty">
+        <option :value="null">— difficulty —</option>
+        <option v-for="d in DIFFICULTIES" :key="d" :value="d">{{ d }}</option>
+      </select>
+      <select v-model="form.visibility" class="form-input" data-testid="edit-visibility">
+        <option value="private">private</option>
+        <option value="public">public</option>
+      </select>
+    </div>
+
+    <div>
+      <p class="text-xs text-gray-500 mb-1">Measures</p>
+      <div class="flex flex-wrap gap-1.5">
+        <label
+          v-for="m in MEASURE_OPTIONS"
+          :key="m.token"
+          class="chip-check"
+          :class="form.measures.includes(m.token) ? 'chip-on' : 'chip-off'"
+          :data-testid="`edit-measure-${m.token}`"
+        >
+          <input v-model="form.measures" type="checkbox" :value="m.token" class="sr-only" />
+          {{ m.label }}
+        </label>
+      </div>
+    </div>
+
+    <label class="flex items-center gap-2 text-xs text-gray-600">
+      <input v-model="form.is_benchmark" type="checkbox" data-testid="edit-benchmark" />
+      Tracked benchmark (trend over the season)
+    </label>
+
+    <input
+      v-model="form.aliases"
+      placeholder="Aliases (comma-separated)"
+      class="form-input w-full"
+      data-testid="edit-aliases"
+    />
+    <input
+      v-model="form.equipment"
+      placeholder="Equipment (comma-separated)"
+      class="form-input w-full"
+      data-testid="edit-equipment"
+    />
+    <textarea
+      v-model="form.cues"
+      rows="2"
+      placeholder="Coaching cues (comma-separated)"
+      class="form-input w-full"
+      data-testid="edit-cues"
+    />
+
+    <div class="flex items-center gap-2">
+      <button type="submit" class="btn-primary text-sm" data-testid="edit-save">Save changes</button>
+      <button type="button" class="btn-secondary text-sm" data-testid="edit-cancel" @click="$emit('cancel')">
+        Cancel
+      </button>
+    </div>
+  </form>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { Exercise, ExerciseCategory, ExerciseUpdate, MovementPattern } from '@/types/workout'
+import {
+  DIFFICULTIES,
+  MEASURE_OPTIONS,
+  buildExercisePatch,
+  exerciseToForm,
+} from '@/utils/exerciseEditForm'
+
+const props = defineProps<{ exercise: Exercise }>()
+const emit = defineEmits<{ (e: 'save', patch: ExerciseUpdate): void; (e: 'cancel'): void }>()
+
+const CATEGORIES: ExerciseCategory[] = ['strength', 'speed', 'power', 'mobility', 'cardio', 'test']
+const PATTERNS: MovementPattern[] = [
+  'squat', 'hinge', 'lunge', 'push', 'pull', 'carry',
+  'rotation', 'anti_rotation', 'jump', 'sprint', 'isometric', 'mobility', 'other',
+]
+
+const form = ref(exerciseToForm(props.exercise))
+
+const submit = (): void => {
+  if (!form.value.display_name.trim()) return
+  emit('save', buildExercisePatch(form.value))
+}
+</script>
+
+<style scoped>
+.chip-check {
+  @apply px-2 py-0.5 rounded-full text-xs font-medium border cursor-pointer transition select-none;
+}
+.chip-on {
+  @apply bg-brand-600 text-white border-brand-600;
+}
+.chip-off {
+  @apply bg-white text-gray-600 border-gray-200 hover:border-gray-300;
+}
+.tag-canonical {
+  @apply px-1.5 py-0.5 rounded bg-purple-100 text-purple-700 text-[10px] font-medium;
+}
+</style>

--- a/frontend/src/components/ExercisePicker.vue
+++ b/frontend/src/components/ExercisePicker.vue
@@ -73,15 +73,26 @@
         <p v-if="ex.cues.length" class="mt-1 text-[11px] text-gray-500 line-clamp-1">
           {{ ex.cues.join(' · ') }}
         </p>
-        <button
-          v-if="mode === 'manage' && ex.owner_id && ex.visibility === 'private'"
-          type="button"
-          class="mt-2 btn-secondary text-[11px]"
-          :data-testid="`publish-${ex.key}`"
-          @click.stop="$emit('publish', ex.key)"
-        >
-          Publish to library
-        </button>
+        <div v-if="mode === 'manage'" class="mt-2 flex items-center gap-2">
+          <button
+            v-if="editableKeys.includes(ex.key)"
+            type="button"
+            class="inline-flex items-center gap-1 btn-secondary text-[11px]"
+            :data-testid="`edit-${ex.key}`"
+            @click.stop="$emit('edit', ex)"
+          >
+            <Pencil class="w-3 h-3" /> Edit
+          </button>
+          <button
+            v-if="ex.owner_id && ex.visibility === 'private'"
+            type="button"
+            class="btn-secondary text-[11px]"
+            :data-testid="`publish-${ex.key}`"
+            @click.stop="$emit('publish', ex.key)"
+          >
+            Publish to library
+          </button>
+        </div>
       </button>
     </div>
 
@@ -134,7 +145,7 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref } from 'vue'
-import { Check, Scale, Search } from 'lucide-vue-next'
+import { Check, Pencil, Scale, Search } from 'lucide-vue-next'
 import type { Exercise, ExerciseCategory, ExerciseCreate, MovementPattern } from '@/types/workout'
 import { balanceNudges } from '@/utils/exerciseBalance'
 
@@ -142,15 +153,17 @@ const props = withDefaults(
   defineProps<{
     exercises: Exercise[]
     selectedKeys?: string[]
+    editableKeys?: string[]
     mode?: 'select' | 'manage'
   }>(),
-  { selectedKeys: () => [], mode: 'select' },
+  { selectedKeys: () => [], editableKeys: () => [], mode: 'select' },
 )
 
 const emit = defineEmits<{
   (e: 'toggle', exercise: Exercise): void
   (e: 'create', payload: ExerciseCreate): void
   (e: 'publish', key: string): void
+  (e: 'edit', exercise: Exercise): void
 }>()
 
 const CATEGORIES: ExerciseCategory[] = ['strength', 'speed', 'power', 'mobility', 'cardio', 'test']

--- a/frontend/src/components/__tests__/ExerciseEditForm.test.ts
+++ b/frontend/src/components/__tests__/ExerciseEditForm.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ExerciseEditForm from '../ExerciseEditForm.vue'
+import type { Exercise, ExerciseUpdate } from '@/types/workout'
+
+const ex = (over: Partial<Exercise> = {}): Exercise => ({
+  key: 'goblet_squat',
+  display_name: 'Goblet Squat',
+  category: 'strength',
+  measures: ['reps', 'load_kg'],
+  is_benchmark: false,
+  owner_id: 'u1',
+  visibility: 'private',
+  created_by: 'u1',
+  forked_from: null,
+  aliases: ['kb squat'],
+  movement_pattern: 'squat',
+  equipment: ['kettlebell'],
+  body_region: [],
+  laterality: null,
+  difficulty: 'beginner',
+  tags: [],
+  media_url: null,
+  thumbnail_url: null,
+  cues: ['Chest up'],
+  instructions: null,
+  ...over,
+})
+
+describe('ExerciseEditForm', () => {
+  it('prefills inputs from the exercise', () => {
+    const w = mount(ExerciseEditForm, { props: { exercise: ex() } })
+    expect((w.find('[data-testid="edit-name"]').element as HTMLInputElement).value).toBe('Goblet Squat')
+    expect((w.find('[data-testid="edit-aliases"]').element as HTMLInputElement).value).toBe('kb squat')
+    expect((w.find('[data-testid="edit-cues"]').element as HTMLTextAreaElement).value).toBe('Chest up')
+  })
+
+  it('shows a Canonical badge only when owner_id is null', () => {
+    expect(mount(ExerciseEditForm, { props: { exercise: ex() } }).find('[data-testid="canonical-badge"]').exists()).toBe(false)
+    const canonical = mount(ExerciseEditForm, { props: { exercise: ex({ owner_id: null }) } })
+    expect(canonical.find('[data-testid="canonical-badge"]').exists()).toBe(true)
+  })
+
+  it('emits a patch reflecting edits (name, measures toggle, cues)', async () => {
+    const w = mount(ExerciseEditForm, { props: { exercise: ex() } })
+    await w.find('[data-testid="edit-name"]').setValue('Goblet Squat 2.0')
+    await w.find('[data-testid="edit-measure-time_s"] input').setValue(true) // add time_s
+    await w.find('[data-testid="edit-cues"]').setValue('Chest up, Brace')
+    await w.find('[data-testid="edit-form"]').trigger('submit')
+
+    const patch = w.emitted('save')?.[0]?.[0] as ExerciseUpdate
+    expect(patch.display_name).toBe('Goblet Squat 2.0')
+    expect(patch.measures).toEqual(['reps', 'load_kg', 'time_s'])
+    expect(patch.cues).toEqual(['Chest up', 'Brace'])
+  })
+
+  it('does not emit save when the name is blanked', async () => {
+    const w = mount(ExerciseEditForm, { props: { exercise: ex() } })
+    await w.find('[data-testid="edit-name"]').setValue('   ')
+    await w.find('[data-testid="edit-form"]').trigger('submit')
+    expect(w.emitted('save')).toBeUndefined()
+  })
+
+  it('emits cancel', async () => {
+    const w = mount(ExerciseEditForm, { props: { exercise: ex() } })
+    await w.find('[data-testid="edit-cancel"]').trigger('click')
+    expect(w.emitted('cancel')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/__tests__/ExercisePicker.test.ts
+++ b/frontend/src/components/__tests__/ExercisePicker.test.ts
@@ -138,6 +138,22 @@ describe('ExercisePicker', () => {
     expect(w.find('[data-testid="publish-goblet_squat"]').exists()).toBe(false)
   })
 
+  it('manage mode shows Edit only on editableKeys and emits the exercise', async () => {
+    const w = mount(ExercisePicker, {
+      props: { exercises: catalog, mode: 'manage', editableKeys: ['goblet_squat'] },
+    })
+    expect(w.find('[data-testid="edit-pushups"]').exists()).toBe(false) // not editable
+    const edit = w.find('[data-testid="edit-goblet_squat"]')
+    expect(edit.exists()).toBe(true)
+    await edit.trigger('click')
+    expect((w.emitted('edit')?.[0]?.[0] as Exercise).key).toBe('goblet_squat')
+  })
+
+  it('manage mode with no editableKeys shows no Edit buttons', () => {
+    const w = mount(ExercisePicker, { props: { exercises: catalog, mode: 'manage' } })
+    expect(w.find('[data-testid="edit-goblet_squat"]').exists()).toBe(false)
+  })
+
   it('empty search offers create; submitting emits a private create payload prefilled from the query', async () => {
     const w = mount(ExercisePicker, { props: { exercises: catalog } })
     await setSearch(w, 'zzz new move')

--- a/frontend/src/composables/useExercises.ts
+++ b/frontend/src/composables/useExercises.ts
@@ -1,6 +1,6 @@
 import { ref } from 'vue'
 import { apiCall } from '@/config/api'
-import type { Exercise, ExerciseCreate } from '@/types/workout'
+import type { Exercise, ExerciseCreate, ExerciseUpdate } from '@/types/workout'
 
 /**
  * The exercise catalog: the public library + the caller's own private exercises
@@ -39,6 +39,21 @@ export function useExercises() {
     }
   }
 
+  const update = async (key: string, patch: ExerciseUpdate): Promise<Exercise | null> => {
+    error.value = null
+    try {
+      const updated = await apiCall<Exercise>(`/workouts/exercises/${key}`, {
+        method: 'PATCH',
+        body: JSON.stringify(patch),
+      })
+      exercises.value = exercises.value.map((e) => (e.key === key ? updated : e))
+      return updated
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to update exercise'
+      return null
+    }
+  }
+
   const publish = async (key: string): Promise<Exercise | null> => {
     error.value = null
     try {
@@ -53,5 +68,5 @@ export function useExercises() {
     }
   }
 
-  return { exercises, loading, error, load, create, publish }
+  return { exercises, loading, error, load, create, update, publish }
 }

--- a/frontend/src/types/workout.ts
+++ b/frontend/src/types/workout.ts
@@ -51,6 +51,21 @@ export interface ExerciseCreate {
   cues?: string[]
 }
 
+/** Partial patch of an existing exercise (all fields optional). */
+export interface ExerciseUpdate {
+  display_name?: string
+  category?: ExerciseCategory
+  measures?: string[]
+  is_benchmark?: boolean
+  visibility?: ExerciseVisibility
+  aliases?: string[]
+  movement_pattern?: MovementPattern | null
+  equipment?: string[]
+  cues?: string[]
+  difficulty?: string | null
+  instructions?: string | null
+}
+
 export type WorkoutSectionKey = 'warmup' | 'main' | 'cooldown'
 export type WorkoutType = 'circuit' | 'intervals' | 'test' | 'session'
 

--- a/frontend/src/utils/__tests__/exerciseEditForm.test.ts
+++ b/frontend/src/utils/__tests__/exerciseEditForm.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildExercisePatch,
+  exerciseToForm,
+  parseList,
+  type ExerciseFormState,
+} from '@/utils/exerciseEditForm'
+import type { Exercise } from '@/types/workout'
+
+const ex = (over: Partial<Exercise> = {}): Exercise => ({
+  key: 'goblet_squat',
+  display_name: 'Goblet Squat',
+  category: 'strength',
+  measures: ['reps', 'load_kg'],
+  is_benchmark: false,
+  owner_id: 'me',
+  visibility: 'private',
+  created_by: 'me',
+  forked_from: null,
+  aliases: ['kb squat'],
+  movement_pattern: 'squat',
+  equipment: ['kettlebell', 'none'],
+  body_region: [],
+  laterality: null,
+  difficulty: 'beginner',
+  tags: [],
+  media_url: null,
+  thumbnail_url: null,
+  cues: ['Chest up', 'Knees out'],
+  instructions: null,
+  ...over,
+})
+
+describe('parseList', () => {
+  it('trims, drops blanks, de-dupes, keeps order', () => {
+    expect(parseList('a, b ,, a ,  c')).toEqual(['a', 'b', 'c'])
+  })
+  it('empty string → empty array', () => {
+    expect(parseList('   ')).toEqual([])
+  })
+})
+
+describe('exerciseToForm', () => {
+  it('maps the exercise into form state, joining lists and dropping the none sentinel', () => {
+    const f = exerciseToForm(ex())
+    expect(f).toMatchObject({
+      display_name: 'Goblet Squat',
+      category: 'strength',
+      movement_pattern: 'squat',
+      difficulty: 'beginner',
+      visibility: 'private',
+      is_benchmark: false,
+      measures: ['reps', 'load_kg'],
+      aliases: 'kb squat',
+      equipment: 'kettlebell', // 'none' filtered out
+      cues: 'Chest up, Knees out',
+    })
+  })
+})
+
+describe('buildExercisePatch', () => {
+  const base: ExerciseFormState = {
+    display_name: '  Goblet Squat  ',
+    category: 'strength',
+    movement_pattern: 'squat',
+    difficulty: '',
+    visibility: 'public',
+    is_benchmark: true,
+    measures: ['reps', 'time_s'],
+    aliases: 'kb squat, goblet',
+    equipment: 'kettlebell',
+    cues: 'Chest up, , Brace',
+  }
+
+  it('trims name, parses lists, and coerces empty difficulty to null', () => {
+    const p = buildExercisePatch(base)
+    expect(p).toEqual({
+      display_name: 'Goblet Squat',
+      category: 'strength',
+      movement_pattern: 'squat',
+      difficulty: null,
+      visibility: 'public',
+      is_benchmark: true,
+      measures: ['reps', 'time_s'],
+      aliases: ['kb squat', 'goblet'],
+      equipment: ['kettlebell'],
+      cues: ['Chest up', 'Brace'],
+    })
+  })
+
+  it('round-trips through exerciseToForm without dropping data', () => {
+    const p = buildExercisePatch(exerciseToForm(ex()))
+    expect(p.measures).toEqual(['reps', 'load_kg'])
+    expect(p.cues).toEqual(['Chest up', 'Knees out'])
+    expect(p.aliases).toEqual(['kb squat'])
+    expect(p.equipment).toEqual(['kettlebell'])
+  })
+})

--- a/frontend/src/utils/exerciseEditForm.ts
+++ b/frontend/src/utils/exerciseEditForm.ts
@@ -1,0 +1,70 @@
+import type { Exercise, ExerciseCategory, ExerciseUpdate, MovementPattern } from '@/types/workout'
+
+/** Measure tokens an exercise can record (canonical seed vocabulary). Note the
+ * token is `time_s` even though the logged-set column is `time_seconds`. */
+export const MEASURE_OPTIONS: { token: string; label: string }[] = [
+  { token: 'reps', label: 'Reps' },
+  { token: 'duration_s', label: 'Duration (s)' },
+  { token: 'load_kg', label: 'Load' },
+  { token: 'distance_m', label: 'Distance (m)' },
+  { token: 'time_s', label: 'Time (s)' },
+]
+
+export const DIFFICULTIES = ['beginner', 'intermediate', 'advanced'] as const
+
+/** Editable shape backing the form — lists as comma text for easy typing. */
+export interface ExerciseFormState {
+  display_name: string
+  category: ExerciseCategory
+  movement_pattern: MovementPattern | null
+  difficulty: string | null
+  visibility: 'public' | 'private'
+  is_benchmark: boolean
+  measures: string[]
+  aliases: string
+  equipment: string
+  cues: string
+}
+
+/** "a, b ,, a " → ['a','b'] — trimmed, blanks dropped, de-duped, order kept. */
+export function parseList(raw: string): string[] {
+  const out: string[] = []
+  for (const part of raw.split(',')) {
+    const v = part.trim()
+    if (v && !out.includes(v)) out.push(v)
+  }
+  return out
+}
+
+/** Current exercise → form state (arrays joined for text inputs). */
+export function exerciseToForm(ex: Exercise): ExerciseFormState {
+  return {
+    display_name: ex.display_name,
+    category: ex.category,
+    movement_pattern: ex.movement_pattern,
+    difficulty: ex.difficulty,
+    visibility: ex.visibility,
+    is_benchmark: ex.is_benchmark,
+    measures: [...ex.measures],
+    aliases: ex.aliases.join(', '),
+    equipment: ex.equipment.filter((e) => e !== 'none').join(', '),
+    cues: ex.cues.join(', '),
+  }
+}
+
+/** Form state → API patch. Pure + deterministic; sends the full editable set
+ * (the backend patches every provided field). */
+export function buildExercisePatch(form: ExerciseFormState): ExerciseUpdate {
+  return {
+    display_name: form.display_name.trim(),
+    category: form.category,
+    movement_pattern: form.movement_pattern,
+    difficulty: form.difficulty || null,
+    visibility: form.visibility,
+    is_benchmark: form.is_benchmark,
+    measures: form.measures,
+    aliases: parseList(form.aliases),
+    equipment: parseList(form.equipment),
+    cues: parseList(form.cues),
+  }
+}

--- a/frontend/src/views/ExerciseCatalogView.vue
+++ b/frontend/src/views/ExerciseCatalogView.vue
@@ -15,27 +15,62 @@
       {{ error }}
     </div>
 
-    <ExercisePicker
-      v-else
-      :exercises="exercises"
-      mode="manage"
-      @create="onCreate"
-      @publish="onPublish"
-    />
+    <template v-else>
+      <ExerciseEditForm
+        v-if="editing"
+        :exercise="editing"
+        class="mb-4"
+        @save="onSave"
+        @cancel="editing = null"
+      />
+
+      <ExercisePicker
+        :exercises="exercises"
+        :editable-keys="editableKeys"
+        mode="manage"
+        @create="onCreate"
+        @publish="onPublish"
+        @edit="startEdit"
+      />
+    </template>
   </div>
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import ExercisePicker from '@/components/ExercisePicker.vue'
+import ExerciseEditForm from '@/components/ExerciseEditForm.vue'
 import { useExercises } from '@/composables/useExercises'
 import { useRoles } from '@/composables/useCoach'
-import type { ExerciseCreate } from '@/types/workout'
+import { useAuthStore } from '@/stores/auth'
+import type { Exercise, ExerciseCreate, ExerciseUpdate } from '@/types/workout'
 
 const router = useRouter()
-const { isCoach, loadRoles } = useRoles()
-const { exercises, loading, error, load, create, publish } = useExercises()
+const { isCoach, isAdmin, loadRoles } = useRoles()
+const auth = useAuthStore()
+const { exercises, loading, error, load, create, update, publish } = useExercises()
+
+const editing = ref<Exercise | null>(null)
+
+// A coach edits only their own; an admin edits anything (incl. the canonical
+// library, owner_id === null). Mirrors the backend permission.
+const editableKeys = computed<string[]>(() => {
+  const myId = auth.user?.id ?? null
+  return exercises.value
+    .filter((ex) => isAdmin.value || (!!ex.owner_id && ex.owner_id === myId))
+    .map((ex) => ex.key)
+})
+
+const startEdit = (ex: Exercise): void => {
+  editing.value = ex
+}
+
+const onSave = async (patch: ExerciseUpdate): Promise<void> => {
+  if (!editing.value) return
+  const updated = await update(editing.value.key, patch)
+  if (updated) editing.value = null
+}
 
 const onCreate = async (payload: ExerciseCreate) => {
   await create(payload)

--- a/frontend/src/views/__tests__/ExerciseCatalogView.test.ts
+++ b/frontend/src/views/__tests__/ExerciseCatalogView.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { ref } from 'vue'
+
+const h = vi.hoisted(() => ({
+  update: vi.fn(),
+  create: vi.fn(),
+  publish: vi.fn(),
+  load: vi.fn().mockResolvedValue(undefined),
+  loadRoles: vi.fn().mockResolvedValue(undefined),
+  isCoach: { value: true },
+  isAdmin: { value: false },
+  userId: { value: 'me' as string | null },
+  replace: vi.fn(),
+}))
+
+const mk = (over: Record<string, unknown>) => ({
+  key: 'k', display_name: 'X', category: 'strength', measures: [], is_benchmark: false,
+  owner_id: null, visibility: 'public', created_by: null, forked_from: null, aliases: [],
+  movement_pattern: null, equipment: [], body_region: [], laterality: null, difficulty: null,
+  tags: [], media_url: null, thumbnail_url: null, cues: [], instructions: null, ...over,
+})
+const catalog = ref([
+  mk({ key: 'pushups', display_name: 'Push-ups' }), // canonical (owner null)
+  mk({ key: 'my_move', display_name: 'My Move', owner_id: 'me', visibility: 'private' }), // mine
+  mk({ key: 'her_move', display_name: 'Her Move', owner_id: 'u2', visibility: 'public' }), // someone else's
+])
+
+vi.mock('@/composables/useExercises', () => ({
+  useExercises: () => ({
+    exercises: catalog, loading: ref(false), error: ref(null),
+    load: h.load, create: h.create, update: h.update, publish: h.publish,
+  }),
+}))
+vi.mock('@/composables/useCoach', () => ({
+  useRoles: () => ({ isCoach: h.isCoach, isAdmin: h.isAdmin, loadRoles: h.loadRoles }),
+}))
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({ user: { id: h.userId.value } }),
+}))
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ replace: h.replace }),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.isCoach.value = true
+  h.isAdmin.value = false
+  h.userId.value = 'me'
+})
+
+async function mountView() {
+  const View = (await import('../ExerciseCatalogView.vue')).default
+  const w = mount(View)
+  await flushPromises()
+  return w
+}
+
+describe('ExerciseCatalogView', () => {
+  it('redirects non-coaches', async () => {
+    h.isCoach.value = false
+    await mountView()
+    expect(h.replace).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('coach: Edit only on own exercises', async () => {
+    const w = await mountView()
+    expect(w.find('[data-testid="edit-my_move"]').exists()).toBe(true)
+    expect(w.find('[data-testid="edit-pushups"]').exists()).toBe(false) // canonical
+    expect(w.find('[data-testid="edit-her_move"]').exists()).toBe(false) // not owned
+  })
+
+  it('admin: Edit on every exercise, including canonical', async () => {
+    h.isAdmin.value = true
+    const w = await mountView()
+    expect(w.find('[data-testid="edit-pushups"]').exists()).toBe(true)
+    expect(w.find('[data-testid="edit-her_move"]').exists()).toBe(true)
+    expect(w.find('[data-testid="edit-my_move"]').exists()).toBe(true)
+  })
+
+  it('editing then saving calls update(key, patch) and closes the form', async () => {
+    h.update.mockResolvedValue(mk({ key: 'my_move', display_name: 'Renamed', owner_id: 'me' }))
+    const w = await mountView()
+    await w.find('[data-testid="edit-my_move"]').trigger('click')
+    expect(w.find('[data-testid="edit-form"]').exists()).toBe(true)
+
+    await w.find('[data-testid="edit-name"]').setValue('Renamed')
+    await w.find('[data-testid="edit-form"]').trigger('submit')
+    await flushPromises()
+
+    expect(h.update).toHaveBeenCalledTimes(1)
+    expect(h.update.mock.calls[0][0]).toBe('my_move')
+    expect(h.update.mock.calls[0][1]).toMatchObject({ display_name: 'Renamed' })
+    expect(w.find('[data-testid="edit-form"]').exists()).toBe(false) // closed on success
+  })
+})

--- a/src/shared/supabase_ops/workout_repository.py
+++ b/src/shared/supabase_ops/workout_repository.py
@@ -121,15 +121,16 @@ class ExercisesRepository:
         result = self.supabase.table("exercises").insert(row).execute()
         return cast(list[dict[str, Any]], result.data)[0]
 
-    def update(self, user_id: UUID, key: str, patch: dict[str, Any]) -> dict[str, Any] | None:
-        """Patch an exercise the caller owns. None if not found / not theirs."""
-        result = (
-            self.supabase.table("exercises")
-            .update(patch)
-            .eq("key", key)
-            .eq("owner_id", str(user_id))
-            .execute()
-        )
+    def update(
+        self, user_id: UUID, key: str, patch: dict[str, Any], *, is_admin: bool = False
+    ) -> dict[str, Any] | None:
+        """Patch an exercise. A coach may patch only their own; an admin may
+        patch any (including the canonical library). None if not found / not
+        theirs."""
+        query = self.supabase.table("exercises").update(patch).eq("key", key)
+        if not is_admin:
+            query = query.eq("owner_id", str(user_id))
+        result = query.execute()
         rows = cast(list[dict[str, Any]], result.data)
         return rows[0] if rows else None
 


### PR DESCRIPTION
## Summary
Coaches could **create** and **publish** exercises but never **edit** one — the manage-mode catalog card had no edit affordance and `useExercises` had no `update`. This wires the already-existing `PATCH /workouts/exercises/{key}` through the UI, and lets **admins** edit the canonical library too.

Closes SB-259 (part of SB-189, Athlete Training Tracker).

## Permissions (as decided)
- **Admin** → edit any exercise, including the 44 seeded canonical (`owner_id = null`).
- **Coach** → edit only their own (`owner_id === me`); others show read-only (no Edit button).

## Backend
- `ExercisesRepository.update` gains an `is_admin` flag — admins skip the `owner_id` filter; coaches stay owner-scoped. Route computes it via `backend.admin.is_admin(user_id)`. 404 semantics unchanged for non-admin non-owner.
- Tests: coach passes `is_admin=False`, admin passes `True`, and the repo drops the `owner_id` `eq()` only for admins.

## Frontend
- `useExercises.update(key, patch)` → PATCH, patches the local list.
- **`ExerciseEditForm.vue`** — prefilled form: name, category, movement pattern, difficulty, visibility, benchmark, measures (`reps/duration_s/load_kg/distance_m/time_s`), aliases, equipment, cues. Pure `exerciseToForm` / `buildExercisePatch` util (parse comma lists, drop the `none` sentinel, empty difficulty → null).
- **`ExercisePicker`** — `editableKeys` prop + Edit affordance (manage mode, editable cards only) + `edit` emit. Publish button unchanged.
- **`ExerciseCatalogView`** — `editableKeys = isAdmin ? all : owned` (owner_id === my auth-store id); renders the edit panel, calls `update` on save.
- `ExerciseUpdate` type.

## Testing
- Backend: `ruff` ✅ · `pytest backend/tests` ✅ (209 passed).
- Frontend: `type-check` ✅ · `build` ✅ · new/changed suites ✅ (util, edit form, picker gating, catalog admin-vs-coach + save wiring). Full suite: only the 7 pre-existing failures (`useSync`, `useUserPreferences` — pass in CI); no new failures.

## Deferred
Coach **"request a change"** to a canonical/other-owned exercise → routed to the owner/admin for approval (future enhancement, noted in SB-259).

🤖 Generated with [Claude Code](https://claude.com/claude-code)