### PR TITLE
feat: run detail view — weather, splits, elevation, vitals (SB-263)

### DIFF
--- a/backend/routes/runs.py
+++ b/backend/routes/runs.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 from backend.auth import authenticate_request
 from backend.cache import cached
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from src.shared.supabase_client import get_supabase_client
 from src.shared.supabase_ops import RunsRepository
 
@@ -100,3 +100,61 @@ async def list_runs(
     distance_max: float | None = Query(None, ge=0, description="Max distance in km"),
 ) -> dict[str, Any]:
     return await _list_runs(user_id, offset, limit, date_from, date_to, distance_min, distance_max)
+
+
+# NOTE: registered after /recent and "" so the static paths keep priority.
+@router.get("/{activity_id}")
+async def get_run_detail(
+    activity_id: str,
+    user_id: UUID = Depends(authenticate_request),
+) -> dict[str, Any]:
+    """One run with everything interesting about it: weather, vitals, splits,
+    and per-split elevation (SB-263 run detail view)."""
+    repo = RunsRepository(get_supabase_client())
+    run = repo.get_run_by_activity_id(user_id, activity_id)
+    if run is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Run not found")
+
+    splits = [
+        {
+            "split_number": s["split_number"],
+            "split_unit": s.get("split_unit"),
+            "cumulative_distance_km": _f(s.get("cumulative_distance_km")),
+            "cumulative_seconds": _f(s.get("cumulative_seconds")),
+            "pace_min_per_km": _f(s.get("pace_min_per_km")),
+            "heart_rate": s.get("heart_rate"),
+            "elevation_gain_m": _f(s.get("cumulative_elevation_gain_meters")),
+            "elevation_loss_m": _f(s.get("cumulative_elevation_loss_meters")),
+        }
+        for s in sorted(
+            repo.get_splits_for_run(UUID(run["id"])), key=lambda s: s["split_number"] or 0
+        )
+    ]
+
+    return {
+        "activity_id": run["source_activity_id"],
+        "date": run["start_date_time_local"],
+        "distance_km": _f(run["distance_km"]),
+        "duration_seconds": _f(run["duration_seconds"]),
+        "avg_pace_min_per_km": _f(run.get("average_pace_min_per_km")),
+        "weather": {
+            "temperature_celsius": _f(run.get("temperature_celsius")),
+            "weather_type": run.get("weather_type"),
+            "humidity_percent": run.get("humidity_percent"),
+            "wind_speed_kph": run.get("wind_speed_kph"),
+        },
+        "vitals": {
+            "heart_rate_avg": _f(run.get("heart_rate_average")),
+            "heart_rate_min": _f(run.get("heart_rate_min")),
+            "heart_rate_max": _f(run.get("heart_rate_max")),
+            "cadence_avg": _f(run.get("cadence_average")),
+        },
+        "how_felt": run.get("how_felt"),
+        "notes": run.get("notes"),
+        "splits": splits,
+    }
+
+
+def _f(value: Any) -> float | None:
+    """Numeric column (str/Decimal from supabase) -> float, preserving None."""
+    return float(value) if value is not None else None

