### PR TITLE
feat: broken reps — segment goals, pace ranges + track exercises (SB-264)

### DIFF
--- a/backend/tests/test_workout_repository.py
+++ b/backend/tests/test_workout_repository.py
@@ -107,6 +107,47 @@ def test_template_create_round_trips_with_items():
     assert all(i["template_id"] == out["id"] for i in out["items"])
 
 
+def test_template_item_broken_rep_round_trips():
+    """Segment goals + a pace range survive create -> read (SB-264)."""
+    supa = _FakeSupabase()
+    repo = WorkoutTemplatesRepository(supa)
+    out = repo.create(
+        uuid4(),
+        {
+            "name": "Track Thursday",
+            "type": "intervals",
+            "items": [
+                {
+                    "exercise_key": "interval_run",
+                    "position": 0,
+                    "target_distance_m": 400,
+                    "target_duration_seconds": 20,
+                    "target_duration_max_seconds": 22,
+                    "segments": [
+                        {
+                            "distance_m": 100,
+                            "target_s_min": 20,
+                            "target_s_max": 22,
+                            "label": "0-100",
+                        },
+                        {"distance_m": 100, "target_s_min": 15, "label": "100-200"},
+                    ],
+                }
+            ],
+        },
+    )
+    item = out["items"][0]
+    assert item["target_duration_max_seconds"] == 22
+    assert len(item["segments"]) == 2
+    assert item["segments"][0] == {
+        "distance_m": 100,
+        "target_s_min": 20,
+        "target_s_max": 22,
+        "label": "0-100",
+    }
+    assert item["segments"][1]["target_s_min"] == 15
+
+
 def test_template_update_replaces_items_and_fields():
     supa = _FakeSupabase()
     repo = WorkoutTemplatesRepository(supa)

--- a/src/shared/models/workout.py
+++ b/src/shared/models/workout.py
@@ -139,6 +139,19 @@ class ExerciseUpdate(BaseModel):
 # --------------------------------------------------------------------------- #
 # Templates (the coach's prescribed plan)
 # --------------------------------------------------------------------------- #
+class SegmentTarget(BaseModel):
+    """Goal for one segment of a broken rep (SB-264).
+
+    E.g. a 400m broken into 100m sections: ``{distance_m: 100, target_s_min: 20,
+    target_s_max: 22}``. A fixed goal sets only ``target_s_min``.
+    """
+
+    distance_m: float = Field(gt=0)
+    target_s_min: float | None = Field(default=None, ge=0)
+    target_s_max: float | None = Field(default=None, ge=0)
+    label: str | None = None  # e.g. "0-100"
+
+
 class TemplateItemCreate(BaseModel):
     """One prescribed exercise within a template."""
 
@@ -147,9 +160,14 @@ class TemplateItemCreate(BaseModel):
     position: int = 0
     target_reps: int | None = Field(default=None, ge=0)
     target_duration_seconds: float | None = Field(default=None, ge=0)
+    # Upper bound when the goal is a range ("20-22 sec"); the field above is the
+    # lower bound (SB-264).
+    target_duration_max_seconds: float | None = Field(default=None, ge=0)
     target_load_kg: float | None = Field(default=None, ge=0)
     target_distance_m: float | None = Field(default=None, ge=0)
     rest_seconds: float | None = Field(default=None, ge=0)
+    # Per-segment goals for a broken rep (SB-264); None for ordinary items.
+    segments: list[SegmentTarget] | None = None
     variant: str | None = None
     notes: str | None = None
 

