### PR TITLE
feat: stk workout review — goal vs reality per segment (SB-264 CLI)

### DIFF
--- a/.claude/skills/log-workout/SKILL.md
+++ b/.claude/skills/log-workout/SKILL.md
@@ -54,6 +54,21 @@ When given a screenshot or pasted workout (the coach's prescription):
 3. Create it: `echo '<json>' | stk workout add-template --file -` (or write a temp
    file). Report the name + id.
 
+### Broken reps + goal pace ranges (SB-264)
+
+Track plans often prescribe a **range** ("2x200 goal 30-32") or a **broken rep**
+("400m broken into 100m sections: 20-22 / 15 / 20-22 / 15"). Model them:
+
+- Range → `target_duration_seconds` (min) + `target_duration_max_seconds` (max).
+- Broken rep → one item with a `segments` list, one entry per section:
+  ```json
+  {"exercise_key":"interval_run","position":5,"target_reps":1,"target_distance_m":400,
+   "segments":[{"distance_m":100,"target_s_min":20,"target_s_max":22,"label":"0-100"},
+               {"distance_m":100,"target_s_min":15,"label":"100-200"}]}
+  ```
+  A fixed goal sets only `target_s_min`. Track reps (200s, 400s) use
+  `interval_run` with `target_distance_m`.
+
 ## Flow B — log the actuals → a session (the live capture)
 
 When the user reads/speaks what the athlete did ("set 2, interval 12s, 18 reps;
@@ -77,7 +92,7 @@ When the user reads/speaks what the athlete did ("set 2, interval 12s, 18 reps;
      push-ups  R1 22 · R2 20 · R3 18
      40-yd dash  5.4 s   (vs last 5.6 — faster!)
      planks felt hard (RPE 8)
-   Save? 
+   Save?
    ```
 5. Save: `echo '<session json>' | stk workout log --file -`. Session JSON:
    ```json
@@ -85,6 +100,23 @@ When the user reads/speaks what the athlete did ("set 2, interval 12s, 18 reps;
     "sets":[{"exercise_key":"pushups","round_number":1,"reps":22},
             {"exercise_key":"40yd_dash","distance_m":36.58,"time_seconds":5.4}]}
    ```
+
+### Broken-rep REALITY (SB-264)
+
+When the athlete reports per-section times for a broken rep ("21 / 14 / stopped,
+walked, 1:40 / 14"), put them in the set's `extra.segments` — same order as the
+template's segments; anomalies go in a segment `note`:
+```json
+{"exercise_key":"interval_run","distance_m":400,
+ "notes":"broken 400 — stopped in 200-300",
+ "extra":{"segments":[{"distance_m":100,"time_s":21,"label":"0-100"},
+                      {"distance_m":100,"time_s":14,"label":"100-200"},
+                      {"distance_m":100,"time_s":100,"label":"200-300","note":"stop, walk — 1:40"},
+                      {"distance_m":100,"time_s":14,"label":"300-400"}]}}
+```
+Parse "1:40" → 100 seconds. Afterwards show the debrief:
+`stk workout review <session-id>` renders goal vs reality per segment
+(hit / fast / missed) — lead the narration with what it shows.
 
 ## Flow C — progress (the coach's feedback loop)
 

--- a/stk/pyproject.toml
+++ b/stk/pyproject.toml
@@ -33,3 +33,13 @@ module-name = "cli"
 [tool.ruff]
 line-length = 100
 target-version = "py312"
+
+[tool.pytest.ini_options]
+# Own config so stk's suite doesn't inherit the repo-root --cov addopts.
+testpaths = ["tests"]
+addopts = ""
+
+[dependency-groups]
+dev = [
+    "pytest>=9.1.1",
+]

--- a/stk/src/cli/commands/workout.py
+++ b/stk/src/cli/commands/workout.py
@@ -58,17 +58,44 @@ def templates(
         )
 
 
+def _fmt_secs(value: float) -> str:
+    """Seconds → compact display: 14 -> '14s', 100 -> '1:40'."""
+    if value >= 60:
+        return f"{int(value // 60)}:{int(value % 60):02d}"
+    return f"{value:g}s"
+
+
+def _fmt_goal(smin: float | None, smax: float | None) -> str:
+    """A goal that may be a range: (20, 22) -> '20-22s'; (15, None) -> '15s'."""
+    if smin is not None and smax is not None:
+        return f"{smin:g}-{smax:g}s"
+    if smin is not None:
+        return _fmt_secs(smin)
+    if smax is not None:
+        return f"≤{_fmt_secs(smax)}"
+    return "—"
+
+
 def _fmt_target(item: dict[str, Any]) -> str:
     parts = []
     if item.get("target_reps") is not None:
         parts.append(f"{item['target_reps']} reps")
-    if item.get("target_duration_seconds") is not None:
-        parts.append(f"{item['target_duration_seconds']}s")
+    smin, smax = item.get("target_duration_seconds"), item.get("target_duration_max_seconds")
+    if smin is not None or smax is not None:
+        parts.append(_fmt_goal(smin, smax))
     if item.get("target_load_kg") is not None:
         parts.append(f"{item['target_load_kg'] * 2.20462:.0f}lb")
     if item.get("target_distance_m") is not None:
-        parts.append(f"{item['target_distance_m'] / 0.9144:.0f}yd")
+        parts.append(_fmt_distance(item["target_distance_m"]))
     return " · ".join(parts) if parts else "—"
+
+
+def _fmt_distance(meters: float) -> str:
+    """Yd-native values (40yd dash -> 36.576m) render as yards; track reps as meters."""
+    yards = meters / 0.9144
+    if abs(yards - round(yards)) < 0.01 and abs(meters - round(meters)) > 0.01:
+        return f"{round(yards)}yd"
+    return f"{meters:g}m"
 
 
 def show(
@@ -96,6 +123,13 @@ def show(
         display.console.print(
             f"  {item['position'] + 1}. {item['exercise_key']:<16} {_fmt_target(item)}"
         )
+        # Broken rep (SB-264): one rep split into segments with per-segment goals.
+        for seg in item.get("segments") or []:
+            label = seg.get("label") or f"{seg['distance_m']:g}m"
+            display.console.print(
+                f"       [dim]{label:<10}[/dim] "
+                f"{_fmt_goal(seg.get('target_s_min'), seg.get('target_s_max'))}"
+            )
     if t.get("notes"):
         display.console.print(f"  [dim]{t['notes']}[/dim]")
     display.console.print("")
@@ -150,9 +184,95 @@ def log(
         )
 
 
+def _goal_status(time_s: float, smin: float | None, smax: float | None) -> str:
+    """Compare an actual segment time to its goal (range or fixed ±1s grace)."""
+    if smin is None and smax is None:
+        return ""
+    lo = smin if smin is not None else 0.0
+    hi = smax if smax is not None else lo + 1.0  # fixed goal: within a second
+    if time_s <= hi:
+        return "[green]hit[/green]" if time_s >= lo else "[green]fast[/green]"
+    return "[red]missed[/red]"
+
+
+def review(
+    session_id: str = typer.Argument(
+        ..., help="Session id (full or 8-char prefix from `sessions`)"
+    ),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
+) -> None:
+    """Goal vs reality for a logged session (SB-264) — the coach's debrief view."""
+    sid = session_id
+    if len(session_id) < 36:  # prefix → resolve against the list
+        match = [
+            s for s in api.request("workouts/sessions", {"limit": 100}) if s["id"].startswith(sid)
+        ]
+        if not match:
+            display.console.print(f"[red]No session id starting {session_id}[/red]")
+            raise typer.Exit(1)
+        sid = match[0]["id"]
+    s = api.request(f"workouts/sessions/{sid}")
+    if json_output:
+        _dump(s)
+        return
+
+    # Segment goals come from the template the session was logged against.
+    goals_by_key: dict[str, list[dict[str, Any]]] = {}
+    tpl_name = None
+    if s.get("template_id"):
+        tpl = api.request(f"workouts/templates/{s['template_id']}")
+        tpl_name = tpl.get("name")
+        for item in tpl.get("items", []):
+            if item.get("segments"):
+                goals_by_key.setdefault(item["exercise_key"], []).append(item)
+
+    header = f"\n[bold]{s['session_date']}[/bold]  {s['type']}"
+    if tpl_name:
+        header += f"  — {tpl_name}"
+    display.console.print(header)
+    if s.get("how_felt"):
+        display.console.print(f"  [dim]felt: {s['how_felt']}[/dim]")
+
+    for st in s.get("sets", []):
+        actual = f"{_fmt_secs(st['time_seconds'])}" if st.get("time_seconds") is not None else ""
+        line = f"  {st['exercise_key']:<16}"
+        if st.get("distance_m") is not None:
+            line += f" {_fmt_distance(st['distance_m']):<7}"
+        if actual:
+            line += f" {actual}"
+        if st.get("reps") is not None:
+            line += f" {st['reps']} reps"
+        display.console.print(line.rstrip())
+
+        # Broken rep: goal vs reality per segment.
+        segments = (st.get("extra") or {}).get("segments") or []
+        if segments:
+            goal_items = goals_by_key.get(st["exercise_key"], [])
+            goal_segs = goal_items[0]["segments"] if goal_items else []
+            display.console.print(f"       [dim]{'segment':<10} {'goal':<9} {'reality':<9}[/dim]")
+            for i, seg in enumerate(segments):
+                goal = goal_segs[i] if i < len(goal_segs) else {}
+                label = seg.get("label") or goal.get("label") or f"#{i + 1}"
+                goal_txt = _fmt_goal(goal.get("target_s_min"), goal.get("target_s_max"))
+                reality = _fmt_secs(seg["time_s"]) if seg.get("time_s") is not None else "—"
+                status = (
+                    _goal_status(seg["time_s"], goal.get("target_s_min"), goal.get("target_s_max"))
+                    if seg.get("time_s") is not None
+                    else ""
+                )
+                note = f"  [dim]{seg['note']}[/dim]" if seg.get("note") else ""
+                display.console.print(
+                    f"       {label:<10} {goal_txt:<9} {reality:<9} {status}{note}"
+                )
+        if st.get("notes"):
+            display.console.print(f"       [dim]{st['notes']}[/dim]")
+    display.console.print("")
+
+
 workout_app.command(name="exercises")(exercises)
 workout_app.command(name="templates")(templates)
 workout_app.command(name="show")(show)
 workout_app.command(name="sessions")(sessions)
+workout_app.command(name="review")(review)
 workout_app.command(name="add-template")(add_template)
 workout_app.command(name="log")(log)

--- a/stk/tests/test_workout_display.py
+++ b/stk/tests/test_workout_display.py
@@ -1,0 +1,44 @@
+"""Tests for workout display helpers — goal ranges, segments, goal-vs-reality (SB-264)."""
+
+from __future__ import annotations
+
+from cli.commands.workout import _fmt_distance, _fmt_goal, _fmt_secs, _fmt_target, _goal_status
+
+
+def test_fmt_secs_compact_and_minutes() -> None:
+    assert _fmt_secs(14) == "14s"
+    assert _fmt_secs(31.0) == "31s"
+    assert _fmt_secs(100) == "1:40"
+
+
+def test_fmt_goal_range_fixed_and_max_only() -> None:
+    assert _fmt_goal(20, 22) == "20-22s"
+    assert _fmt_goal(15, None) == "15s"
+    assert _fmt_goal(None, 22) == "≤22s"
+    assert _fmt_goal(None, None) == "—"
+
+
+def test_fmt_target_renders_range_and_meters() -> None:
+    item = {
+        "target_reps": 1,
+        "target_duration_seconds": 20,
+        "target_duration_max_seconds": 22,
+        "target_distance_m": 400,
+    }
+    assert _fmt_target(item) == "1 reps · 20-22s · 400m"
+
+
+def test_fmt_distance_yd_native_vs_track() -> None:
+    assert _fmt_distance(36.576) == "40yd"  # 40yd dash stored in meters
+    assert _fmt_distance(200) == "200m"
+    assert _fmt_distance(804) == "804m"
+
+
+def test_goal_status() -> None:
+    assert _goal_status(21, 20, 22) == "[green]hit[/green]"
+    assert _goal_status(19, 20, 22) == "[green]fast[/green]"
+    assert _goal_status(23, 20, 22) == "[red]missed[/red]"
+    assert _goal_status(15, 15, None) == "[green]hit[/green]"  # fixed goal, exact
+    assert _goal_status(16, 15, None) == "[green]hit[/green]"  # +1s grace
+    assert _goal_status(100, 20, 22) == "[red]missed[/red]"  # the stop-and-walk segment
+    assert _goal_status(14, None, None) == ""  # no goal, no verdict

--- a/stk/uv.lock
+++ b/stk/uv.lock
@@ -133,6 +133,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -267,6 +276,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -276,12 +294,37 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -347,6 +390,11 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
@@ -356,6 +404,9 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12.0" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.1.1" }]
 
 [[package]]
 name = "typer"


### PR DESCRIPTION
Completes SB-264 (schema/model shipped in #151). The broken-rep data is now
usable end-to-end from the terminal + the log-workout skill.

## The debrief, live (real local session)

```
2026-07-09  intervals  — Track Thursday — broken 400 + hills
  interval_run     200m    31s
  interval_run     200m    29s
  interval_run     100m    14s ...
  interval_run     400m
       segment    goal      reality
       0-100      20-22s    21s       hit
       100-200    15s       14s       fast
       200-300    20-22s    1:40      missed  stop, walk — 1:40
       300-400    15s       14s       fast
```

## What

- **`stk workout show`** — segment goals render under their item; duration
  ranges as `20-22s`; meters for track reps (yd-native values like the 40yd
  dash keep yards).
- **`stk workout review <session>`** — goal vs reality per segment:
  hit / fast / missed (+1s grace on fixed goals), segment notes inline, m:ss
  for ≥60s.
- **log-workout skill** — build segment goals in templates, parse REALITY
  ("21 / 14 / stop 1:40 / 14") into `extra.segments`, close with `review`.
- stk pytest config (identical to the block on the open SB-262 branch — merges
  clean either way) + **5 display-helper tests**.

Matthew's whole loop now: build the plan (segments included) → Gabe logs →
`review` shows exactly his GOAL/REALITY sheet.

Part of SB-264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)