--- a/backend/tests/test_run_detail.py
+++ b/backend/tests/test_run_detail.py
@@ -1,0 +1,97 @@
+"""Tests for GET /runs/{activity_id} (SB-263 run detail)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from backend.routes import runs as runs_module
+from fastapi import HTTPException
+
+USER = uuid4()
+RUN_ID = str(uuid4())
+
+_RUN = {
+    "id": RUN_ID,
+    "source_activity_id": "act-123",
+    "start_date_time_local": "2026-07-10T06:45:00",
+    "distance_km": "5.31",
+    "duration_seconds": "3141",
+    "average_pace_min_per_km": "9.86",
+    "temperature_celsius": "27.8",
+    "weather_type": "hot",
+    "humidity_percent": 82,
+    "wind_speed_kph": 9,
+    "heart_rate_average": "151",
+    "heart_rate_min": "128",
+    "heart_rate_max": "167",
+    "cadence_average": "169",
+    "how_felt": None,
+    "notes": None,
+}
+
+_SPLITS = [
+    {
+        "split_number": 2,
+        "split_unit": "mi",
+        "cumulative_distance_km": "3.219",
+        "cumulative_seconds": "1254",
+        "pace_min_per_km": "9.98",
+        "heart_rate": 150,
+        "cumulative_elevation_gain_meters": "29",
+        "cumulative_elevation_loss_meters": "15",
+    },
+    {
+        "split_number": 1,
+        "split_unit": "mi",
+        "cumulative_distance_km": "1.609",
+        "cumulative_seconds": "612",
+        "pace_min_per_km": "9.51",
+        "heart_rate": 142,
+        "cumulative_elevation_gain_meters": "12",
+        "cumulative_elevation_loss_meters": "4",
+    },
+]
+
+
+class _Repo:
+    def __init__(self, run: dict[str, Any] | None, splits: list[dict[str, Any]]):
+        self._run, self._splits = run, splits
+
+    def __call__(self, _supabase: Any) -> _Repo:
+        return self
+
+    def get_run_by_activity_id(self, user_id: Any, activity_id: str) -> dict[str, Any] | None:
+        return self._run
+
+    def get_splits_for_run(self, run_id: Any) -> list[dict[str, Any]]:
+        return self._splits
+
+
+def _detail(run: dict[str, Any] | None, splits: list[dict[str, Any]], monkeypatch: Any) -> Any:
+    monkeypatch.setattr(runs_module, "get_supabase_client", lambda: object())
+    monkeypatch.setattr(runs_module, "RunsRepository", _Repo(run, splits))
+    return asyncio.run(runs_module.get_run_detail("act-123", user_id=USER))
+
+
+def test_detail_shapes_weather_vitals_and_sorted_splits(monkeypatch: Any) -> None:
+    out = _detail(_RUN, _SPLITS, monkeypatch)
+    assert out["weather"] == {
+        "temperature_celsius": 27.8,
+        "weather_type": "hot",
+        "humidity_percent": 82,
+        "wind_speed_kph": 9,
+    }
+    assert out["vitals"]["heart_rate_max"] == 167.0
+    # Splits sorted by split_number, numerics coerced to float.
+    assert [s["split_number"] for s in out["splits"]] == [1, 2]
+    assert out["splits"][0]["pace_min_per_km"] == 9.51
+    assert out["splits"][1]["elevation_gain_m"] == 29.0
+
+
+def test_detail_404_when_not_owned(monkeypatch: Any) -> None:
+    with pytest.raises(HTTPException) as err:
+        _detail(None, [], monkeypatch)
+    assert err.value.status_code == 404

--- a/frontend/src/components/RunRow.vue
+++ b/frontend/src/components/RunRow.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="flex items-center justify-between py-3 px-4 hover:bg-gray-50 transition">
+  <component
+    :is="activityId ? RouterLink : 'div'"
+    :to="activityId ? `/runs/${activityId}` : undefined"
+    class="flex items-center justify-between py-3 px-4 hover:bg-gray-50 transition"
+    :class="activityId ? 'cursor-pointer' : ''"
+  >
     <div class="flex flex-col">
       <span class="text-sm font-semibold text-gray-900">{{ formatDate(date) }}</span>
       <span v-if="weather" class="text-xs text-gray-400 mt-0.5">{{ weather }}</span>
@@ -8,12 +13,15 @@
       <span class="font-medium">{{ formatDistanceWithUnit(distanceKm, unit) }}</span>
       <span>{{ duration }}</span>
       <span class="hidden sm:inline text-gray-500">{{ formatPace(paceMinPerKm, unit) }}</span>
+      <ChevronRight v-if="activityId" class="w-4 h-4 text-gray-300" />
     </div>
-  </div>
+  </component>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { RouterLink } from 'vue-router'
+import { ChevronRight } from 'lucide-vue-next'
 import { formatDate, formatDistanceWithUnit, formatPace, formatDuration } from '@/utils/format'
 import type { Unit } from '@/types/runs'
 
@@ -25,6 +33,8 @@ const props = defineProps<{
   paceMinPerKm: number | null
   unit: Unit
   weather?: string | null
+  /** When set, the row links to the run detail view (SB-263). */
+  activityId?: string
 }>()
 
 const duration = computed(() => {

--- a/frontend/src/composables/useRunDetail.ts
+++ b/frontend/src/composables/useRunDetail.ts
@@ -1,0 +1,24 @@
+import { ref } from 'vue'
+import { apiCall } from '@/config/api'
+import type { RunDetail } from '@/types/runs'
+
+/** One run's full story — weather, vitals, splits, elevation (SB-263). */
+export function useRunDetail(activityId: string) {
+  const run = ref<RunDetail | null>(null)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const load = async (): Promise<void> => {
+    loading.value = true
+    error.value = null
+    try {
+      run.value = await apiCall<RunDetail>(`/runs/${encodeURIComponent(activityId)}`)
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load run'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { run, loading, error, load }
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -44,6 +44,12 @@ const router = createRouter({
       meta: { requiresAuth: true },
     },
     {
+      path: '/runs/:activityId',
+      name: 'run-detail',
+      component: () => import('@/views/RunDetailView.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
       path: '/settings',
       name: 'settings',
       component: () => import('@/views/SettingsView.vue'),

--- a/frontend/src/types/runs.ts
+++ b/frontend/src/types/runs.ts
@@ -106,3 +106,43 @@ export interface GoalHistoryItem extends GoalProgress {
   period: 'year' | 'month'
   hit: boolean
 }
+
+// ---- Run detail (SB-263) ----
+
+export interface RunSplit {
+  split_number: number
+  split_unit: string | null
+  cumulative_distance_km: number | null
+  cumulative_seconds: number | null
+  pace_min_per_km: number | null
+  heart_rate: number | null
+  elevation_gain_m: number | null
+  elevation_loss_m: number | null
+}
+
+export interface RunWeather {
+  temperature_celsius: number | null
+  weather_type: string | null
+  humidity_percent: number | null
+  wind_speed_kph: number | null
+}
+
+export interface RunVitals {
+  heart_rate_avg: number | null
+  heart_rate_min: number | null
+  heart_rate_max: number | null
+  cadence_avg: number | null
+}
+
+export interface RunDetail {
+  activity_id: string
+  date: string
+  distance_km: number
+  duration_seconds: number
+  avg_pace_min_per_km: number | null
+  weather: RunWeather
+  vitals: RunVitals
+  how_felt: string | null
+  notes: string | null
+  splits: RunSplit[]
+}

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -113,6 +113,7 @@
             :pace-min-per-km="run.avg_pace_min_per_km"
             :unit="unit"
             :weather="run.weather"
+            :activity-id="run.activity_id"
           />
         </div>
       </div>

--- a/frontend/src/views/RunDetailView.vue
+++ b/frontend/src/views/RunDetailView.vue
@@ -1,0 +1,246 @@
+<template>
+  <div class="container-app py-8 max-w-3xl">
+    <RouterLink to="/runs" class="text-sm text-gray-500 hover:text-brand-600">← Runs</RouterLink>
+
+    <div v-if="loading" class="space-y-3 mt-4">
+      <div v-for="i in 3" :key="i" class="bg-white rounded-xl border border-gray-100 h-28 animate-pulse" />
+    </div>
+
+    <div v-else-if="error" class="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-700 mt-4">
+      {{ error }}
+    </div>
+
+    <template v-else-if="run">
+      <div class="bg-white rounded-xl border border-gray-100 shadow-sm p-6 mt-4">
+        <div class="flex items-start justify-between flex-wrap gap-3">
+          <div>
+            <h1 class="text-xl font-bold text-gray-900">{{ formatDate(run.date) }}</h1>
+            <div
+              v-if="weatherText"
+              class="inline-flex items-center gap-1.5 mt-2 px-3 py-1 rounded-full border text-xs"
+              :class="isSteamy ? 'border-amber-200 bg-amber-50 text-amber-800' : 'border-gray-200 text-gray-500'"
+            >
+              <component :is="weatherIcon" class="w-3.5 h-3.5" />
+              <span>{{ weatherText }}</span>
+            </div>
+          </div>
+          <p class="text-3xl font-bold text-gray-900">
+            {{ formatDistance(run.distance_km, unit) }}<span class="text-base font-normal text-gray-400"> {{ distanceLabel(unit) }}</span>
+          </p>
+        </div>
+
+        <p v-if="isSteamy" class="text-xs text-amber-700 mt-3">
+          Hot + humid — expect pace to run slower than the effort feels.
+        </p>
+
+        <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mt-5">
+          <div class="bg-gray-50 rounded-lg px-4 py-3">
+            <p class="text-xs text-gray-500">Time</p>
+            <p class="text-lg font-semibold text-gray-900">{{ formatDuration(run.duration_seconds) }}</p>
+          </div>
+          <div class="bg-gray-50 rounded-lg px-4 py-3">
+            <p class="text-xs text-gray-500">Avg pace</p>
+            <p class="text-lg font-semibold text-gray-900">{{ formatPace(run.avg_pace_min_per_km, unit) }}</p>
+          </div>
+          <div class="bg-gray-50 rounded-lg px-4 py-3">
+            <p class="text-xs text-gray-500">Elev gain</p>
+            <p class="text-lg font-semibold text-gray-900">{{ elevGainText }}</p>
+          </div>
+          <div class="bg-gray-50 rounded-lg px-4 py-3">
+            <p class="text-xs text-gray-500">Avg HR</p>
+            <p class="text-lg font-semibold text-gray-900">
+              {{ run.vitals.heart_rate_avg ? `${Math.round(run.vitals.heart_rate_avg)}` : '—' }}
+              <span v-if="run.vitals.heart_rate_avg" class="text-xs font-normal text-gray-400">bpm</span>
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="run.splits.length > 0" class="bg-white rounded-xl border border-gray-100 shadow-sm p-6 mt-4">
+        <h2 class="font-semibold text-gray-900 mb-1">{{ splitNoun }} splits</h2>
+        <p class="text-xs text-gray-400 mb-3">fastest split highlighted</p>
+        <ApexChart type="bar" height="220" :options="splitOptions" :series="splitSeries" />
+      </div>
+
+      <div v-if="hasElevation" class="bg-white rounded-xl border border-gray-100 shadow-sm p-6 mt-4">
+        <div class="flex items-baseline justify-between">
+          <h2 class="font-semibold text-gray-900">Elevation</h2>
+          <p class="text-xs text-gray-500">↑ {{ elevGainText }} · ↓ {{ elevLossText }}</p>
+        </div>
+        <ApexChart type="area" height="160" :options="elevOptions" :series="elevSeries" />
+      </div>
+
+      <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mt-4">
+        <div class="bg-white rounded-xl border border-gray-100 shadow-sm px-4 py-3">
+          <p class="text-xs text-gray-500">HR max</p>
+          <p class="font-semibold text-gray-900">{{ run.vitals.heart_rate_max ? `${Math.round(run.vitals.heart_rate_max)} bpm` : '—' }}</p>
+        </div>
+        <div class="bg-white rounded-xl border border-gray-100 shadow-sm px-4 py-3">
+          <p class="text-xs text-gray-500">HR min</p>
+          <p class="font-semibold text-gray-900">{{ run.vitals.heart_rate_min ? `${Math.round(run.vitals.heart_rate_min)} bpm` : '—' }}</p>
+        </div>
+        <div class="bg-white rounded-xl border border-gray-100 shadow-sm px-4 py-3">
+          <p class="text-xs text-gray-500">Cadence</p>
+          <p class="font-semibold text-gray-900">{{ run.vitals.cadence_avg ? `${Math.round(run.vitals.cadence_avg)} spm` : '—' }}</p>
+        </div>
+        <div class="bg-white rounded-xl border border-gray-100 shadow-sm px-4 py-3">
+          <p class="text-xs text-gray-500">Wind</p>
+          <p class="font-semibold text-gray-900">{{ windText }}</p>
+        </div>
+      </div>
+
+      <p v-if="run.notes" class="text-sm text-gray-500 mt-4">{{ run.notes }}</p>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import { RouterLink } from 'vue-router'
+import ApexChart from 'vue3-apexcharts'
+import {
+  Cloud, CloudDrizzle, CloudRain, CloudSnow, Snowflake, Sun, SunDim, Wind, Zap, Home, Thermometer,
+} from 'lucide-vue-next'
+import { useRunDetail } from '@/composables/useRunDetail'
+import { useUserPreferences } from '@/composables/useUserPreferences'
+import { formatDate, formatDistance, formatDuration, formatPace, distanceLabel } from '@/utils/format'
+
+const KM_PER_MI = 1.609344
+
+const route = useRoute()
+const { unit } = useUserPreferences()
+const { run, loading, error, load } = useRunDetail(String(route.params.activityId))
+
+// ---- weather (the "hot + humid" story) ----
+const WEATHER_ICONS: Record<string, unknown> = {
+  clear: Sun, sunny: Sun, hot: Thermometer, partlycloudy: SunDim, cloudy: Cloud,
+  rain: CloudRain, rainy: CloudRain, drizzle: CloudDrizzle, extremerain: CloudRain,
+  storm: Zap, snow: CloudSnow, snowy: CloudSnow, blizzard: CloudSnow,
+  extremecold: Snowflake, cold: Snowflake, windy: Wind, extremewind: Wind, indoor: Home,
+}
+const weatherIcon = computed(() => WEATHER_ICONS[run.value?.weather.weather_type ?? ''] ?? Cloud)
+
+const tempText = computed(() => {
+  const c = run.value?.weather.temperature_celsius
+  if (c == null) return null
+  return unit.value === 'mi' ? `${Math.round((c * 9) / 5 + 32)}°F` : `${Math.round(c)}°C`
+})
+
+const weatherText = computed(() => {
+  if (!run.value) return null
+  const w = run.value.weather
+  const parts = [w.weather_type, tempText.value, w.humidity_percent != null ? `${w.humidity_percent}% humidity` : null]
+  const text = parts.filter(Boolean).join(' · ')
+  return text || null
+})
+
+// Heat stress flag: warm AND humid — the conditions that quietly slow a run.
+const isSteamy = computed(() => {
+  const w = run.value?.weather
+  return !!w && w.temperature_celsius != null && w.humidity_percent != null &&
+    w.temperature_celsius >= 24 && w.humidity_percent >= 70
+})
+
+const windText = computed(() => {
+  const kph = run.value?.weather.wind_speed_kph
+  if (kph == null) return '—'
+  return unit.value === 'mi' ? `${Math.round(kph / KM_PER_MI)} mph` : `${kph} kph`
+})
+
+// ---- splits ----
+const splitNoun = computed(() => (run.value?.splits[0]?.split_unit === 'mi' ? 'Mile' : 'Km'))
+
+const paceInUnit = (minPerKm: number) => (unit.value === 'mi' ? minPerKm * KM_PER_MI : minPerKm)
+
+const splitPaces = computed(() =>
+  (run.value?.splits ?? [])
+    .filter((s) => s.pace_min_per_km != null)
+    .map((s) => ({ n: s.split_number, pace: paceInUnit(s.pace_min_per_km as number) })),
+)
+
+const fastestIdx = computed(() => {
+  let idx = -1
+  let best = Infinity
+  splitPaces.value.forEach((s, i) => {
+    if (s.pace < best) { best = s.pace; idx = i }
+  })
+  return idx
+})
+
+const fmtPaceTick = (v: number) => {
+  const m = Math.floor(v)
+  return `${m}:${Math.round((v - m) * 60).toString().padStart(2, '0')}`
+}
+
+const splitSeries = computed(() => [
+  { name: `pace (min/${distanceLabel(unit.value)})`, data: splitPaces.value.map((s) => Number(s.pace.toFixed(2))) },
+])
+
+const splitOptions = computed(() => ({
+  chart: { toolbar: { show: false }, fontFamily: 'inherit' },
+  plotOptions: { bar: { borderRadius: 4, columnWidth: '55%', distributed: true } },
+  colors: splitPaces.value.map((_, i) => (i === fastestIdx.value ? '#f1930f' : '#fbd9a2')),
+  dataLabels: {
+    enabled: true,
+    formatter: fmtPaceTick,
+    style: { colors: ['#78716c'], fontWeight: 500 },
+    offsetY: -18,
+  },
+  legend: { show: false },
+  xaxis: { categories: splitPaces.value.map((s) => String(s.n)), axisBorder: { show: false }, axisTicks: { show: false } },
+  yaxis: { labels: { formatter: fmtPaceTick }, reversed: false },
+  grid: { borderColor: '#f3f4f6' },
+  tooltip: { y: { formatter: (v: number) => `${fmtPaceTick(v)} /${distanceLabel(unit.value)}` } },
+}))
+
+// ---- elevation (cumulative gain across splits) ----
+const elevPoints = computed(() =>
+  (run.value?.splits ?? []).filter((s) => s.elevation_gain_m != null),
+)
+const hasElevation = computed(() => elevPoints.value.length > 1)
+
+const toElev = (m: number) => (unit.value === 'mi' ? m * 3.28084 : m)
+const elevUnit = computed(() => (unit.value === 'mi' ? 'ft' : 'm'))
+
+const lastElev = computed(() => {
+  const pts = elevPoints.value
+  return pts.length ? pts[pts.length - 1] : null
+})
+const elevGainText = computed(() =>
+  lastElev.value?.elevation_gain_m != null
+    ? `${Math.round(toElev(lastElev.value.elevation_gain_m))} ${elevUnit.value}`
+    : '—',
+)
+const elevLossText = computed(() =>
+  lastElev.value?.elevation_loss_m != null
+    ? `${Math.round(toElev(lastElev.value.elevation_loss_m))} ${elevUnit.value}`
+    : '—',
+)
+
+const elevSeries = computed(() => [
+  {
+    name: `climb (${elevUnit.value})`,
+    data: [0, ...elevPoints.value.map((s) => Math.round(toElev(s.elevation_gain_m as number)))],
+  },
+])
+
+const elevOptions = computed(() => ({
+  chart: { toolbar: { show: false }, sparkline: { enabled: false }, fontFamily: 'inherit' },
+  stroke: { curve: 'smooth' as const, width: 2 },
+  colors: ['#f1930f'],
+  fill: { type: 'solid', opacity: 0.16 },
+  dataLabels: { enabled: false },
+  xaxis: {
+    categories: ['0', ...elevPoints.value.map((s) => String(s.split_number))],
+    axisBorder: { show: false },
+    axisTicks: { show: false },
+    title: { text: `${splitNoun.value.toLowerCase()} marker`, style: { fontSize: '11px', color: '#9ca3af' } },
+  },
+  yaxis: { labels: { formatter: (v: number) => `${Math.round(v)}` } },
+  grid: { borderColor: '#f3f4f6' },
+  tooltip: { y: { formatter: (v: number) => `${Math.round(v)} ${elevUnit.value}` } },
+}))
+
+onMounted(load)
+</script>

--- a/frontend/src/views/RunsView.vue
+++ b/frontend/src/views/RunsView.vue
@@ -43,6 +43,7 @@
           :duration-minutes="run.duration_minutes"
           :pace-min-per-km="run.avg_pace_min_per_km"
           :unit="unit"
+          :activity-id="run.activity_id"
         />
       </div>
     </div>

--- a/frontend/src/views/__tests__/RunDetailView.test.ts
+++ b/frontend/src/views/__tests__/RunDetailView.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+const apiCallMock = vi.fn()
+vi.mock('@/config/api', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+}))
+vi.mock('@/composables/useUserPreferences', async () => {
+  const { ref } = await import('vue')
+  return { useUserPreferences: () => ({ unit: ref('mi') }) }
+})
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { activityId: 'act-123' } }),
+  RouterLink: { template: '<a><slot /></a>' },
+}))
+vi.mock('vue3-apexcharts', () => ({
+  default: { name: 'ApexChart', template: '<div class="apex-stub" />' },
+}))
+
+import RunDetailView from '../RunDetailView.vue'
+
+const detail = {
+  activity_id: 'act-123',
+  date: '2026-07-10T06:45:00',
+  distance_km: 5.31,
+  duration_seconds: 3141,
+  avg_pace_min_per_km: 9.86,
+  weather: { temperature_celsius: 27.8, weather_type: 'hot', humidity_percent: 82, wind_speed_kph: 9 },
+  vitals: { heart_rate_avg: 151, heart_rate_min: 128, heart_rate_max: 167, cadence_avg: 169 },
+  how_felt: null,
+  notes: null,
+  splits: [
+    { split_number: 1, split_unit: 'mi', cumulative_distance_km: 1.609, cumulative_seconds: 612, pace_min_per_km: 9.51, heart_rate: 142, elevation_gain_m: 12, elevation_loss_m: 4 },
+    { split_number: 2, split_unit: 'mi', cumulative_distance_km: 3.219, cumulative_seconds: 1254, pace_min_per_km: 9.98, heart_rate: 150, elevation_gain_m: 29, elevation_loss_m: 15 },
+  ],
+}
+
+beforeEach(() => {
+  apiCallMock.mockReset()
+})
+
+describe('RunDetailView (SB-263)', () => {
+  it('renders hero, weather badge and the hot+humid callout', async () => {
+    apiCallMock.mockResolvedValue(detail)
+    const w = mount(RunDetailView)
+    await flushPromises()
+
+    expect(apiCallMock).toHaveBeenCalledWith('/runs/act-123')
+    expect(w.text()).toContain('hot')
+    expect(w.text()).toContain('82% humidity')
+    expect(w.text()).toContain('82°F') // default unit mi -> Fahrenheit
+    expect(w.text()).toContain('Hot + humid') // heat-stress callout (27.8C / 82%)
+    expect(w.text()).toContain('Mile splits')
+    expect(w.text()).toContain('Elevation')
+    expect(w.text()).toContain('167 bpm')
+  })
+
+  it('no heat callout on a cool run', async () => {
+    apiCallMock.mockResolvedValue({
+      ...detail,
+      weather: { ...detail.weather, temperature_celsius: 10, humidity_percent: 40, weather_type: 'clear' },
+    })
+    const w = mount(RunDetailView)
+    await flushPromises()
+    expect(w.text()).not.toContain('Hot + humid')
+  })
+
+  it('hides splits + elevation cards when a run has no splits', async () => {
+    apiCallMock.mockResolvedValue({ ...detail, splits: [] })
+    const w = mount(RunDetailView)
+    await flushPromises()
+    expect(w.text()).not.toContain('splits')
+    expect(w.text()).not.toContain('Elevation')
+  })
+})

--- a/src/shared/supabase_ops/runs_repository.py
+++ b/src/shared/supabase_ops/runs_repository.py
@@ -81,6 +81,19 @@ class RunsRepository:
 
         return data_list[0] if data_list else None
 
+    def get_run_by_activity_id(self, user_id: UUID, activity_id: str) -> dict[str, Any] | None:
+        """A user's run by its source activity id (what the frontend holds)."""
+        result = (
+            self.supabase.table("runs")
+            .select("*")
+            .eq("user_id", str(user_id))
+            .eq("source_activity_id", activity_id)
+            .limit(1)
+            .execute()
+        )
+        data_list = cast(list[dict[str, Any]], result.data)
+        return data_list[0] if data_list else None
+
     def _apply_run_filters(
         self,
         query: Any,


### PR DESCRIPTION
Click any run → its full story. Everything was already synced from SmashRun —
**temperature, conditions, humidity, wind**, per-split pace/HR/**elevation** —
this adds one endpoint + the view.

## What

- **`GET /runs/{activity_id}`** — run + weather + vitals + ordered splits
  (404 for other users' runs). `get_run_by_activity_id` repo lookup.
- **Clickable run rows** (Dashboard + Runs) → `/runs/:activityId`.
- **`RunDetailView`**:
  - Hero: date, distance, **weather badge** (condition icon, °F/°C by unit,
    humidity) + a **heat-stress callout** when ≥24 °C and ≥70 % humidity —
    "Hot + humid — expect pace to run slower than the effort feels."
  - Metric tiles: time · avg pace · elev gain · avg HR.
  - **Mile/km splits** bar chart — fastest split highlighted, m:ss labels,
    pace converted to the user's unit.
  - **Elevation** area chart from cumulative split gain, ↑/↓ totals (ft/mi
    units aware).
  - Vitals: HR max/min, cadence, **wind** (mph/kph).

## Verified

- Browser-verified against a seeded hot-humid run (**82 °F / 82 % humidity**,
  4 mile splits, 141 ft gain) — badge, callout, charts, vitals all render.
- 2 backend tests (shape/sorting/404) — backend suite **216 green**.
- 3 view tests (hot badge + callout, cool-run no-callout, splitless fallback);
  `vue-tsc` clean. The 7 pre-existing frontend failures are being fixed in the
  separate rot-fix session.

Fixes SB-263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)