--- a/supabase/migrations/20260711000000_broken_reps.sql
+++ b/supabase/migrations/20260711000000_broken_reps.sql
@@ -1,0 +1,46 @@
+-- =====================================================
+-- Broken reps: segment goals + pace ranges (SB-264)
+-- =====================================================
+-- Matthew prescribes reps like "400m broken into 100m sections" with a goal
+-- range per section (0-100: 20-22s, 100-200: 15s, ...). Two additions:
+--
+--   target_duration_max_seconds  upper bound of a goal range; existing
+--                                target_duration_seconds becomes the lower
+--                                bound when both are set.
+--   segments                     JSONB list of per-segment goals for one rep:
+--                                [{"distance_m":100,"target_s_min":20,"target_s_max":22}, ...]
+--
+-- Actuals (the REALITY side) reuse exercise_sets.extra JSONB:
+--   extra.segments = [{"distance_m":100,"time_s":21,"note":null}, ...]
+-- so no schema change is needed on the logging side.
+
+ALTER TABLE template_items ADD COLUMN target_duration_max_seconds NUMERIC(8, 2);
+ALTER TABLE template_items ADD COLUMN segments JSONB;
+
+COMMENT ON COLUMN template_items.target_duration_max_seconds IS
+    'Upper bound of a goal time range (SB-264); target_duration_seconds is the lower bound';
+COMMENT ON COLUMN template_items.segments IS
+    'Per-segment goals for a broken rep: [{distance_m, target_s_min, target_s_max, label?}]';
+
+-- ---- seed: movements from Matthew's Thursday track session not yet in the library ----
+INSERT INTO exercises
+    (key, display_name, category, measures, is_benchmark, movement_pattern,
+     equipment, body_region, laterality, difficulty, aliases, cues, instructions)
+VALUES
+('paced_strides', 'Paced strides', 'speed', ARRAY['reps','distance_m'], FALSE, 'sprint',
+ ARRAY['none'], ARRAY['lower','full'], 'bilateral', 'beginner',
+ ARRAY['strides','striders'],
+ ARRAY['Smooth build to ~85% speed','Relax and float, quick turnover'], NULL),
+('bounding', 'Bounding', 'power', ARRAY['reps','distance_m'], FALSE, 'jump',
+ ARRAY['none'], ARRAY['lower','full'], 'bilateral', 'intermediate',
+ ARRAY['bounding starts','bounds'],
+ ARRAY['Exaggerated running leaps','Drive the knee, hang in the air'], NULL),
+('backward_run', 'Backward run', 'speed', ARRAY['duration_s','distance_m'], FALSE, 'sprint',
+ ARRAY['none'], ARRAY['lower'], 'bilateral', 'beginner',
+ ARRAY['backwards running','retro running','running backward'],
+ ARRAY['Small quick steps, stay on the balls of the feet','Lean slightly forward, arms drive'], NULL),
+('interval_run', 'Interval run', 'speed', ARRAY['distance_m','time_s'], TRUE, 'sprint',
+ ARRAY['none'], ARRAY['lower','full'], 'bilateral', 'intermediate',
+ ARRAY['track interval','repeat','rep'],
+ ARRAY['Fixed distance at prescribed pace','Recover fully between reps'], NULL)
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
Matthew's real track sessions (Gabe's Thursday) prescribe a rep like **"400m
broken into 100m sections"** with a goal *range* per section, then record
reality per section — including a mid-rep stop. The workout model couldn't
express that. Now it can.

## What

- **`template_items`** — `target_duration_max_seconds` (goal ranges, "20-22 sec")
  + `segments` JSONB: `[{distance_m, target_s_min, target_s_max, label}]`.
- **Models** — `SegmentTarget` + the two fields on `TemplateItemCreate`. Routes
  are `model_dump` pass-through → zero route changes.
- **Actuals** — convention `exercise_sets.extra.segments =
  [{distance_m, time_s, label, note}]` (existing JSONB — no schema change).
- **Seed 4 exercises** — `interval_run` (generic track rep; 2x200/4x100/400s had
  no exercise), `paced_strides`, `bounding`, `backward_run`.

## Verified end-to-end (local)

Thursday's session stored as **one template** (11 items, warmup→main→cooldown,
athlete-scoped to Gabe so his coaches see it via `can_coach_athlete`), and the
actuals logged against it:

```
GOAL   0-100: 20-22 · 100-200: 15 · 200-300: 20-22 · 300-400: 15
REALITY 0-100: 21   · 100-200: 14 · 200-300: stop, walk — 1:40 · 300-400: 14
```

Plus 2x200 (31/29), 4x100 (14/15/14/14), hills, jogs — all structured, not prose.

Repo test: broken-rep round-trip (segments + range). 9 workout tests pass.

## Follow-ups (tracked on SB-264)

- `stk workout` CLI + log-workout skill: segment goal entry + REALITY parsing.
- Goal-vs-reality rendering (CLI table first, web later).
- Prod: apply migration + load the Thursday template for Matthew/Gabe.

Fixes SB-264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)