### PR TITLE
feat: role-aware landing — coaches skip the SmashRun dead end (SB-265)

### DIFF
--- a/frontend/src/components/EmptyState.vue
+++ b/frontend/src/components/EmptyState.vue
@@ -1,5 +1,23 @@
 <template>
-  <div class="bg-white rounded-xl border border-gray-100 shadow-sm p-10 text-center">
+  <div
+    v-if="variant === 'coach'"
+    class="bg-white rounded-xl border border-gray-100 shadow-sm p-10 text-center"
+  >
+    <ClipboardList class="w-12 h-12 mx-auto mb-4 text-brand-600" />
+    <h2 class="text-xl font-bold text-gray-900 mb-2">You're set up as a coach</h2>
+    <p class="text-gray-500 max-w-md mx-auto mb-6">
+      This dashboard tracks your own runs. Your athletes, workouts, and logged
+      sessions live in the Coach area.
+    </p>
+    <RouterLink
+      to="/coach"
+      class="inline-block px-4 py-2 rounded-lg bg-brand-600 text-white font-medium hover:bg-brand-700"
+    >
+      Go to Coach
+    </RouterLink>
+  </div>
+
+  <div v-else class="bg-white rounded-xl border border-gray-100 shadow-sm p-10 text-center">
     <Footprints class="w-12 h-12 mx-auto mb-4 text-brand-600" />
     <h2 class="text-xl font-bold text-gray-900 mb-2">Connect SmashRun to import your runs</h2>
     <p class="text-gray-500 max-w-md mx-auto mb-6">
@@ -11,8 +29,11 @@
 </template>
 
 <script setup lang="ts">
-import { Footprints } from 'lucide-vue-next'
+import { Footprints, ClipboardList } from 'lucide-vue-next'
+import { RouterLink } from 'vue-router'
 import SyncButton from './SyncButton.vue'
+
+withDefaults(defineProps<{ variant?: 'runner' | 'coach' }>(), { variant: 'runner' })
 
 defineEmits<{ synced: [] }>()
 </script>

