### PR TITLE
feat: run explorer — collections, On this day, sort + filters (SB-269 PR1)

### DIFF
--- a/backend/routes/runs.py
+++ b/backend/routes/runs.py
@@ -46,6 +46,15 @@ async def get_recent_runs(
     return await _recent(user_id, limit)
 
 
+# Whitelist for the sort param -> actual column (SB-269).
+_SORT_COLUMNS = {
+    "date": "start_date_time_local",
+    "distance": "distance_km",
+    "pace": "average_pace_min_per_km",
+    "temperature": "temperature_celsius",
+}
+
+
 @cached(ttl=60, key_prefix="runs:list")
 async def _list_runs(
     user_id: UUID,
@@ -55,6 +64,14 @@ async def _list_runs(
     date_to: date | None = None,
     distance_min: float | None = None,
     distance_max: float | None = None,
+    weather_type: str | None = None,
+    temp_min: float | None = None,
+    temp_max: float | None = None,
+    pace_min: float | None = None,
+    pace_max: float | None = None,
+    on_this_day: str | None = None,
+    sort: str = "date",
+    order: str = "desc",
 ) -> dict[str, Any]:
     supabase = get_supabase_client()
     runs_repo = RunsRepository(supabase)
@@ -63,8 +80,18 @@ async def _list_runs(
         "date_to": date_to,
         "distance_min": distance_min,
         "distance_max": distance_max,
+        "weather_type": weather_type,
+        "temp_min": temp_min,
+        "temp_max": temp_max,
+        "pace_min": pace_min,
+        "pace_max": pace_max,
+        "on_this_day": on_this_day,
     }
-    runs_data = runs_repo.get_runs_by_user(user_id, limit=limit, offset=offset, **filters)
+    sort_by = _SORT_COLUMNS.get(sort, "start_date_time_local")
+    sort_desc = order != "asc"
+    runs_data = runs_repo.get_runs_by_user(
+        user_id, limit=limit, offset=offset, sort_by=sort_by, sort_desc=sort_desc, **filters
+    )
     total = runs_repo.count_runs_by_user(user_id, **filters)
 
     runs = [
@@ -102,8 +129,34 @@ async def list_runs(
     date_to: date | None = Query(None, description="Runs on/before this date (inclusive)"),
     distance_min: float | None = Query(None, ge=0, description="Min distance in km"),
     distance_max: float | None = Query(None, ge=0, description="Max distance in km"),
+    weather_type: str | None = Query(None, description="Exact weather condition"),
+    temp_min: float | None = Query(None, description="Min temperature (C)"),
+    temp_max: float | None = Query(None, description="Max temperature (C)"),
+    pace_min: float | None = Query(None, ge=0, description="Min pace (min/km) — slower bound"),
+    pace_max: float | None = Query(None, ge=0, description="Max pace (min/km) — faster bound"),
+    on_this_day: str | None = Query(
+        None, pattern=r"^\d{2}-\d{2}$", description="MM-DD across all years (SB-269)"
+    ),
+    sort: str = Query("date", pattern="^(date|distance|pace|temperature)$"),
+    order: str = Query("desc", pattern="^(asc|desc)$"),
 ) -> dict[str, Any]:
-    return await _list_runs(user_id, offset, limit, date_from, date_to, distance_min, distance_max)
+    return await _list_runs(
+        user_id,
+        offset,
+        limit,
+        date_from,
+        date_to,
+        distance_min,
+        distance_max,
+        weather_type,
+        temp_min,
+        temp_max,
+        pace_min,
+        pace_max,
+        on_this_day,
+        sort,
+        order,
+    )
 
 
 # NOTE: registered after /recent and "" so the static paths keep priority.

--- a/backend/tests/test_run_filters.py
+++ b/backend/tests/test_run_filters.py
@@ -1,0 +1,68 @@
+"""Tests for run explorer filters (SB-269): weather/temp/pace, on-this-day, sort."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from src.shared.supabase_ops.runs_repository import RunsRepository
+
+
+class _CaptureQuery:
+    """Records filter calls so we can assert what reached PostgREST."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, Any]] = []
+
+    def _rec(self, op: str, col: str, val: Any) -> _CaptureQuery:
+        self.calls.append((op, col, val))
+        return self
+
+    def gte(self, col: str, val: Any) -> _CaptureQuery:
+        return self._rec("gte", col, val)
+
+    def lte(self, col: str, val: Any) -> _CaptureQuery:
+        return self._rec("lte", col, val)
+
+    def eq(self, col: str, val: Any) -> _CaptureQuery:
+        return self._rec("eq", col, val)
+
+    def in_(self, col: str, val: Any) -> _CaptureQuery:
+        return self._rec("in", col, val)
+
+
+def _apply(**kwargs: Any) -> _CaptureQuery:
+    repo = RunsRepository(supabase=None)  # type: ignore[arg-type]  # query object injected
+    q = _CaptureQuery()
+    repo._apply_run_filters(q, None, None, None, None, **kwargs)
+    return q
+
+
+def test_weather_temp_pace_filters() -> None:
+    q = _apply(weather_type="rainy", temp_min=20, temp_max=30, pace_min=5, pace_max=6)
+    assert ("eq", "weather_type", "rainy") in q.calls
+    assert ("gte", "temperature_celsius", 20) in q.calls
+    assert ("lte", "temperature_celsius", 30) in q.calls
+    assert ("gte", "average_pace_min_per_km", 5) in q.calls
+    assert ("lte", "average_pace_min_per_km", 6) in q.calls
+
+
+def test_on_this_day_builds_exact_date_list() -> None:
+    q = _apply(on_this_day="07-12")
+    op, col, dates = q.calls[0]
+    assert (op, col) == ("in", "start_date")
+    assert "2014-07-12" in dates
+    assert f"{date.today().year}-07-12" in dates
+    # Every entry is the same month-day.
+    assert all(d.endswith("-07-12") for d in dates)
+
+
+def test_on_this_day_feb29_skips_non_leap_years() -> None:
+    q = _apply(on_this_day="02-29")
+    _, _, dates = q.calls[0]
+    assert "2024-02-29" in dates  # leap year
+    assert not any(d.startswith("2023") for d in dates)  # non-leap skipped
+
+
+def test_no_extra_filters_no_calls() -> None:
+    assert _apply().calls == []

--- a/frontend/src/types/runs.ts
+++ b/frontend/src/types/runs.ts
@@ -56,12 +56,20 @@ export interface PaginatedRun {
   temperature_celsius: number | null
 }
 
-/** GET /runs filter params (SB-268 history filters). */
+/** GET /runs filter params (SB-268 history filters; SB-269 explorer). */
 export interface RunFilters {
   date_from?: string
   date_to?: string
   distance_min?: number
   distance_max?: number
+  weather_type?: string
+  temp_min?: number
+  temp_max?: number
+  pace_min?: number
+  pace_max?: number
+  on_this_day?: string
+  sort?: 'date' | 'distance' | 'pace' | 'temperature'
+  order?: 'asc' | 'desc'
 }
 
 export interface RecentRunsResponse {

--- a/frontend/src/views/RunsView.vue
+++ b/frontend/src/views/RunsView.vue
@@ -10,6 +10,18 @@
       <SyncButton mode="full" @synced="reload" />
     </div>
 
+    <div class="flex flex-wrap items-center gap-2 mb-3">
+      <button
+        v-for="c in collections"
+        :key="c.key"
+        type="button"
+        @click="selectCollection(c.key)"
+        :class="chipClass(collection === c.key)"
+      >
+        {{ c.label }}
+      </button>
+    </div>
+
     <div class="flex flex-wrap items-center gap-2 mb-5">
       <button
         v-for="p in periodChips"
@@ -124,7 +136,43 @@ const distanceChips = computed<{ key: DistanceKey; label: string }[]>(() => {
   ]
 })
 
-const isFiltered = computed(() => period.value !== 'all' || distance.value !== 'all')
+// ---- collections: curated filter+sort presets (SB-269) ----
+type CollectionKey = 'today' | 'hottest' | 'coldest' | 'rainy' | 'fastest' | 'longest'
+
+const collection = ref<CollectionKey | null>(null)
+
+const todayMmDd = () => {
+  const d = new Date()
+  return `${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+const COLLECTION_PRESETS: Record<CollectionKey, RunFilters> = {
+  today: { on_this_day: todayMmDd(), sort: 'date', order: 'desc' },
+  hottest: { sort: 'temperature', order: 'desc' },
+  coldest: { sort: 'temperature', order: 'asc' },
+  rainy: { weather_type: 'rainy' },
+  // Ignore sub-mile stub runs when hunting PRs.
+  fastest: { sort: 'pace', order: 'asc', distance_min: 1.61 },
+  longest: { sort: 'distance', order: 'desc' },
+}
+
+const collections: { key: CollectionKey; label: string }[] = [
+  { key: 'today', label: '📅 On this day' },
+  { key: 'fastest', label: '⚡ Fastest' },
+  { key: 'longest', label: '🏔 Longest' },
+  { key: 'hottest', label: '🔥 Hottest' },
+  { key: 'coldest', label: '❄️ Coldest' },
+  { key: 'rainy', label: '🌧 Rainy' },
+]
+
+const selectCollection = (key: CollectionKey) => {
+  collection.value = collection.value === key ? null : key
+  void applyFilters()
+}
+
+const isFiltered = computed(
+  () => period.value !== 'all' || distance.value !== 'all' || collection.value !== null,
+)
 
 const chipClass = (active: boolean) =>
   [
@@ -151,6 +199,7 @@ const buildFilters = (): RunFilters => {
     f.distance_max = toKm(5)
   }
   if (distance.value === 'long') f.distance_min = toKm(5)
+  if (collection.value) Object.assign(f, COLLECTION_PRESETS[collection.value])
   return f
 }
 

--- a/src/shared/supabase_ops/runs_repository.py
+++ b/src/shared/supabase_ops/runs_repository.py
@@ -101,8 +101,15 @@ class RunsRepository:
         date_to: date | None,
         distance_min: float | None,
         distance_max: float | None,
+        weather_type: str | None = None,
+        temp_min: float | None = None,
+        temp_max: float | None = None,
+        pace_min: float | None = None,
+        pace_max: float | None = None,
+        on_this_day: str | None = None,
     ) -> Any:
-        """Apply optional date/distance filters to a runs query (SB-184)."""
+        """Apply optional filters to a runs query (SB-184 date/distance;
+        SB-269 weather/temp/pace + on-this-day)."""
         if date_from is not None:
             query = query.gte("start_date", date_from.isoformat())
         if date_to is not None:
@@ -111,6 +118,27 @@ class RunsRepository:
             query = query.gte("distance_km", distance_min)
         if distance_max is not None:
             query = query.lte("distance_km", distance_max)
+        if weather_type is not None:
+            query = query.eq("weather_type", weather_type)
+        if temp_min is not None:
+            query = query.gte("temperature_celsius", temp_min)
+        if temp_max is not None:
+            query = query.lte("temperature_celsius", temp_max)
+        if pace_min is not None:
+            query = query.gte("average_pace_min_per_km", pace_min)
+        if pace_max is not None:
+            query = query.lte("average_pace_min_per_km", pace_max)
+        if on_this_day is not None:
+            # "MM-DD" across every plausible streak year -> exact date list, so
+            # count + pagination keep working (no post-filtering).
+            month, day = on_this_day.split("-")
+            dates = []
+            for year in range(2000, date.today().year + 1):
+                try:
+                    dates.append(date(year, int(month), int(day)).isoformat())
+                except ValueError:  # Feb 29 in non-leap years
+                    continue
+            query = query.in_("start_date", dates)
         return query
 
     def get_runs_by_user(
@@ -123,6 +151,9 @@ class RunsRepository:
         date_to: date | None = None,
         distance_min: float | None = None,
         distance_max: float | None = None,
+        sort_by: str = "start_date_time_local",
+        sort_desc: bool = True,
+        **extra_filters: Any,
     ) -> list[dict[str, Any]]:
         """
         Get runs for a specific user with pagination + optional filters.
@@ -140,9 +171,13 @@ class RunsRepository:
             List of run records
         """
         query = self.supabase.table("runs").select("*").eq("user_id", str(user_id))
-        query = self._apply_run_filters(query, date_from, date_to, distance_min, distance_max)
+        query = self._apply_run_filters(
+            query, date_from, date_to, distance_min, distance_max, **extra_filters
+        )
+        # Sortable columns are whitelisted at the route; date is the tiebreaker.
         result = (
-            query.order("start_date_time_local", desc=True)
+            query.order(sort_by, desc=sort_desc, nullsfirst=False)
+            .order("start_date_time_local", desc=True)
             .range(offset, offset + limit - 1)
             .execute()
         )
@@ -157,10 +192,13 @@ class RunsRepository:
         date_to: date | None = None,
         distance_min: float | None = None,
         distance_max: float | None = None,
+        **extra_filters: Any,
     ) -> int:
         """Count runs for a user, honoring the same filters as get_runs_by_user."""
         query = self.supabase.table("runs").select("id", count="exact").eq("user_id", str(user_id))
-        query = self._apply_run_filters(query, date_from, date_to, distance_min, distance_max)
+        query = self._apply_run_filters(
+            query, date_from, date_to, distance_min, distance_max, **extra_filters
+        )
         result = query.execute()
         return cast(int, result.count or 0)
 


### PR DESCRIPTION
First slice of **SB-269** (run explorer). The star: **📅 On this day**.

## Verified live (restored prod copy, 4,753 runs)

Clicking **On this day** on Jul 12 returns **one run per year, 2014 → 2025**,
each in its own year card with weather + pace — a decade of the streak on one
screen (8:40/mi in 2021 → 9:38 in 2025, visible at a glance).

## What

**Backend (`GET /runs`):**
- `weather_type`, `temp_min/max`, `pace_min/max` filters
- `sort=date|distance|pace|temperature` + `order` (whitelisted columns, date
  tiebreaker, nulls last)
- `on_this_day=MM-DD` — expands to an exact date list across all years, so
  count/pagination stay correct; Feb 29 skips non-leap years

**Frontend (Run history):**
- **Collections row**: 📅 On this day · ⚡ Fastest · 🏔 Longest · 🔥 Hottest ·
  ❄️ Coldest · 🌧 Rainy — one-click presets that **compose** with the existing
  period/distance chips (Rainy + 5+ mi works). Click again to clear.
- Fastest ignores sub-mile stubs.

## Tests

4 new backend filter tests (wiring, on-this-day list, Feb 29, no-op) — 220
green. `vue-tsc` clean; pre-existing 7 frontend failures tracked separately.

Part of SB-269 — PR2 adds the natural-language search box + the
conditions-impact readout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)