### PR TITLE
feat: coach home — athlete state, activity feed, needs-attention (SB-266)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -6,6 +6,7 @@ from backend.config import get_settings
 from backend.routes import (
     athletes,
     auth_routes,
+    coach,
     invites,
     metrics,
     plan,
@@ -61,6 +62,7 @@ def create_app() -> FastAPI:
     app.include_router(invites.router)
     app.include_router(athletes.router)
     app.include_router(athletes.me_router)
+    app.include_router(coach.router)
 
     return app
 

--- a/backend/routes/coach.py
+++ b/backend/routes/coach.py
@@ -1,0 +1,106 @@
+"""/coach — the coach's home aggregate (SB-266).
+
+One response powers the coach landing page: athlete cards with training state,
+a cross-athlete recent-activity feed, and the pending-invite count. Aggregated
+server-side so the SPA doesn't fan out a call per athlete.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from backend.admin import is_admin, require_coach
+from backend.auth import authenticate_request
+from fastapi import APIRouter, Depends
+from src.shared.models import Athlete
+from src.shared.models.coach_home import CoachHome, CoachHomeAthlete, CoachHomeSession
+from src.shared.supabase_client import get_supabase_client
+from src.shared.supabase_ops import (
+    AthletesRepository,
+    InvitesRepository,
+    WorkoutSessionsRepository,
+    WorkoutTemplatesRepository,
+)
+
+router = APIRouter(prefix="/coach", tags=["coach"])
+
+#: Sessions pulled for the aggregate — enough to compute per-athlete state at
+#: this product's scale; the feed itself shows only the newest few.
+_SESSION_WINDOW = 200
+_FEED_LIMIT = 10
+
+
+@router.get("/home", response_model=CoachHome)
+def coach_home(user_id: UUID = Depends(authenticate_request)) -> CoachHome:
+    """Everything the coach landing page needs, in one call."""
+    require_coach(user_id)
+    supabase = get_supabase_client()
+
+    athletes = [Athlete(**r) for r in AthletesRepository(supabase).list_for_coach(user_id)]
+    ids = [a.id for a in athletes]
+    names = {str(a.id): a.display_name for a in athletes}
+
+    sessions = WorkoutSessionsRepository(supabase).list_for_athletes(ids, limit=_SESSION_WINDOW)
+    templates = WorkoutTemplatesRepository(supabase).list_for_athletes(ids)
+    template_names = {t["id"]: t["name"] for t in templates}
+
+    # Both lists arrive newest-first, so "first seen per athlete" == latest.
+    last_session: dict[str, str] = {}
+    session_counts: dict[str, int] = {}
+    for s in sessions:
+        aid = s["athlete_id"]
+        last_session.setdefault(aid, s["session_date"])
+        session_counts[aid] = session_counts.get(aid, 0) + 1
+    latest_template: dict[str, dict] = {}
+    for t in templates:
+        latest_template.setdefault(t["athlete_id"], t)
+
+    cards: list[CoachHomeAthlete] = []
+    for athlete in athletes:
+        aid = str(athlete.id)
+        tpl = latest_template.get(aid)
+        last = last_session.get(aid)
+        needs_attention = False
+        if tpl is not None:
+            assigned = datetime.fromisoformat(tpl["created_at"]).astimezone(UTC).date()
+            # Assigned a plan and nothing logged since (or nothing logged ever).
+            needs_attention = last is None or datetime.fromisoformat(last).date() < assigned
+        cards.append(
+            CoachHomeAthlete(
+                athlete=athlete,
+                last_session_date=last,  # type: ignore[arg-type]  # ISO date str -> date via pydantic
+                sessions_count=session_counts.get(aid, 0),
+                latest_template_id=tpl["id"] if tpl else None,
+                latest_template_name=tpl["name"] if tpl else None,
+                latest_template_created_at=tpl["created_at"] if tpl else None,
+                needs_attention=needs_attention,
+            )
+        )
+    # Athletes needing attention float to the top.
+    cards.sort(key=lambda c: (not c.needs_attention, c.athlete.display_name.lower()))
+
+    feed = [
+        CoachHomeSession(
+            id=s["id"],
+            athlete_id=s["athlete_id"],
+            athlete_name=names.get(s["athlete_id"], "?"),
+            session_date=s["session_date"],
+            type=s["type"],
+            template_id=s.get("template_id"),
+            template_name=template_names.get(s.get("template_id") or ""),
+            how_felt=s.get("how_felt"),
+        )
+        for s in sessions[:_FEED_LIMIT]
+    ]
+
+    pending = 0
+    if is_admin(user_id):
+        now = datetime.now(UTC)
+        pending = sum(
+            1
+            for i in InvitesRepository(supabase).list_by_creator(user_id)
+            if i.get("redeemed_at") is None and datetime.fromisoformat(i["expires_at"]) > now
+        )
+
+    return CoachHome(athletes=cards, recent_sessions=feed, pending_invites=pending)

--- a/backend/tests/test_coach_home.py
+++ b/backend/tests/test_coach_home.py
@@ -1,0 +1,171 @@
+"""Tests for the coach home aggregate (SB-266)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import uuid4
+
+from backend.routes import coach as coach_module
+
+USER = uuid4()
+GABE = str(uuid4())
+MAYA = str(uuid4())
+TPL = str(uuid4())
+
+
+def _athlete_row(athlete_id: str, name: str) -> dict[str, Any]:
+    return {
+        "id": athlete_id,
+        "display_name": name,
+        "birth_year": 2012,
+        "linked_user_id": None,
+        "created_by": str(USER),
+        "notes": None,
+        "created_at": "2026-07-01T00:00:00+00:00",
+    }
+
+
+class _Repo:
+    """Stand-in for any repository: canned return values per method."""
+
+    def __init__(self, **methods: Any) -> None:
+        self._methods = methods
+
+    def __call__(self, _supabase: Any) -> _Repo:
+        return self
+
+    def __getattr__(self, name: str) -> Any:
+        if name in self._methods:
+            return lambda *a, **k: self._methods[name]
+        raise AttributeError(name)
+
+
+def _patch(monkeypatch: Any, *, athletes: Any, sessions: Any, templates: Any, invites: Any = ()):
+    monkeypatch.setattr(coach_module, "get_supabase_client", lambda: object())
+    monkeypatch.setattr(coach_module, "require_coach", lambda _u: None)
+    monkeypatch.setattr(coach_module, "AthletesRepository", _Repo(list_for_coach=athletes))
+    monkeypatch.setattr(
+        coach_module, "WorkoutSessionsRepository", _Repo(list_for_athletes=sessions)
+    )
+    monkeypatch.setattr(
+        coach_module, "WorkoutTemplatesRepository", _Repo(list_for_athletes=templates)
+    )
+    monkeypatch.setattr(coach_module, "InvitesRepository", _Repo(list_by_creator=list(invites)))
+
+
+def test_needs_attention_when_template_newer_than_last_session(monkeypatch: Any) -> None:
+    _patch(
+        monkeypatch,
+        athletes=[_athlete_row(GABE, "Gabe"), _athlete_row(MAYA, "Maya")],
+        sessions=[
+            # Maya trained after her plan landed; Gabe hasn't logged since his.
+            {
+                "id": str(uuid4()),
+                "athlete_id": MAYA,
+                "session_date": "2026-07-10",
+                "type": "intervals",
+                "template_id": None,
+                "how_felt": "good",
+            },
+            {
+                "id": str(uuid4()),
+                "athlete_id": GABE,
+                "session_date": "2026-07-05",
+                "type": "intervals",
+                "template_id": None,
+                "how_felt": None,
+            },
+        ],
+        templates=[
+            {
+                "id": TPL,
+                "athlete_id": GABE,
+                "name": "Track Thursday",
+                "created_at": "2026-07-08T12:00:00+00:00",
+            },
+            {
+                "id": str(uuid4()),
+                "athlete_id": MAYA,
+                "name": "Hills",
+                "created_at": "2026-07-09T12:00:00+00:00",
+            },
+        ],
+    )
+    monkeypatch.setattr(coach_module, "is_admin", lambda _u: False)
+    out = coach_module.coach_home(user_id=USER)
+
+    by_name = {c.athlete.display_name: c for c in out.athletes}
+    assert by_name["Gabe"].needs_attention is True
+    assert by_name["Gabe"].latest_template_name == "Track Thursday"
+    assert by_name["Maya"].needs_attention is False
+    # Flagged athletes sort first.
+    assert out.athletes[0].athlete.display_name == "Gabe"
+
+
+def test_feed_carries_names_and_template(monkeypatch: Any) -> None:
+    sid = str(uuid4())
+    _patch(
+        monkeypatch,
+        athletes=[_athlete_row(GABE, "Gabe")],
+        sessions=[
+            {
+                "id": sid,
+                "athlete_id": GABE,
+                "session_date": "2026-07-09",
+                "type": "intervals",
+                "template_id": TPL,
+                "how_felt": "strong",
+            }
+        ],
+        templates=[
+            {
+                "id": TPL,
+                "athlete_id": GABE,
+                "name": "Track Thursday",
+                "created_at": "2026-07-08T12:00:00+00:00",
+            }
+        ],
+    )
+    monkeypatch.setattr(coach_module, "is_admin", lambda _u: False)
+    out = coach_module.coach_home(user_id=USER)
+
+    assert len(out.recent_sessions) == 1
+    row = out.recent_sessions[0]
+    assert row.athlete_name == "Gabe"
+    assert row.template_name == "Track Thursday"
+    assert out.pending_invites == 0  # non-admin never counts invites
+
+
+def test_pending_invites_counts_only_live_unredeemed_for_admin(monkeypatch: Any) -> None:
+    future = (datetime.now(UTC) + timedelta(days=7)).isoformat()
+    past = (datetime.now(UTC) - timedelta(days=1)).isoformat()
+    _patch(
+        monkeypatch,
+        athletes=[],
+        sessions=[],
+        templates=[],
+        invites=[
+            {"redeemed_at": None, "expires_at": future},  # counts
+            {"redeemed_at": "2026-07-01T00:00:00+00:00", "expires_at": future},  # redeemed
+            {"redeemed_at": None, "expires_at": past},  # expired
+        ],
+    )
+    monkeypatch.setattr(coach_module, "is_admin", lambda _u: True)
+    out = coach_module.coach_home(user_id=USER)
+    assert out.pending_invites == 1
+
+
+def test_no_template_never_flags(monkeypatch: Any) -> None:
+    _patch(
+        monkeypatch,
+        athletes=[_athlete_row(GABE, "Gabe")],
+        sessions=[],
+        templates=[],
+    )
+    monkeypatch.setattr(coach_module, "is_admin", lambda _u: False)
+    out = coach_module.coach_home(user_id=USER)
+    card = out.athletes[0]
+    assert card.needs_attention is False
+    assert card.last_session_date is None
+    assert card.sessions_count == 0

--- a/frontend/src/composables/useCoachHome.ts
+++ b/frontend/src/composables/useCoachHome.ts
@@ -1,0 +1,24 @@
+import { ref } from 'vue'
+import { apiCall } from '@/config/api'
+import type { CoachHome } from '@/types/coach'
+
+/** The coach landing aggregate (SB-266) — one call, everything the page shows. */
+export function useCoachHome() {
+  const home = ref<CoachHome | null>(null)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const load = async (): Promise<void> => {
+    loading.value = true
+    error.value = null
+    try {
+      home.value = await apiCall<CoachHome>('/coach/home')
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load coach home'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { home, loading, error, load }
+}

--- a/frontend/src/types/coach.ts
+++ b/frontend/src/types/coach.ts
@@ -92,3 +92,32 @@ export interface WorkoutSession {
   notes: string | null
   sets: ExerciseSet[]
 }
+
+// ---- Coach home aggregate (SB-266) ----
+
+export interface CoachHomeAthlete {
+  athlete: Athlete
+  last_session_date: string | null
+  sessions_count: number
+  latest_template_id: string | null
+  latest_template_name: string | null
+  latest_template_created_at: string | null
+  needs_attention: boolean
+}
+
+export interface CoachHomeSession {
+  id: string
+  athlete_id: string
+  athlete_name: string
+  session_date: string
+  type: WorkoutType
+  template_id: string | null
+  template_name: string | null
+  how_felt: string | null
+}
+
+export interface CoachHome {
+  athletes: CoachHomeAthlete[]
+  recent_sessions: CoachHomeSession[]
+  pending_invites: number
+}

--- a/frontend/src/views/CoachView.vue
+++ b/frontend/src/views/CoachView.vue
@@ -2,14 +2,20 @@
   <div class="container-app py-8">
     <div class="flex items-center justify-between mb-6">
       <div>
-        <h1 class="text-2xl font-bold text-gray-900">Athletes</h1>
+        <h1 class="text-2xl font-bold text-gray-900">Coach</h1>
         <p class="text-sm text-gray-500 mt-1">
-          {{ athletes.length > 0 ? `Coaching ${athletes.length}` : 'No athletes yet' }}
+          {{ cards.length > 0 ? `Coaching ${cards.length}` : 'No athletes yet' }}
+          <span v-if="home && home.pending_invites > 0" class="text-amber-600">
+            · {{ home.pending_invites }} pending invite{{ home.pending_invites > 1 ? 's' : '' }}
+          </span>
         </p>
       </div>
-      <button class="btn-primary text-sm" @click="showForm = !showForm">
-        {{ showForm ? 'Cancel' : '+ Add athlete' }}
-      </button>
+      <div class="flex gap-2">
+        <RouterLink to="/exercises" class="btn-secondary text-sm">Exercise catalog</RouterLink>
+        <button class="btn-primary text-sm" @click="showForm = !showForm">
+          {{ showForm ? 'Cancel' : '+ Add athlete' }}
+        </button>
+      </div>
     </div>
 
     <form
@@ -41,49 +47,98 @@
       </button>
     </form>
 
-    <div v-if="loading && athletes.length === 0" class="space-y-2">
-      <div v-for="i in 3" :key="i" class="bg-white rounded-lg border border-gray-100 h-16 animate-pulse" />
+    <div v-if="loading && !home" class="space-y-2">
+      <div v-for="i in 3" :key="i" class="bg-white rounded-lg border border-gray-100 h-24 animate-pulse" />
     </div>
 
     <div v-else-if="error" class="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-700">
       {{ error }}
     </div>
 
-    <div
-      v-else-if="athletes.length === 0"
-      class="bg-white rounded-xl border border-gray-100 shadow-sm p-10 text-center text-gray-500"
-    >
-      <p>No athletes yet. Click <span class="font-semibold">Add athlete</span> to create one.</p>
-    </div>
-
-    <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-      <RouterLink
-        v-for="a in athletes"
-        :key="a.id"
-        :to="`/coach/${a.id}`"
-        class="bg-white rounded-xl border border-gray-100 shadow-sm p-4 hover:border-brand-300 hover:shadow transition"
+    <template v-else>
+      <div
+        v-if="cards.length === 0"
+        class="bg-white rounded-xl border border-gray-100 shadow-sm p-10 text-center text-gray-500"
       >
-        <p class="font-semibold text-gray-900">{{ a.display_name }}</p>
-        <p class="text-sm text-gray-500 mt-1">
-          {{ a.birth_year ? `Born ${a.birth_year}` : 'No birth year' }}
-          <span v-if="a.linked_user_id" class="text-brand-600"> · has login</span>
-        </p>
-      </RouterLink>
-    </div>
+        <p>No athletes yet. Click <span class="font-semibold">Add athlete</span> to create one.</p>
+      </div>
+
+      <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+        <RouterLink
+          v-for="c in cards"
+          :key="c.athlete.id"
+          :to="`/coach/${c.athlete.id}`"
+          class="bg-white rounded-xl border shadow-sm p-4 hover:shadow transition"
+          :class="c.needs_attention ? 'border-amber-300 hover:border-amber-400' : 'border-gray-100 hover:border-brand-300'"
+        >
+          <div class="flex items-start justify-between">
+            <p class="font-semibold text-gray-900">{{ c.athlete.display_name }}</p>
+            <span
+              v-if="c.needs_attention"
+              class="text-xs font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-full px-2 py-0.5"
+            >
+              workout waiting
+            </span>
+          </div>
+          <p class="text-sm text-gray-500 mt-2">
+            {{ c.last_session_date ? `Last logged ${formatDay(c.last_session_date)}` : 'Nothing logged yet' }}
+            <span v-if="c.sessions_count"> · {{ c.sessions_count }} session{{ c.sessions_count > 1 ? 's' : '' }}</span>
+          </p>
+          <p v-if="c.latest_template_name" class="text-sm text-gray-500 mt-1 truncate">
+            Plan: <span class="text-gray-700">{{ c.latest_template_name }}</span>
+          </p>
+        </RouterLink>
+      </div>
+
+      <div v-if="home && home.recent_sessions.length > 0">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Recent activity</h2>
+        <div class="bg-white rounded-xl border border-gray-100 shadow-sm divide-y divide-gray-50">
+          <RouterLink
+            v-for="s in home.recent_sessions"
+            :key="s.id"
+            :to="`/coach/${s.athlete_id}`"
+            class="flex items-center justify-between px-4 py-3 hover:bg-gray-50 transition"
+          >
+            <div class="min-w-0">
+              <p class="text-sm font-medium text-gray-900">
+                {{ s.athlete_name }}
+                <span class="text-gray-400 font-normal"> · {{ s.template_name || s.type }}</span>
+              </p>
+              <p v-if="s.how_felt" class="text-xs text-gray-500 truncate mt-0.5">{{ s.how_felt }}</p>
+            </div>
+            <span class="text-sm text-gray-500 shrink-0 ml-4">{{ formatDay(s.session_date) }}</span>
+          </RouterLink>
+        </div>
+      </div>
+    </template>
   </div>
 </template>
 
 <script setup lang="ts">
-import { onMounted, reactive, ref } from 'vue'
+import { computed, onMounted, reactive, ref } from 'vue'
 import { RouterLink } from 'vue-router'
 import { useCoach } from '@/composables/useCoach'
+import { useCoachHome } from '@/composables/useCoachHome'
 import type { AthleteCreate } from '@/types/coach'
 
-const { athletes, loading, error, loadAthletes, createAthlete } = useCoach()
+const { createAthlete } = useCoach()
+const { home, loading, error, load } = useCoachHome()
+
+const cards = computed(() => home.value?.athletes ?? [])
 
 const showForm = ref(false)
 const saving = ref(false)
 const form = reactive<AthleteCreate>({ display_name: '', birth_year: null, notes: null })
+
+const formatDay = (iso: string): string => {
+  const d = new Date(`${iso}T00:00:00`)
+  const today = new Date()
+  const days = Math.round((today.setHours(0, 0, 0, 0) - d.getTime()) / 86_400_000)
+  if (days === 0) return 'today'
+  if (days === 1) return 'yesterday'
+  if (days < 7) return d.toLocaleDateString(undefined, { weekday: 'short' })
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
 
 const submit = async () => {
   saving.value = true
@@ -98,8 +153,9 @@ const submit = async () => {
     form.birth_year = null
     form.notes = null
     showForm.value = false
+    await load()
   }
 }
 
-onMounted(loadAthletes)
+onMounted(load)
 </script>

--- a/frontend/src/views/__tests__/CoachView.test.ts
+++ b/frontend/src/views/__tests__/CoachView.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+const apiCallMock = vi.fn()
+vi.mock('@/config/api', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+}))
+
+import CoachView from '../CoachView.vue'
+
+const athlete = (id: string, name: string) => ({
+  id,
+  display_name: name,
+  birth_year: 2012,
+  linked_user_id: null,
+  created_by: 'u',
+  notes: null,
+  created_at: '2026-07-01T00:00:00Z',
+  profile: null,
+})
+
+const home = {
+  athletes: [
+    {
+      athlete: athlete('a1', 'Gabe'),
+      last_session_date: '2026-07-05',
+      sessions_count: 3,
+      latest_template_id: 't1',
+      latest_template_name: 'Track Thursday',
+      latest_template_created_at: '2026-07-08T12:00:00Z',
+      needs_attention: true,
+    },
+    {
+      athlete: athlete('a2', 'Maya'),
+      last_session_date: '2026-07-10',
+      sessions_count: 8,
+      latest_template_id: null,
+      latest_template_name: null,
+      latest_template_created_at: null,
+      needs_attention: false,
+    },
+  ],
+  recent_sessions: [
+    {
+      id: 's1',
+      athlete_id: 'a1',
+      athlete_name: 'Gabe',
+      session_date: '2026-07-05',
+      type: 'intervals',
+      template_id: 't1',
+      template_name: 'Track Thursday',
+      how_felt: 'strong through the 200s',
+    },
+  ],
+  pending_invites: 2,
+}
+
+const globalStubs = { global: { stubs: { RouterLink: { template: '<a><slot /></a>' } } } }
+
+beforeEach(() => {
+  apiCallMock.mockReset()
+})
+
+describe('CoachView (SB-266)', () => {
+  it('renders athlete cards with training state + attention badge', async () => {
+    apiCallMock.mockResolvedValue(home)
+    const w = mount(CoachView, globalStubs)
+    await flushPromises()
+
+    expect(apiCallMock).toHaveBeenCalledWith('/coach/home')
+    expect(w.text()).toContain('Gabe')
+    expect(w.text()).toContain('workout waiting')
+    expect(w.text()).toContain('Track Thursday')
+    expect(w.text()).toContain('Coaching 2')
+    expect(w.text()).toContain('2 pending invites')
+  })
+
+  it('renders the recent-activity feed', async () => {
+    apiCallMock.mockResolvedValue(home)
+    const w = mount(CoachView, globalStubs)
+    await flushPromises()
+    expect(w.text()).toContain('Recent activity')
+    expect(w.text()).toContain('strong through the 200s')
+  })
+
+  it('shows the empty state with no athletes', async () => {
+    apiCallMock.mockResolvedValue({ athletes: [], recent_sessions: [], pending_invites: 0 })
+    const w = mount(CoachView, globalStubs)
+    await flushPromises()
+    expect(w.text()).toContain('No athletes yet')
+  })
+})

--- a/src/shared/models/coach_home.py
+++ b/src/shared/models/coach_home.py
@@ -1,0 +1,48 @@
+"""Coach home aggregate (SB-266) — everything a coach's landing page shows in
+one response, so the SPA doesn't fan out N+1 calls per athlete."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from src.shared.models.athlete import Athlete
+
+
+class CoachHomeAthlete(BaseModel):
+    """An athlete card: who they are + where their training stands."""
+
+    athlete: Athlete
+    last_session_date: date | None = None
+    sessions_count: int = 0
+    latest_template_id: UUID | None = None
+    latest_template_name: str | None = None
+    latest_template_created_at: datetime | None = None
+    #: A template was assigned and no session has been logged since ("Gabe
+    #: hasn't logged Thursday yet"), or a template exists with no sessions ever.
+    needs_attention: bool = False
+
+
+class CoachHomeSession(BaseModel):
+    """One row of the cross-athlete recent-activity feed."""
+
+    id: UUID
+    athlete_id: UUID
+    athlete_name: str
+    session_date: date
+    type: str
+    template_id: UUID | None = None
+    template_name: str | None = None
+    how_felt: str | None = None
+
+
+class CoachHome(BaseModel):
+    """Response of ``GET /coach/home``."""
+
+    athletes: list[CoachHomeAthlete] = Field(default_factory=list)
+    recent_sessions: list[CoachHomeSession] = Field(default_factory=list)
+    #: Invites issued by the caller and not yet redeemed (admins only — empty
+    #: for plain coaches, who cannot list invites).
+    pending_invites: int = 0

--- a/src/shared/supabase_ops/workout_repository.py
+++ b/src/shared/supabase_ops/workout_repository.py
@@ -223,6 +223,21 @@ class WorkoutTemplatesRepository:
             t["items"] = by_template.get(t["id"], [])
         return templates
 
+    def list_for_athletes(self, athlete_ids: Sequence[UUID]) -> list[dict[str, Any]]:
+        """Template header rows (no items) across a coach's athletes, newest
+        first. Feeds the coach home aggregate (SB-266); callers hold the
+        athlete set, so access is enforced upstream."""
+        if not athlete_ids:
+            return []
+        result = (
+            self.supabase.table("workout_templates")
+            .select("*")
+            .in_("athlete_id", [str(a) for a in athlete_ids])
+            .order("created_at", desc=True)
+            .execute()
+        )
+        return cast(list[dict[str, Any]], result.data)
+
     def get(
         self, user_id: UUID, template_id: UUID, athlete_id: UUID | None = None
     ) -> dict[str, Any] | None:
@@ -288,6 +303,23 @@ class WorkoutSessionsRepository:
         if date_to is not None:
             query = query.lte("session_date", date_to.isoformat())
         result = query.order("session_date", desc=True).limit(limit).execute()
+        return cast(list[dict[str, Any]], result.data)
+
+    def list_for_athletes(
+        self, athlete_ids: Sequence[UUID], limit: int = 10
+    ) -> list[dict[str, Any]]:
+        """Recent sessions across a coach's athletes, newest first (no sets).
+        Feeds the coach home aggregate (SB-266); access enforced upstream."""
+        if not athlete_ids:
+            return []
+        result = (
+            self.supabase.table("workout_sessions")
+            .select("*")
+            .in_("athlete_id", [str(a) for a in athlete_ids])
+            .order("session_date", desc=True)
+            .limit(limit)
+            .execute()
+        )
         return cast(list[dict[str, Any]], result.data)
 
     def get(


### PR DESCRIPTION
P2 of the persona-aware UX arc (SB-265 shipped → **SB-266** → SB-267). The
Coach tab was a bare athlete list; combined with SB-265's routing, a coach now
lands on a page that tells them where every athlete stands.

## Backend

- **`GET /coach/home`** — one aggregate response (no per-athlete fan-out):
  - **Athlete cards**: last logged session, session count, latest assigned
    template.
  - **`needs_attention`**: a plan was assigned and nothing logged since (or
    ever) — "Gabe hasn't logged Thursday yet". Flagged athletes sort first.
  - **Recent activity**: newest sessions across all coached athletes, enriched
    with athlete + template names.
  - **Pending invites** count (admins only; plain coaches get 0 — they can't
    list invites).
- Repo: `list_for_athletes` for sessions + template headers — single `.in_()`
  queries each.
- 4 route tests: attention logic, feed enrichment, live-unredeemed invite
  counting, empty state.

## Frontend

- `CoachView` → coach home: cards with a **"workout waiting"** badge (amber
  border), last-logged + plan lines, a **Recent activity** feed linking to the
  athlete, pending-invites note, Exercise catalog quick link. Add-athlete flow
  unchanged.
- `useCoachHome` composable + types; 3 view tests; `vue-tsc` clean.

## Verified live (local API)

`/coach/home` returns Gabe flagged with "Track Thursday — broken 400 + hills"
(plan assigned after his last logged session) and the feed row carries his
name + the template — exactly the Matthew-checks-on-Gabe flow.

Fixes SB-266. SB-267 (settings default-tab override) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)