--- a/frontend/src/components/LoginForm.vue
+++ b/frontend/src/components/LoginForm.vue
@@ -88,6 +88,7 @@
 import { ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
+import { resolveLanding } from '@/composables/useLanding'
 import BrandLogo from '@/components/BrandLogo.vue'
 
 const auth = useAuthStore()
@@ -109,7 +110,8 @@ const switchMode = (next: Mode) => {
 const handleSignIn = async () => {
   const result = await auth.signIn(email.value, password.value)
   if (result.success) {
-    const redirect = (route.query.redirect as string) || '/dashboard'
+    // A deep link the user was headed to wins; otherwise land by role (SB-265).
+    const redirect = (route.query.redirect as string) || (await resolveLanding())
     router.push(redirect)
   }
 }

--- a/frontend/src/composables/__tests__/useLanding.test.ts
+++ b/frontend/src/composables/__tests__/useLanding.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the API layer; tests drive responses by path via mockImplementation.
+const apiCallMock = vi.fn()
+vi.mock('@/config/api', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+}))
+
+// Fresh module per test — both the landing cache and useCoach's roles cache
+// are module-scoped.
+async function freshModule() {
+  vi.resetModules()
+  return import('../useLanding')
+}
+
+function mockApi(roles: { roles: string[]; is_admin: boolean }, totalRuns: number) {
+  apiCallMock.mockImplementation((path: string) => {
+    if (path === '/me/roles') return Promise.resolve(roles)
+    if (path === '/stats/overall') return Promise.resolve({ total_runs: totalRuns })
+    return Promise.reject(new Error(`unexpected call: ${path}`))
+  })
+}
+
+beforeEach(() => {
+  apiCallMock.mockReset()
+})
+
+describe('resolveLanding (SB-265)', () => {
+  it('coach with no runs lands on Coach', async () => {
+    mockApi({ roles: ['coach'], is_admin: false }, 0)
+    const { resolveLanding } = await freshModule()
+    expect(await resolveLanding()).toBe('/coach')
+  })
+
+  it('coach who also runs keeps the dashboard', async () => {
+    mockApi({ roles: ['coach'], is_admin: false }, 42)
+    const { resolveLanding } = await freshModule()
+    expect(await resolveLanding()).toBe('/dashboard')
+  })
+
+  it('plain runner lands on the dashboard without a stats call', async () => {
+    apiCallMock.mockImplementation((path: string) => {
+      if (path === '/me/roles') return Promise.resolve({ roles: [], is_admin: false })
+      return Promise.reject(new Error(`unexpected call: ${path}`))
+    })
+    const { resolveLanding } = await freshModule()
+    expect(await resolveLanding()).toBe('/dashboard')
+    expect(apiCallMock).not.toHaveBeenCalledWith('/stats/overall')
+  })
+
+  it('admin with runs keeps the dashboard', async () => {
+    mockApi({ roles: [], is_admin: true }, 500)
+    const { resolveLanding } = await freshModule()
+    expect(await resolveLanding()).toBe('/dashboard')
+  })
+
+  it('falls back to the dashboard when stats fail', async () => {
+    apiCallMock.mockImplementation((path: string) => {
+      if (path === '/me/roles') return Promise.resolve({ roles: ['coach'], is_admin: false })
+      return Promise.reject(new Error('boom'))
+    })
+    const { resolveLanding } = await freshModule()
+    expect(await resolveLanding()).toBe('/dashboard')
+  })
+
+  it('caches the decision until reset', async () => {
+    mockApi({ roles: ['coach'], is_admin: false }, 0)
+    const { resolveLanding, resetLanding } = await freshModule()
+    expect(await resolveLanding()).toBe('/coach')
+    apiCallMock.mockClear()
+    expect(await resolveLanding()).toBe('/coach')
+    expect(apiCallMock).not.toHaveBeenCalled()
+
+    // After reset it re-resolves — same coach, now with runs -> dashboard.
+    resetLanding()
+    mockApi({ roles: ['coach'], is_admin: false }, 42)
+    expect(await resolveLanding()).toBe('/dashboard')
+  })
+})

--- a/frontend/src/composables/useLanding.ts
+++ b/frontend/src/composables/useLanding.ts
@@ -1,0 +1,40 @@
+import { apiCall } from '@/config/api'
+import type { OverallStats } from '@/types/runs'
+import { useRoles } from './useCoach'
+
+// Cached for the session: the landing decision is made once (login / first
+// navigation), not on every route change. Reset on logout.
+let resolved: string | null = null
+
+/**
+ * Where a just-authenticated user should land (SB-265).
+ *
+ * Coaches (or admins) with no run history land on Coach — the runner
+ * dashboard's "Connect SmashRun" CTA is a dead end for them. Anyone with runs,
+ * or without the coach role, keeps the runner dashboard. Explicit user
+ * preference will take precedence over this heuristic when SB-267 lands.
+ *
+ * Returns a route path ('/coach' | '/dashboard').
+ */
+export async function resolveLanding(): Promise<string> {
+  if (resolved) return resolved
+  const { roles, loadRoles } = useRoles()
+  await loadRoles()
+  const coachish = !!roles.value && (roles.value.roles.includes('coach') || roles.value.is_admin)
+  if (!coachish) {
+    resolved = '/dashboard'
+    return resolved
+  }
+  try {
+    const stats = await apiCall<OverallStats>('/stats/overall')
+    resolved = stats.total_runs === 0 ? '/coach' : '/dashboard'
+  } catch {
+    resolved = '/dashboard'
+  }
+  return resolved
+}
+
+/** Forget the cached decision (logout, tests). */
+export function resetLanding(): void {
+  resolved = null
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
+import { resolveLanding } from '@/composables/useLanding'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -120,7 +121,15 @@ router.beforeEach(async (to) => {
   }
 
   if (to.meta.requiresGuest && auth.isAuthenticated) {
-    return { name: 'dashboard' }
+    return resolveLanding()
+  }
+
+  // '/' is the only implicit entry (its redirect targets the dashboard);
+  // route it by role so coaches don't land on a runner page (SB-265).
+  // Explicit visits to /dashboard are left alone.
+  if (auth.isAuthenticated && to.redirectedFrom?.path === '/') {
+    const landing = await resolveLanding()
+    if (landing !== '/dashboard') return landing
   }
 })
 

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import type { Session, User } from '@supabase/supabase-js'
 import { supabase, getOAuthRedirectUrl } from '@/config/supabase'
 import { apiCall } from '@/config/api'
