### PR TITLE
feat: settings default-view override for landing (SB-267)

### DIFF
--- a/frontend/src/composables/__tests__/useLanding.test.ts
+++ b/frontend/src/composables/__tests__/useLanding.test.ts
@@ -6,6 +6,12 @@ vi.mock('@/config/api', () => ({
   apiCall: (...args: unknown[]) => apiCallMock(...args),
 }))
 
+// Supabase auth supplies the default_view preference (SB-267).
+const getUserMock = vi.fn()
+vi.mock('@/config/supabase', () => ({
+  supabase: { auth: { getUser: getUserMock } },
+}))
+
 // Fresh module per test — both the landing cache and useCoach's roles cache
 // are module-scoped.
 async function freshModule() {
@@ -21,11 +27,17 @@ function mockApi(roles: { roles: string[]; is_admin: boolean }, totalRuns: numbe
   })
 }
 
+function mockPreference(defaultView: string | undefined) {
+  getUserMock.mockResolvedValue({ data: { user: { user_metadata: { default_view: defaultView } } } })
+}
+
 beforeEach(() => {
   apiCallMock.mockReset()
+  getUserMock.mockReset()
+  mockPreference(undefined)
 })
 
-describe('resolveLanding (SB-265)', () => {
+describe('resolveLanding (SB-265 heuristic)', () => {
   it('coach with no runs lands on Coach', async () => {
     mockApi({ roles: ['coach'], is_admin: false }, 0)
     const { resolveLanding } = await freshModule()
@@ -75,5 +87,46 @@ describe('resolveLanding (SB-265)', () => {
     resetLanding()
     mockApi({ roles: ['coach'], is_admin: false }, 42)
     expect(await resolveLanding()).toBe('/dashboard')
+  })
+})
+
+describe('resolveLanding (SB-267 preference override)', () => {
+  it('an explicit preference beats the heuristic — no API calls needed', async () => {
+    mockPreference('runs')
+    const { resolveLanding } = await freshModule()
+    expect(await resolveLanding()).toBe('/runs')
+    expect(apiCallMock).not.toHaveBeenCalled()
+  })
+
+  it('a coach preference sends even a running coach to Coach', async () => {
+    mockPreference('coach')
+    mockApi({ roles: ['coach'], is_admin: false }, 500)
+    const { resolveLanding } = await freshModule()
+    expect(await resolveLanding()).toBe('/coach')
+  })
+
+  it("'auto' falls through to the heuristic", async () => {
+    mockPreference('auto')
+    mockApi({ roles: ['coach'], is_admin: false }, 0)
+    const { resolveLanding } = await freshModule()
+    expect(await resolveLanding()).toBe('/coach')
+  })
+
+  it('an unknown stored value falls through to the heuristic', async () => {
+    mockPreference('bogus')
+    mockApi({ roles: [], is_admin: false }, 0)
+    const { resolveLanding } = await freshModule()
+    expect(await resolveLanding()).toBe('/dashboard')
+  })
+
+  it('a preference change takes effect after resetLanding', async () => {
+    mockPreference(undefined)
+    mockApi({ roles: [], is_admin: false }, 10)
+    const { resolveLanding, resetLanding } = await freshModule()
+    expect(await resolveLanding()).toBe('/dashboard')
+
+    mockPreference('runs')
+    resetLanding()
+    expect(await resolveLanding()).toBe('/runs')
   })
 })

--- a/frontend/src/composables/useLanding.ts
+++ b/frontend/src/composables/useLanding.ts
@@ -1,4 +1,5 @@
 import { apiCall } from '@/config/api'
+import { supabase } from '@/config/supabase'
 import type { OverallStats } from '@/types/runs'
 import { useRoles } from './useCoach'
 
@@ -6,18 +7,38 @@ import { useRoles } from './useCoach'
 // navigation), not on every route change. Reset on logout.
 let resolved: string | null = null
 
+const PREFERENCE_PATHS: Record<string, string> = {
+  dashboard: '/dashboard',
+  runs: '/runs',
+  coach: '/coach',
+}
+
 /**
- * Where a just-authenticated user should land (SB-265).
+ * Where a just-authenticated user should land (SB-265 / SB-267).
  *
- * Coaches (or admins) with no run history land on Coach — the runner
- * dashboard's "Connect SmashRun" CTA is a dead end for them. Anyone with runs,
- * or without the coach role, keeps the runner dashboard. Explicit user
- * preference will take precedence over this heuristic when SB-267 lands.
+ * Precedence: an explicit "default view" preference (Settings, stored in
+ * Supabase user_metadata) → role heuristic → runner dashboard. The heuristic:
+ * coaches (or admins) with no run history land on Coach — the runner
+ * dashboard's "Connect SmashRun" CTA is a dead end for them.
  *
- * Returns a route path ('/coach' | '/dashboard').
+ * Returns a route path ('/coach' | '/runs' | '/dashboard').
  */
 export async function resolveLanding(): Promise<string> {
   if (resolved) return resolved
+
+  // 1. Explicit preference wins (SB-267). 'auto' or absent falls through.
+  try {
+    const { data } = await supabase.auth.getUser()
+    const pref = data.user?.user_metadata?.default_view as string | undefined
+    if (pref && PREFERENCE_PATHS[pref]) {
+      resolved = PREFERENCE_PATHS[pref]
+      return resolved
+    }
+  } catch {
+    // fall through to the heuristic
+  }
+
+  // 2. Role heuristic (SB-265).
   const { roles, loadRoles } = useRoles()
   await loadRoles()
   const coachish = !!roles.value && (roles.value.roles.includes('coach') || roles.value.is_admin)
@@ -34,7 +55,7 @@ export async function resolveLanding(): Promise<string> {
   return resolved
 }
 
-/** Forget the cached decision (logout, tests). */
+/** Forget the cached decision (logout, or the preference just changed). */
 export function resetLanding(): void {
   resolved = null
 }

--- a/frontend/src/composables/useUserPreferences.ts
+++ b/frontend/src/composables/useUserPreferences.ts
@@ -5,7 +5,14 @@ import type { Unit } from '@/types/runs'
 const STORAGE_KEY = 'mrs.unit'
 const DEFAULT_UNIT: Unit = 'mi'
 
+/** Where the app opens by default. 'auto' = role heuristic (SB-265/267). */
+export type DefaultView = 'auto' | 'dashboard' | 'runs' | 'coach'
+const VIEW_STORAGE_KEY = 'mrs.defaultView'
+const DEFAULT_VIEW: DefaultView = 'auto'
+const VIEW_VALUES: readonly DefaultView[] = ['auto', 'dashboard', 'runs', 'coach']
+
 const unit = ref<Unit>(loadInitialUnit())
+const defaultView = ref<DefaultView>(loadInitialView())
 const loaded = ref(false)
 
 function loadInitialUnit(): Unit {
@@ -14,9 +21,21 @@ function loadInitialUnit(): Unit {
   return stored === 'mi' || stored === 'km' ? stored : DEFAULT_UNIT
 }
 
+function loadInitialView(): DefaultView {
+  if (typeof window === 'undefined') return DEFAULT_VIEW
+  const stored = window.localStorage.getItem(VIEW_STORAGE_KEY)
+  return VIEW_VALUES.includes(stored as DefaultView) ? (stored as DefaultView) : DEFAULT_VIEW
+}
+
 function persistLocally(value: Unit): void {
   if (typeof window !== 'undefined') {
     window.localStorage.setItem(STORAGE_KEY, value)
+  }
+}
+
+function persistViewLocally(value: DefaultView): void {
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(VIEW_STORAGE_KEY, value)
   }
 }
 
@@ -27,6 +46,11 @@ async function syncFromSupabase(): Promise<void> {
     unit.value = remote
     persistLocally(remote)
   }
+  const remoteView = data.user?.user_metadata?.default_view as DefaultView | undefined
+  if (remoteView && VIEW_VALUES.includes(remoteView)) {
+    defaultView.value = remoteView
+    persistViewLocally(remoteView)
+  }
   loaded.value = true
 }
 
@@ -36,13 +60,20 @@ async function setUnit(value: Unit): Promise<void> {
   await supabase.auth.updateUser({ data: { unit: value } })
 }
 
+async function setDefaultView(value: DefaultView): Promise<void> {
+  defaultView.value = value
+  persistViewLocally(value)
+  await supabase.auth.updateUser({ data: { default_view: value } })
+}
+
 export function useUserPreferences() {
   if (!loaded.value) {
     void syncFromSupabase()
   }
-  return { unit, setUnit, loaded }
+  return { unit, setUnit, defaultView, setDefaultView, loaded }
 }
 
 if (typeof window !== 'undefined') {
   watch(unit, persistLocally)
+  watch(defaultView, persistViewLocally)
 }

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -27,21 +27,62 @@
 
       <p v-if="saved" class="text-xs text-green-600 mt-3">Saved</p>
     </div>
+
+    <div class="bg-white rounded-xl border border-gray-100 shadow-sm p-6 mt-6">
+      <h2 class="text-lg font-semibold text-gray-900 mb-1">Default view</h2>
+      <p class="text-sm text-gray-500 mb-4">
+        Where the app opens after you sign in. Auto picks based on your role.
+      </p>
+
+      <div class="inline-flex rounded-lg border border-gray-200 p-1 bg-gray-50">
+        <button
+          v-for="option in viewOptions"
+          :key="option.value"
+          type="button"
+          @click="selectView(option.value)"
+          :class="[
+            'px-4 py-2 text-sm font-semibold rounded-md transition',
+            defaultView === option.value
+              ? 'bg-white text-brand-600 shadow-sm'
+              : 'text-gray-500 hover:text-gray-800',
+          ]"
+        >
+          {{ option.label }}
+        </button>
+      </div>
+
+      <p v-if="viewSaved" class="text-xs text-green-600 mt-3">Saved</p>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
-import { useUserPreferences } from '@/composables/useUserPreferences'
+import { computed, onMounted, ref } from 'vue'
+import { useUserPreferences, type DefaultView } from '@/composables/useUserPreferences'
+import { useRoles } from '@/composables/useCoach'
+import { resetLanding } from '@/composables/useLanding'
 import type { Unit } from '@/types/runs'
 
-const { unit, setUnit } = useUserPreferences()
+const { unit, setUnit, defaultView, setDefaultView } = useUserPreferences()
+const { isCoach, loadRoles } = useRoles()
 const saved = ref(false)
+const viewSaved = ref(false)
 
 const options: { value: Unit; label: string }[] = [
   { value: 'mi', label: 'Miles' },
   { value: 'km', label: 'Kilometers' },
 ]
+
+// Coach is only a meaningful destination for coaches/admins.
+const viewOptions = computed(() => {
+  const base: { value: DefaultView; label: string }[] = [
+    { value: 'auto', label: 'Auto' },
+    { value: 'dashboard', label: 'Dashboard' },
+    { value: 'runs', label: 'Runs' },
+  ]
+  if (isCoach.value) base.push({ value: 'coach', label: 'Coach' })
+  return base
+})
 
 const selectUnit = async (value: Unit) => {
   if (unit.value === value) return
@@ -49,4 +90,14 @@ const selectUnit = async (value: Unit) => {
   saved.value = true
   setTimeout(() => (saved.value = false), 2000)
 }
+
+const selectView = async (value: DefaultView) => {
+  if (defaultView.value === value) return
+  await setDefaultView(value)
+  resetLanding() // the next implicit navigation re-resolves with the new pick
+  viewSaved.value = true
+  setTimeout(() => (viewSaved.value = false), 2000)
+}
+
+onMounted(loadRoles)
 </script>


### PR DESCRIPTION
P3 — completes the persona-aware landing arc (SB-265 heuristic → SB-266 coach
home → **SB-267** explicit override).

## What

- **Settings → Default view**: Auto / Dashboard / Runs / Coach segmented
  control (Coach option only for coaches/admins), styled like the Units
  control. Saving resets the cached landing decision so it applies on the next
  implicit navigation.
- Stored in **Supabase `user_metadata.default_view`** (server-side, follows the
  user across devices) with a localStorage mirror — the exact mechanism the
  unit preference already uses. No new tables, no backend change.
- **Precedence in `resolveLanding`**: explicit preference → role heuristic
  (SB-265) → runner dashboard. `auto`/unknown fall through; a real preference
  short-circuits before any API call.

## Verified

- 11 landing tests (5 new: preference beats heuristic, a pinned Coach wins even
  for a running coach, `auto`/bogus fall through, change applies after reset).
- `vue-tsc` clean. Full suite: 188 pass; the 7 pre-existing failures are being
  fixed in a separate session (task already spun off).

Right defaults + an escape hatch: Matthew lands on Coach with zero config
(SB-265/266); you can pin Dashboard (or anything) regardless of role.

Fixes SB-267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)