### PR TITLE
feat: run history UX — month groups, weather, bars, filters (SB-268)

### DIFF
--- a/backend/routes/runs.py
+++ b/backend/routes/runs.py
@@ -76,6 +76,10 @@ async def _list_runs(
             "avg_pace_min_per_km": (
                 float(r["average_pace_min_per_km"]) if r["average_pace_min_per_km"] else None
             ),
+            "weather": r.get("weather_type"),
+            "temperature_celsius": (
+                float(r["temperature_celsius"]) if r.get("temperature_celsius") else None
+            ),
         }
         for r in runs_data
     ]

--- a/frontend/src/components/RunRow.vue
+++ b/frontend/src/components/RunRow.vue
@@ -2,19 +2,26 @@
   <component
     :is="activityId ? RouterLink : 'div'"
     :to="activityId ? `/runs/${activityId}` : undefined"
-    class="flex items-center justify-between py-3 px-4 hover:bg-gray-50 transition"
+    class="relative block py-3 px-4 hover:bg-gray-50 transition"
     :class="activityId ? 'cursor-pointer' : ''"
   >
-    <div class="flex flex-col">
-      <span class="text-sm font-semibold text-gray-900">{{ formatDate(date) }}</span>
-      <span v-if="weather" class="text-xs text-gray-400 mt-0.5">{{ weather }}</span>
+    <div class="flex items-center justify-between">
+      <div class="flex flex-col">
+        <span class="text-sm font-semibold text-gray-900">{{ formatDate(date) }}</span>
+        <span v-if="weather" class="text-xs text-gray-400 mt-0.5">{{ weather }}</span>
+      </div>
+      <div class="flex items-center gap-6 text-sm text-gray-700 tabular-nums">
+        <span class="font-medium">{{ formatDistanceWithUnit(distanceKm, unit) }}</span>
+        <span>{{ duration }}</span>
+        <span class="hidden sm:inline text-gray-500">{{ formatPace(paceMinPerKm, unit) }}</span>
+        <ChevronRight v-if="activityId" class="w-4 h-4 text-gray-300" />
+      </div>
     </div>
-    <div class="flex items-center gap-6 text-sm text-gray-700 tabular-nums">
-      <span class="font-medium">{{ formatDistanceWithUnit(distanceKm, unit) }}</span>
-      <span>{{ duration }}</span>
-      <span class="hidden sm:inline text-gray-500">{{ formatPace(paceMinPerKm, unit) }}</span>
-      <ChevronRight v-if="activityId" class="w-4 h-4 text-gray-300" />
-    </div>
+    <div
+      v-if="barFraction !== undefined"
+      class="absolute bottom-0 left-4 h-0.5 rounded-full bg-brand-200"
+      :style="{ width: `calc((100% - 2rem) * ${Math.min(1, Math.max(0, barFraction))})` }"
+    />
   </component>
 </template>
 