+import { resetLanding } from '@/composables/useLanding'
 
 export const useAuthStore = defineStore('auth', () => {
   const session = ref<Session | null>(null)
@@ -102,6 +103,7 @@ export const useAuthStore = defineStore('auth', () => {
       await supabase.auth.signOut()
       session.value = null
       user.value = null
+      resetLanding() // next account may land elsewhere (SB-265)
     } finally {
       loading.value = false
     }

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -21,7 +21,7 @@
       {{ loadError }}
     </div>
 
-    <EmptyState v-else-if="isNewUser" @synced="reload" />
+    <EmptyState v-else-if="isNewUser" :variant="isCoach ? 'coach' : 'runner'" @synced="reload" />
 
     <template v-else>
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
@@ -143,6 +143,7 @@ import { useMonthlyStats } from '@/composables/useMonthlyStats'
 import { useGoals } from '@/composables/useGoals'
 import { useGoalHistory } from '@/composables/useGoalHistory'
 import { useUserPreferences } from '@/composables/useUserPreferences'
+import { useRoles } from '@/composables/useCoach'
 import { useAuthStore } from '@/stores/auth'
 import {
   formatDistance,
@@ -213,6 +214,10 @@ const loadError = computed(
 )
 const isNewUser = computed(() => stats.value !== null && stats.value.total_runs === 0)
 
+// Coaches with no runs get a pointer to the Coach area instead of a SmashRun
+// CTA they can't use (SB-265).
+const { isCoach, loadRoles } = useRoles()
+
 const heatmapGrid = computed(() => buildHeatmapGrid(recentRuns.value, 12))
 
 const reload = async () => {
@@ -220,6 +225,6 @@ const reload = async () => {
 }
 
 onMounted(async () => {
-  await Promise.all([reload(), loadMetricTypes()])
+  await Promise.all([reload(), loadMetricTypes(), loadRoles()])
 })
 </script>


### PR DESCRIPTION
P1 of the persona-aware UX arc (SB-265 → SB-266 coach home → SB-267 settings
override). A coach (Matthew) logging in landed on the runner dashboard with a
"Connect SmashRun" CTA he can never use — a dead end on the first login of
exactly the user we're onboarding.

## What

- **`useLanding.resolveLanding()`** — coach/admin with **zero runs** → `/coach`;
  anyone with runs, or without the coach role, keeps `/dashboard`. Cached per
  session (reset on sign-out). Plain runners never pay the extra stats call.
- Applied at the **three implicit entries only**: post-login redirect
  (LoginForm), `requiresGuest` bounce, and the `/` redirect. Explicit
  `/dashboard` visits untouched; a `?redirect=` deep link still wins.
- **Invite intent for free** — a redeemed `--role coach` invite produces coach
  role + zero runs → first login lands on Coach. No special casing.
- **EmptyState `coach` variant** — a coach who visits the dashboard anyway gets
  "your athletes live in the Coach area" + a Go to Coach button instead of the
  SmashRun CTA.

## Verified

- 6 new vitest cases: heuristic (coach-no-runs, coach-with-runs, plain runner
  short-circuit, admin, stats-failure fallback) + session caching/reset.
- `vue-tsc --noEmit` clean.
- Full suite: 186 pass; the 7 failing `useSync`/`useUserPreferences` tests fail
  identically on main (pre-existing; frontend eslint is also broken repo-wide
  and not in CI — both worth their own cleanup ticket).

## Matthew's first login (once invited)

redeem coach invite → log in → land on **Coach** → see Gabe + "Track Thursday".

Fixes SB-265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)