### PR TITLE
feat: natural-language run search + conditions impact (SB-269 PR2)

### DIFF
--- a/backend/routes/runs.py
+++ b/backend/routes/runs.py
@@ -159,6 +159,46 @@ async def list_runs(
     )
 
 
+@cached(ttl=60, key_prefix="runs:summary")
+async def _summary(user_id: UUID, **filters: Any) -> dict[str, Any]:
+    repo = RunsRepository(get_supabase_client())
+    summary = repo.summarize_runs(user_id, **{k: v for k, v in filters.items() if v is not None})
+    overall = repo.summarize_runs(user_id)
+    summary["overall_avg_pace_min_per_km"] = overall["avg_pace_min_per_km"]
+    return summary
+
+
+@router.get("/summary")
+async def runs_summary(
+    user_id: UUID = Depends(authenticate_request),
+    date_from: date | None = Query(None),
+    date_to: date | None = Query(None),
+    distance_min: float | None = Query(None, ge=0),
+    distance_max: float | None = Query(None, ge=0),
+    weather_type: str | None = Query(None),
+    temp_min: float | None = Query(None),
+    temp_max: float | None = Query(None),
+    pace_min: float | None = Query(None, ge=0),
+    pace_max: float | None = Query(None, ge=0),
+    on_this_day: str | None = Query(None, pattern=r"^\d{2}-\d{2}$"),
+) -> dict[str, Any]:
+    """Aggregate of the filtered set vs overall — the conditions-impact readout
+    ("runs above 75% humidity: 22s/mi slower"). SB-269."""
+    return await _summary(
+        user_id,
+        date_from=date_from,
+        date_to=date_to,
+        distance_min=distance_min,
+        distance_max=distance_max,
+        weather_type=weather_type,
+        temp_min=temp_min,
+        temp_max=temp_max,
+        pace_min=pace_min,
+        pace_max=pace_max,
+        on_this_day=on_this_day,
+    )
+
+
 # NOTE: registered after /recent and "" so the static paths keep priority.
 @router.get("/{activity_id}")
 async def get_run_detail(

--- a/frontend/src/utils/__tests__/runQuery.test.ts
+++ b/frontend/src/utils/__tests__/runQuery.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { parseRunQuery } from '../runQuery'
+
+// Fixed "today" so season/year math is deterministic: July 12, 2026.
+const TODAY = new Date(Date.UTC(2026, 6, 12))
+
+const parse = (q: string, unit: 'mi' | 'km' = 'mi') => parseRunQuery(q, unit, TODAY)
+
+describe('parseRunQuery (SB-269 natural-language search)', () => {
+  it('the flagship: "rainy 5 milers last summer"', () => {
+    const { filters, chips, ignored } = parse('rainy 5 milers last summer')
+    expect(filters.weather_type).toBe('rainy')
+    // ~5 miles -> 8.05km ± 0.5
+    expect(filters.distance_min).toBeCloseTo(7.55, 1)
+    expect(filters.distance_max).toBeCloseTo(8.55, 1)
+    // last summer (said in July 2026, summer already started) -> summer 2025
+    expect(filters.date_from).toBe('2025-06-01')
+    expect(filters.date_to).toBe('2025-08-31')
+    expect(chips).toContain('rainy')
+    expect(ignored).toEqual([])
+  })
+
+  it('pace: "hot runs under 9:30" converts min/mi to min/km', () => {
+    const { filters, chips } = parse('hot runs under 9:30')
+    expect(filters.temp_min).toBe(24)
+    expect(filters.pace_max).toBeCloseTo(9.5 / 1.609344, 3)
+    expect(chips).toContain('pace under 9:30/mi')
+  })
+
+  it('pace in km mode stays min/km', () => {
+    const { filters } = parse('under 5:30', 'km')
+    expect(filters.pace_max).toBeCloseTo(5.5, 3)
+  })
+
+  it('"faster than 9:00" and "slower than 10:00"', () => {
+    expect(parse('faster than 9:00').filters.pace_max).toBeCloseTo(9 / 1.609344, 3)
+    expect(parse('slower than 10:00').filters.pace_min).toBeCloseTo(10 / 1.609344, 3)
+  })
+
+  it('distances: "10k" and "3 miles"', () => {
+    const k = parse('10k').filters
+    expect(k.distance_min).toBeCloseTo(9.5, 1)
+    expect(k.distance_max).toBeCloseTo(10.5, 1)
+    const mi = parse('3 miles').filters
+    expect(mi.distance_min).toBeCloseTo(3 * 1.609344 - 0.5, 1)
+  })
+
+  it('long/short shorthands are unit-aware', () => {
+    expect(parse('long runs').filters.distance_min).toBeCloseTo(5 * 1.609344, 2)
+    expect(parse('short runs', 'km').filters.distance_max).toBe(3)
+  })
+
+  it('month names: past month uses this year, future month rolls back', () => {
+    const may = parse('may').filters // May 2026 already happened by Jul 12
+    expect(may.date_from).toBe('2026-05-01')
+    const dec = parse('december').filters // December 2026 hasn't -> 2025
+    expect(dec.date_from).toBe('2025-12-01')
+    expect(dec.date_to).toBe('2025-12-31')
+  })
+
+  it('month with explicit year', () => {
+    const { filters } = parse('january 2023')
+    expect(filters.date_from).toBe('2023-01-01')
+    expect(filters.date_to).toBe('2023-01-31')
+  })
+
+  it('bare year', () => {
+    const { filters } = parse('2019')
+    expect(filters.date_from).toBe('2019-01-01')
+    expect(filters.date_to).toBe('2019-12-31')
+  })
+
+  it('winter spans the year boundary', () => {
+    const { filters } = parse('last winter')
+    expect(filters.date_from).toBe('2025-12-01')
+    expect(filters.date_to).toBe('2026-02-28')
+  })
+
+  it('sort words: "fastest long runs"', () => {
+    const { filters } = parse('fastest long runs')
+    expect(filters.sort).toBe('pace')
+    expect(filters.order).toBe('asc')
+    expect(filters.distance_min).toBeCloseTo(8.05, 1)
+  })
+
+  it('unknown tokens are surfaced, stopwords are not', () => {
+    const { ignored } = parse('show me sparkly runs')
+    expect(ignored).toEqual(['sparkly'])
+  })
+
+  it('empty query parses to nothing', () => {
+    const { filters, chips, ignored } = parse('')
+    expect(filters).toEqual({})
+    expect(chips).toEqual([])
+    expect(ignored).toEqual([])
+  })
+})

--- a/frontend/src/utils/runQuery.ts
+++ b/frontend/src/utils/runQuery.ts
@@ -1,0 +1,251 @@
+import type { RunFilters, Unit } from '@/types/runs'
+
+/** Result of parsing a natural-language run query (SB-269).
+ *  `chips` are human labels for what was understood; `ignored` is what wasn't. */
+export interface ParsedRunQuery {
+  filters: RunFilters
+  chips: string[]
+  ignored: string[]
+}
+
+const KM_PER_MI = 1.609344
+
+const WEATHER_WORDS: Record<string, string> = {
+  rain: 'rainy',
+  rainy: 'rainy',
+  wet: 'rainy',
+  sun: 'sunny',
+  sunny: 'sunny',
+  clear: 'sunny',
+  cloud: 'cloudy',
+  cloudy: 'cloudy',
+  overcast: 'cloudy',
+  snow: 'snowy',
+  snowy: 'snowy',
+  wind: 'windy',
+  windy: 'windy',
+}
+
+// Temperature qualifiers (C) — 'hot' matches the detail view's heat threshold.
+const TEMP_WORDS: Record<string, Partial<RunFilters>> = {
+  hot: { temp_min: 24 },
+  warm: { temp_min: 20 },
+  cool: { temp_max: 15 },
+  cold: { temp_max: 5 },
+  freezing: { temp_max: 0 },
+}
+
+const SORT_WORDS: Record<string, Pick<RunFilters, 'sort' | 'order'>> = {
+  fastest: { sort: 'pace', order: 'asc' },
+  slowest: { sort: 'pace', order: 'desc' },
+  longest: { sort: 'distance', order: 'desc' },
+  shortest: { sort: 'distance', order: 'asc' },
+  hottest: { sort: 'temperature', order: 'desc' },
+  coldest: { sort: 'temperature', order: 'asc' },
+}
+
+const MONTHS = [
+  'january', 'february', 'march', 'april', 'may', 'june',
+  'july', 'august', 'september', 'october', 'november', 'december',
+]
+
+const SEASONS: Record<string, [number, number]> = {
+  spring: [3, 5],
+  summer: [6, 8],
+  fall: [9, 11],
+  autumn: [9, 11],
+  winter: [12, 2], // spans the year boundary
+}
+
+const STOPWORDS = new Set([
+  'run', 'runs', 'runner', 'in', 'the', 'a', 'an', 'of', 'on', 'at', 'my',
+  'with', 'and', 'from', 'during', 'all', 'show', 'me', 'find', 'pace',
+])
+
+const iso = (d: Date) => d.toISOString().slice(0, 10)
+
+/** "9:30" or "9" -> minutes as float (9.5 / 9). */
+const parseClock = (s: string): number | null => {
+  const m = s.match(/^(\d{1,2})(?::(\d{2}))?$/)
+  if (!m) return null
+  return Number(m[1]) + (m[2] ? Number(m[2]) / 60 : 0)
+}
+
+/**
+ * Parse a free-text query like "rainy 5 milers last summer" or
+ * "hot runs under 9:30" into run filters. Deterministic token grammar —
+ * every understood token becomes a visible chip, so the translation is
+ * transparent. Distances/paces are interpreted in the user's unit.
+ */
+export function parseRunQuery(
+  query: string,
+  unit: Unit,
+  today: Date = new Date(),
+): ParsedRunQuery {
+  const filters: RunFilters = {}
+  const chips: string[] = []
+  const ignored: string[] = []
+
+  const toKm = (v: number) => (unit === 'mi' ? v * KM_PER_MI : v)
+  const paceToKm = (v: number) => (unit === 'mi' ? v / KM_PER_MI : v)
+  const year = today.getFullYear()
+
+  const setRange = (from: Date, to: Date, label: string) => {
+    filters.date_from = iso(from)
+    filters.date_to = iso(to)
+    chips.push(label)
+  }
+
+  // Normalize: keep :,-,digits; split words.
+  const tokens = query
+    .toLowerCase()
+    .replace(/[^\w:.\-\s]/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean)
+
+  let i = 0
+  while (i < tokens.length) {
+    const tok = tokens[i]
+    const next = tokens[i + 1] ?? ''
+    const prev = tokens[i - 1] ?? ''
+
+    // --- pace comparisons: "under 9:30", "sub 9", "faster than 9:00" ---
+    if (['under', 'sub', 'below', 'faster'].includes(tok)) {
+      const target = next === 'than' ? tokens[i + 2] : next
+      const mins = target ? parseClock(target) : null
+      if (mins !== null) {
+        filters.pace_max = Number(paceToKm(mins).toFixed(4))
+        chips.push(`pace under ${target}/${unit}`)
+        i += next === 'than' ? 3 : 2
+        continue
+      }
+    }
+    if (['over', 'above', 'slower'].includes(tok)) {
+      const target = next === 'than' ? tokens[i + 2] : next
+      const mins = target ? parseClock(target) : null
+      if (mins !== null && mins > 3) {
+        filters.pace_min = Number(paceToKm(mins).toFixed(4))
+        chips.push(`pace over ${target}/${unit}`)
+        i += next === 'than' ? 3 : 2
+        continue
+      }
+    }
+
+    // --- distance: "5 miler(s)", "5 mi", "10 km", "5k" ---
+    const dm = tok.match(/^(\d+(?:\.\d+)?)(k|km|mi|mile|miles|miler|milers)?$/)
+    if (dm) {
+      const value = Number(dm[1])
+      let suffix = dm[2]
+      if (!suffix && /^(mi|mile|miles|miler|milers|km|k)$/.test(next)) {
+        suffix = next
+        i += 1
+      }
+      if (suffix) {
+        const km = suffix.startsWith('k') ? value : value * KM_PER_MI
+        filters.distance_min = Number((km - 0.5).toFixed(3))
+        filters.distance_max = Number((km + 0.5).toFixed(3))
+        chips.push(`~${value} ${suffix.startsWith('k') ? 'km' : 'mi'}`)
+        i += 1
+        continue
+      }
+      // Bare 4-digit year
+      if (/^(19|20)\d{2}$/.test(tok)) {
+        setRange(new Date(Date.UTC(value, 0, 1)), new Date(Date.UTC(value, 11, 31)), tok)
+        i += 1
+        continue
+      }
+    }
+
+    // --- long/short shorthands ---
+    if (tok === 'long') {
+      filters.distance_min = Number(toKm(5).toFixed(3))
+      chips.push(`5+ ${unit}`)
+      i += 1
+      continue
+    }
+    if (tok === 'short') {
+      filters.distance_max = Number(toKm(3).toFixed(3))
+      chips.push(`< 3 ${unit}`)
+      i += 1
+      continue
+    }
+
+    // --- sort words ---
+    if (tok in SORT_WORDS) {
+      Object.assign(filters, SORT_WORDS[tok])
+      chips.push(tok)
+      i += 1
+      continue
+    }
+
+    // --- weather / temperature ---
+    if (tok in WEATHER_WORDS) {
+      filters.weather_type = WEATHER_WORDS[tok]
+      chips.push(WEATHER_WORDS[tok])
+      i += 1
+      continue
+    }
+    if (tok in TEMP_WORDS) {
+      Object.assign(filters, TEMP_WORDS[tok])
+      chips.push(tok)
+      i += 1
+      continue
+    }
+
+    // --- seasons (optionally preceded by "last"/"this") ---
+    if (tok in SEASONS) {
+      const [m1, m2] = SEASONS[tok]
+      let y = year
+      const currentMonth = today.getMonth() + 1
+      const startedThisYear = currentMonth >= m1 || (m1 > m2 && currentMonth <= m2)
+      if (prev === 'last') y = startedThisYear ? y - 1 : y - 1
+      else if (!startedThisYear) y = y - 1
+      const from = new Date(Date.UTC(y, m1 - 1, 1))
+      const endYear = m1 > m2 ? y + 1 : y
+      const to = new Date(Date.UTC(endYear, m2, 0)) // day 0 = last day of month m2
+      setRange(from, to, `${prev === 'last' ? 'last ' : ''}${tok} ${y}`)
+      i += 1
+      continue
+    }
+
+    // --- month names (optional trailing year) ---
+    const monthIdx = MONTHS.indexOf(tok)
+    if (monthIdx >= 0) {
+      let y = year
+      if (/^(19|20)\d{2}$/.test(next)) {
+        y = Number(next)
+        i += 1
+      } else if (monthIdx + 1 > today.getMonth() + 1) {
+        y = year - 1 // "december" said in July means last December
+      }
+      setRange(
+        new Date(Date.UTC(y, monthIdx, 1)),
+        new Date(Date.UTC(y, monthIdx + 1, 0)),
+        `${tok} ${y}`,
+      )
+      i += 1
+      continue
+    }
+
+    // --- relative years ---
+    if (tok === 'last' && next === 'year') {
+      setRange(new Date(Date.UTC(year - 1, 0, 1)), new Date(Date.UTC(year - 1, 11, 31)), `${year - 1}`)
+      i += 2
+      continue
+    }
+    if (tok === 'this' && next === 'year') {
+      setRange(new Date(Date.UTC(year, 0, 1)), today, `${year}`)
+      i += 2
+      continue
+    }
+    if (tok === 'last' && (next in SEASONS || MONTHS.includes(next))) {
+      i += 1 // consumed by the season/month branch via `prev`
+      continue
+    }
+
+    if (!STOPWORDS.has(tok)) ignored.push(tok)
+    i += 1
+  }
+
+  return { filters, chips, ignored }
+}

--- a/frontend/src/views/RunsView.vue
+++ b/frontend/src/views/RunsView.vue
@@ -10,6 +10,38 @@
       <SyncButton mode="full" @synced="reload" />
     </div>
 
+    <form class="mb-3" @submit.prevent="submitSearch">
+      <div class="relative">
+        <input
+          v-model="searchText"
+          type="search"
+          placeholder='Try "rainy 5 milers last summer" or "hot runs under 9:30"…'
+          class="w-full border border-gray-200 rounded-xl px-4 py-2.5 text-sm bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-200"
+        />
+        <button
+          type="submit"
+          class="absolute right-2 top-1/2 -translate-y-1/2 text-xs font-medium text-brand-600 px-2 py-1"
+        >
+          Search
+        </button>
+      </div>
+      <div v-if="nlChips.length || nlIgnored.length" class="flex flex-wrap items-center gap-1.5 mt-2">
+        <span
+          v-for="chip in nlChips"
+          :key="chip"
+          class="px-2.5 py-0.5 rounded-full bg-brand-50 border border-brand-200 text-brand-700 text-xs font-medium"
+        >
+          {{ chip }}
+        </span>
+        <span v-if="nlIgnored.length" class="text-xs text-gray-400">
+          (ignored: {{ nlIgnored.join(', ') }})
+        </span>
+        <button type="button" class="text-xs text-gray-500 underline ml-1" @click="clearSearch">
+          clear
+        </button>
+      </div>
+    </form>
+
     <div class="flex flex-wrap items-center gap-2 mb-3">
       <button
         v-for="c in collections"
@@ -43,6 +75,10 @@
         {{ d.label }}
       </button>
     </div>
+
+    <p v-if="impact" class="text-sm mb-4 px-1" :class="impact.slower ? 'text-amber-700' : 'text-green-700'">
+      {{ impact.text }}
+    </p>
 
     <div v-if="loading && runs.length === 0" class="space-y-2">
       <div v-for="i in 5" :key="i" class="bg-white rounded-lg border border-gray-100 h-14 animate-pulse" />
@@ -104,7 +140,9 @@ import RunRow from '@/components/RunRow.vue'
 import SyncButton from '@/components/SyncButton.vue'
 import { useRuns } from '@/composables/useRuns'
 import { useUserPreferences } from '@/composables/useUserPreferences'
+import { apiCall } from '@/config/api'
 import { formatDistanceWithUnit, formatPace } from '@/utils/format'
+import { parseRunQuery } from '@/utils/runQuery'
 import type { PaginatedRun, RunFilters } from '@/types/runs'
 
 const KM_PER_MI = 1.609344
@@ -170,9 +208,78 @@ const selectCollection = (key: CollectionKey) => {
   void applyFilters()
 }
 
+// ---- natural-language search (SB-269 PR2) ----
+const searchText = ref('')
+const nlFilters = ref<RunFilters>({})
+const nlChips = ref<string[]>([])
+const nlIgnored = ref<string[]>([])
+
+const submitSearch = () => {
+  const parsed = parseRunQuery(searchText.value, unit.value)
+  nlFilters.value = parsed.filters
+  nlChips.value = parsed.chips
+  nlIgnored.value = parsed.ignored
+  void applyFilters()
+}
+
+const clearSearch = () => {
+  searchText.value = ''
+  nlFilters.value = {}
+  nlChips.value = []
+  nlIgnored.value = []
+  void applyFilters()
+}
+
 const isFiltered = computed(
-  () => period.value !== 'all' || distance.value !== 'all' || collection.value !== null,
+  () =>
+    period.value !== 'all' ||
+    distance.value !== 'all' ||
+    collection.value !== null ||
+    nlChips.value.length > 0,
 )
+
+// ---- conditions impact: filtered set vs overall (SB-269 PR2) ----
+interface RunsSummary {
+  count: number
+  total_km: number
+  avg_pace_min_per_km: number | null
+  overall_avg_pace_min_per_km: number | null
+}
+
+const summary = ref<RunsSummary | null>(null)
+
+const loadSummary = async (f: RunFilters) => {
+  if (!isFiltered.value) {
+    summary.value = null
+    return
+  }
+  try {
+    const params = new URLSearchParams()
+    for (const [k, v] of Object.entries(f)) {
+      if (v !== undefined && v !== null && k !== 'sort' && k !== 'order') params.set(k, String(v))
+    }
+    summary.value = await apiCall<RunsSummary>(`/runs/summary?${params.toString()}`)
+  } catch {
+    summary.value = null
+  }
+}
+
+const impact = computed(() => {
+  const s = summary.value
+  if (!s || !isFiltered.value || s.avg_pace_min_per_km == null || s.overall_avg_pace_min_per_km == null)
+    return null
+  const deltaMinPerKm = s.avg_pace_min_per_km - s.overall_avg_pace_min_per_km
+  const perUnit = unit.value === 'mi' ? deltaMinPerKm * KM_PER_MI : deltaMinPerKm
+  const secs = Math.round(Math.abs(perUnit) * 60)
+  const slower = deltaMinPerKm > 0
+  if (secs < 2) {
+    return { slower: false, text: `${s.count} runs · avg ${formatPace(s.avg_pace_min_per_km, unit.value)} — right at your overall pace` }
+  }
+  return {
+    slower,
+    text: `${s.count} runs · avg ${formatPace(s.avg_pace_min_per_km, unit.value)} — ${secs}s/${unit.value} ${slower ? 'slower' : 'faster'} than your overall ${formatPace(s.overall_avg_pace_min_per_km, unit.value)}`,
+  }
+})
 
 const chipClass = (active: boolean) =>
   [
@@ -200,10 +307,14 @@ const buildFilters = (): RunFilters => {
   }
   if (distance.value === 'long') f.distance_min = toKm(5)
   if (collection.value) Object.assign(f, COLLECTION_PRESETS[collection.value])
+  Object.assign(f, nlFilters.value) // typed search wins
   return f
 }
 
-const applyFilters = () => setFilters(buildFilters())
+const applyFilters = async () => {
+  const f = buildFilters()
+  await Promise.all([setFilters(f), loadSummary(f)])
+}
 const selectPeriod = (key: PeriodKey) => {
   period.value = key
   void applyFilters()

--- a/src/shared/supabase_ops/runs_repository.py
+++ b/src/shared/supabase_ops/runs_repository.py
@@ -202,6 +202,39 @@ class RunsRepository:
         result = query.execute()
         return cast(int, result.count or 0)
 
+    def summarize_runs(self, user_id: UUID, **filters: Any) -> dict[str, Any]:
+        """Aggregate the FULL filtered set (SB-269 conditions impact): count,
+        total km, and distance-weighted avg pace. Fetches only two columns."""
+        query = (
+            self.supabase.table("runs")
+            .select("distance_km,average_pace_min_per_km")
+            .eq("user_id", str(user_id))
+        )
+        query = self._apply_run_filters(
+            query,
+            filters.pop("date_from", None),
+            filters.pop("date_to", None),
+            filters.pop("distance_min", None),
+            filters.pop("distance_max", None),
+            **filters,
+        )
+        rows = cast(list[dict[str, Any]], query.limit(10000).execute().data)
+        total_km = 0.0
+        weighted = 0.0
+        paced_km = 0.0
+        for r in rows:
+            km = float(r["distance_km"] or 0)
+            total_km += km
+            pace = r.get("average_pace_min_per_km")
+            if pace is not None and km > 0:
+                weighted += float(pace) * km
+                paced_km += km
+        return {
+            "count": len(rows),
+            "total_km": round(total_km, 2),
+            "avg_pace_min_per_km": round(weighted / paced_km, 4) if paced_km else None,
+        }
+
     def get_runs_by_date_range(
         self, user_id: UUID, start_date: date, end_date: date
     ) -> list[dict[str, Any]]:


### PR DESCRIPTION
Completes **SB-269**. Type what you mean; see what it costs you.

## Live on real data (4,753 runs)

- Typed **"rainy 5 milers last summer"** → chips: `rainy · ~5 mi · last summer 2025`
- Typed **"rainy runs"** → **"299 runs · avg 9:00 /mi — 32s/mi slower than your
  overall 8:28 /mi"**

The heat/humidity question this arc started with now has a product answer.

## Natural-language search

`parseRunQuery()` — a deterministic token grammar (no LLM, no magic):
- **weather** (rainy/sunny/…), **temperature** ("hot" ≥24 °C, "cold" ≤5 °C…)
- **distances** — "5 milers", "10k", "3 miles", long/short (unit-aware)
- **pace** — "under 9:30", "sub 9", "faster/slower than 9:00" (min/mi→min/km)
- **time** — months (past-aware ±year), bare years, seasons (winter spans the
  year boundary), "last summer", "last/this year"
- **sort** — fastest/longest/hottest/coldest…

Every understood token renders as a chip; unrecognized words show as
"(ignored: …)". Composes with the collections + existing chips; typed search
wins. **13 parser tests** with a pinned clock.

## Conditions impact

- **`GET /runs/summary`** — same filter params → count, total km, filtered
  distance-weighted avg pace + overall avg (two-column fetch, cached,
  registered before `/runs/{activity_id}`).
- Any active filter renders the readout (amber = slower, green = faster; ±2s
  reads "right at your overall pace").

## Tests

Backend 220 green · 13 new parser tests (207 frontend passing; the 7
pre-existing failures live in the rot-fix session).

Fixes SB-269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)