@@ -35,6 +42,8 @@ const props = defineProps<{
   weather?: string | null
   /** When set, the row links to the run detail view (SB-263). */
   activityId?: string
+  /** 0..1 — draws a subtle distance bar along the row's bottom (SB-268). */
+  barFraction?: number
 }>()
 
 const duration = computed(() => {

--- a/frontend/src/composables/useRuns.ts
+++ b/frontend/src/composables/useRuns.ts
@@ -1,6 +1,6 @@
 import { ref, computed } from 'vue'
 import { apiCall } from '@/config/api'
-import type { PaginatedRun, RunsResponse } from '@/types/runs'
+import type { PaginatedRun, RunFilters, RunsResponse } from '@/types/runs'
 
 export function useRuns(pageSize = 25) {
   const runs = ref<PaginatedRun[]>([])
@@ -8,6 +8,7 @@ export function useRuns(pageSize = 25) {
   const offset = ref(0)
   const loading = ref(false)
   const error = ref<string | null>(null)
+  const filters = ref<RunFilters>({})
 
   const page = computed(() => Math.floor(offset.value / pageSize) + 1)
   const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)))
@@ -18,9 +19,14 @@ export function useRuns(pageSize = 25) {
     loading.value = true
     error.value = null
     try {
-      const res = await apiCall<RunsResponse>(
-        `/runs?offset=${offset.value}&limit=${pageSize}`,
-      )
+      const params = new URLSearchParams({
+        offset: String(offset.value),
+        limit: String(pageSize),
+      })
+      for (const [k, v] of Object.entries(filters.value)) {
+        if (v !== undefined && v !== null) params.set(k, String(v))
+      }
+      const res = await apiCall<RunsResponse>(`/runs?${params.toString()}`)
       runs.value = res.runs
       total.value = res.total
     } catch (e) {
@@ -28,6 +34,13 @@ export function useRuns(pageSize = 25) {
     } finally {
       loading.value = false
     }
+  }
+
+  /** Replace the active filters and reload from page 1 (SB-268). */
+  const setFilters = async (next: RunFilters): Promise<void> => {
+    filters.value = next
+    offset.value = 0
+    await load()
   }
 
   const next = async (): Promise<void> => {
@@ -48,11 +61,13 @@ export function useRuns(pageSize = 25) {
     offset,
     loading,
     error,
+    filters,
     page,
     totalPages,
     hasPrev,
     hasNext,
     load,
+    setFilters,
     next,
     prev,
   }

--- a/frontend/src/types/runs.ts
+++ b/frontend/src/types/runs.ts
@@ -52,6 +52,16 @@ export interface PaginatedRun {
   distance_km: number
   duration_minutes: number
   avg_pace_min_per_km: number | null
+  weather: string | null
+  temperature_celsius: number | null
+}
+
+/** GET /runs filter params (SB-268 history filters). */
+export interface RunFilters {
+  date_from?: string
+  date_to?: string
+  distance_min?: number
+  distance_max?: number
 }
 
 export interface RecentRunsResponse {

--- a/frontend/src/views/RunsView.vue
+++ b/frontend/src/views/RunsView.vue
@@ -1,13 +1,35 @@
 <template>
   <div class="container-app py-8">
-    <div class="flex items-center justify-between mb-6">
+    <div class="flex items-center justify-between mb-4">
       <div>
         <h1 class="text-2xl font-bold text-gray-900">Run history</h1>
         <p class="text-sm text-gray-500 mt-1">
-          {{ total > 0 ? `${total} total runs` : 'No runs yet' }}
+          {{ total > 0 ? `${total} runs` : 'No runs yet' }}
         </p>
       </div>
       <SyncButton mode="full" @synced="reload" />
+    </div>
+
+    <div class="flex flex-wrap items-center gap-2 mb-5">
+      <button
+        v-for="p in periodChips"
+        :key="p.key"
+        type="button"
+        @click="selectPeriod(p.key)"
+        :class="chipClass(period === p.key)"
+      >
+        {{ p.label }}
+      </button>
+      <span class="w-px h-5 bg-gray-200 mx-1 hidden sm:block" />
+      <button
+        v-for="d in distanceChips"
+        :key="d.key"
+        type="button"
+        @click="selectDistance(d.key)"
+        :class="chipClass(distance === d.key)"
+      >
+        {{ d.label }}
+      </button>
     </div>
 
     <div v-if="loading && runs.length === 0" class="space-y-2">
@@ -22,46 +44,42 @@
       v-else-if="runs.length === 0"
       class="bg-white rounded-xl border border-gray-100 shadow-sm p-10 text-center text-gray-500"
     >
-      <p>No runs to show yet. Click <span class="font-semibold">Sync now</span> to import.</p>
+      <p v-if="isFiltered">No runs match these filters.</p>
+      <p v-else>No runs to show yet. Click <span class="font-semibold">Sync now</span> to import.</p>
     </div>
 
-    <div v-else class="bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden">
-      <div class="hidden sm:flex items-center justify-between px-4 py-2 text-xs font-semibold text-gray-400 uppercase tracking-wide border-b border-gray-100">
-        <span>Date</span>
-        <div class="flex gap-6">
-          <span>Distance</span>
-          <span>Duration</span>
-          <span>Pace</span>
+    <template v-else>
+      <div v-for="group in monthGroups" :key="group.key" class="mb-5">
+        <div class="flex items-baseline justify-between px-1 mb-2">
+          <h2 class="text-sm font-semibold text-gray-900">{{ group.label }}</h2>
+          <p class="text-xs text-gray-500 tabular-nums">
+            {{ group.count }} run{{ group.count === 1 ? '' : 's' }} · {{ formatDistanceWithUnit(group.totalKm, unit) }} · avg
+            {{ formatPace(group.avgPace, unit) }}
+          </p>
+        </div>
+        <div class="bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden divide-y divide-gray-100">
+          <RunRow
+            v-for="run in group.runs"
+            :key="run.activity_id"
+            :date="run.date"
+            :distance-km="run.distance_km"
+            :duration-minutes="run.duration_minutes"
+            :pace-min-per-km="run.avg_pace_min_per_km"
+            :unit="unit"
+            :weather="weatherText(run)"
+            :activity-id="run.activity_id"
+            :bar-fraction="run.distance_km / maxKm"
+          />
         </div>
       </div>
-      <div class="divide-y divide-gray-100">
-        <RunRow
-          v-for="run in runs"
-          :key="run.activity_id"
-          :date="run.date"
-          :distance-km="run.distance_km"
-          :duration-minutes="run.duration_minutes"
-          :pace-min-per-km="run.avg_pace_min_per_km"
-          :unit="unit"
-          :activity-id="run.activity_id"
-        />
-      </div>
-    </div>
+    </template>
 
     <div v-if="runs.length > 0" class="flex items-center justify-between mt-4 text-sm">
-      <button
-        @click="prev"
-        :disabled="!hasPrev || loading"
-        class="btn-secondary disabled:opacity-50"
-      >
+      <button @click="prev" :disabled="!hasPrev || loading" class="btn-secondary disabled:opacity-50">
         ← Prev
       </button>
       <span class="text-gray-500">Page {{ page }} of {{ totalPages }}</span>
-      <button
-        @click="next"
-        :disabled="!hasNext || loading"
-        class="btn-secondary disabled:opacity-50"
-      >
+      <button @click="next" :disabled="!hasNext || loading" class="btn-secondary disabled:opacity-50">
         Next →
       </button>
     </div>
@@ -69,15 +87,138 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import RunRow from '@/components/RunRow.vue'
 import SyncButton from '@/components/SyncButton.vue'
 import { useRuns } from '@/composables/useRuns'
 import { useUserPreferences } from '@/composables/useUserPreferences'
+import { formatDistanceWithUnit, formatPace } from '@/utils/format'
+import type { PaginatedRun, RunFilters } from '@/types/runs'
 
-const { runs, total, loading, error, page, totalPages, hasPrev, hasNext, load, next, prev } =
+const KM_PER_MI = 1.609344
+
+const { runs, total, loading, error, page, totalPages, hasPrev, hasNext, load, setFilters, next, prev } =
   useRuns(25)
 const { unit } = useUserPreferences()
+
+// ---- filter chips (backed by GET /runs query params) ----
+type PeriodKey = 'all' | 'month' | '30d'
+type DistanceKey = 'all' | 'short' | 'mid' | 'long'
+
+const period = ref<PeriodKey>('all')
+const distance = ref<DistanceKey>('all')
+
+const periodChips: { key: PeriodKey; label: string }[] = [
+  { key: 'all', label: 'All time' },
+  { key: 'month', label: 'This month' },
+  { key: '30d', label: 'Last 30 days' },
+]
+
+const distanceChips = computed<{ key: DistanceKey; label: string }[]>(() => {
+  const u = unit.value
+  return [
+    { key: 'all', label: 'Any distance' },
+    { key: 'short', label: `< 3 ${u}` },
+    { key: 'mid', label: `3–5 ${u}` },
+    { key: 'long', label: `5+ ${u}` },
+  ]
+})
+
+const isFiltered = computed(() => period.value !== 'all' || distance.value !== 'all')
+
+const chipClass = (active: boolean) =>
+  [
+    'px-3 py-1.5 rounded-full text-xs font-medium border transition',
+    active
+      ? 'bg-brand-600 border-brand-600 text-white'
+      : 'bg-white border-gray-200 text-gray-600 hover:border-gray-300',
+  ].join(' ')
+
+const iso = (d: Date) => d.toISOString().slice(0, 10)
+
+const buildFilters = (): RunFilters => {
+  const f: RunFilters = {}
+  const today = new Date()
+  if (period.value === 'month') {
+    f.date_from = iso(new Date(today.getFullYear(), today.getMonth(), 1))
+  } else if (period.value === '30d') {
+    f.date_from = iso(new Date(today.getTime() - 30 * 86_400_000))
+  }
+  const toKm = (v: number) => (unit.value === 'mi' ? v * KM_PER_MI : v)
+  if (distance.value === 'short') f.distance_max = toKm(3)
+  if (distance.value === 'mid') {
+    f.distance_min = toKm(3)
+    f.distance_max = toKm(5)
+  }
+  if (distance.value === 'long') f.distance_min = toKm(5)
+  return f
+}
+
+const applyFilters = () => setFilters(buildFilters())
+const selectPeriod = (key: PeriodKey) => {
+  period.value = key
+  void applyFilters()
+}
+const selectDistance = (key: DistanceKey) => {
+  distance.value = key
+  void applyFilters()
+}
+
+// ---- month grouping with per-group summary ----
+interface MonthGroup {
+  key: string
+  label: string
+  runs: PaginatedRun[]
+  count: number
+  totalKm: number
+  avgPace: number | null
+}
+
+const monthGroups = computed<MonthGroup[]>(() => {
+  const groups: MonthGroup[] = []
+  let current: MonthGroup | null = null
+  for (const run of runs.value) {
+    const d = new Date(run.date)
+    const key = `${d.getFullYear()}-${d.getMonth()}`
+    if (!current || current.key !== key) {
+      current = {
+        key,
+        label: d.toLocaleDateString(undefined, { month: 'long', year: 'numeric' }),
+        runs: [],
+        count: 0,
+        totalKm: 0,
+        avgPace: null,
+      }
+      groups.push(current)
+    }
+    current.runs.push(run)
+    current.count += 1
+    current.totalKm += run.distance_km
+  }
+  for (const g of groups) {
+    const paced = g.runs.filter((r) => r.avg_pace_min_per_km != null)
+    // Distance-weighted average pace: total time over total distance.
+    const km = paced.reduce((s, r) => s + r.distance_km, 0)
+    const mins = paced.reduce((s, r) => s + (r.avg_pace_min_per_km as number) * r.distance_km, 0)
+    g.avgPace = km > 0 ? mins / km : null
+  }
+  return groups
+})
+
+const maxKm = computed(() => Math.max(...runs.value.map((r) => r.distance_km), 0.001))
+
+const weatherText = (run: PaginatedRun): string | null => {
+  const parts: string[] = []
+  if (run.weather) parts.push(run.weather)
+  if (run.temperature_celsius != null) {
+    parts.push(
+      unit.value === 'mi'
+        ? `${Math.round((run.temperature_celsius * 9) / 5 + 32)}°F`
+        : `${Math.round(run.temperature_celsius)}°C`,
+    )
+  }
+  return parts.length ? parts.join(' · ') : null
+}
 
 const reload = async () => {
   await load()


### PR DESCRIPTION
The /runs page was a flat 4,700-row spreadsheet. Now it reads like a training
log.

## What

- **Month sections** with summaries — "June 2026 · 24 runs · 95.10 mi · avg
  9:32/mi" (distance-weighted).
- **Weather on every row** — `GET /runs` rows now carry `weather_type` +
  `temperature_celsius` (only `/recent` had them before); rendered as
  "sunny · 74°F" under the date, °F/°C by unit.
- **Distance bars** — subtle per-row bar scaled to the page max; long runs pop
  while scanning. (`RunRow` gains an optional `barFraction` prop; dashboard
  unchanged.)
- **Filter chips** — wired to the existing `GET /runs` params: All time / This
  month / Last 30 days · distance presets (<3, 3–5, 5+ in the user's unit).
  Filters reset to page 1; filtered-empty state included.
- Rows keep the SB-263 detail links.

## Verified (browser, against the restored prod copy — 4,753 real runs)

- Month groups + summaries render with real weather ("sunny · 74°F", 49–85°F
  spread visible).
- **5+ mi** chip → server-side filter, 4,753 → 1,397 runs, summaries recalc.
- `vue-tsc` clean; RunRow tests green (7 pre-existing failures tracked in the
  rot-fix session).

Fixes SB-268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)