### PR TITLE
chore: onboard qe-plugin (QE config + quality goals)

### DIFF
--- a/.claude/agents/qe-engineer.md
+++ b/.claude/agents/qe-engineer.md
@@ -1,0 +1,34 @@
+---
+name: qe-engineer
+description: QE engineer for myrunstreak.run. Writes tests and enforces coverage. Use when code has been added or changed and tests need to be written or reviewed.
+tools: Bash, Read, Edit, Write, Grep, Glob
+---
+
+Follows the global qe-engineer rules. myrunstreak-specific additions:
+
+## Layout — three suites
+
+| Suite | Tests | Run from | Command |
+|-------|-------|----------|---------|
+| Root (src/ core lib) | `tests/` | repo root | `uv run pytest tests/ -q` |
+| Backend (FastAPI) | `backend/tests/` | **repo root** | `uv run --project backend python -m pytest backend/tests/ -q` |
+| Frontend (Vue 3 + TS) | `frontend/src/**/__tests__/` | `frontend/` | `npm test` |
+
+Backend tests import `backend.*` — they break if run from inside `backend/`.
+
+## Stack rules
+
+- **UV only** — never pip, never `python -m pytest` outside `uv run`
+- **Pydantic v2** models everywhere; mypy strict is on
+- Frontend: vitest + @vue/test-utils, `happy-dom` environment
+- CI floors (`.github/workflows/test.yml`): root ≥60%, backend ≥80% — new code must not sink these
+- CI does NOT run the frontend suite — do not assume green frontend without running it locally
+
+## Fixtures
+
+- Root/backend: check each suite's `conftest.py` before writing fixtures
+- Never hit real Smashrun/Supabase in tests — mock at the client boundary (`smashrun_client`, Supabase client)
+
+## Test debt
+
+Tracked in Linear, team SB (no repo label assigned yet — check `linear label list` before tagging).

--- a/.claude/qe.yml
+++ b/.claude/qe.yml
@@ -1,0 +1,36 @@
+# QE plugin config (silverbeer/qe-plugin) — read by /qe and /generate-tests
+# Top level = the root suite (src/ core lib). All commands run from the repo root.
+stack: python
+test_cmd: "uv run pytest tests/ -q"
+coverage_cmd: "uv run pytest tests/ -q --cov=src --cov-report=json"
+coverage_report: "coverage.json"
+coverage_format: python-json
+
+# Floors mirror CI (.github/workflows/test.yml --cov-fail-under values).
+goals:
+  coverage_total_min: 60
+  coverage_no_regression: true
+  coverage_target: 75
+
+subprojects:
+  backend:
+    stack: python
+    # Backend tests import `backend.*` — commands MUST run from the repo root.
+    test_cmd: "uv run --project backend python -m pytest backend/tests/ -q"
+    coverage_cmd: "uv run --project backend python -m pytest backend/tests/ -q --cov=backend --cov-report=json:backend/coverage.json"
+    coverage_report: "coverage.json"
+    coverage_format: python-json
+    openapi_url: "http://localhost:8000/openapi.json"
+    goals:
+      coverage_total_min: 80
+      coverage_no_regression: true
+      coverage_target: 85
+  frontend:
+    stack: node
+    test_cmd: "npm test"
+    coverage_cmd: "npx vitest run --coverage --coverage.reporter=json-summary --coverage.reportOnFailure"
+    coverage_report: "coverage/coverage-summary.json"
+    coverage_format: istanbul-json
+    goals:
+      coverage_no_regression: true
+      coverage_target: 60

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,9 @@ docs/PLANNING.md
 
 # Playwright CLI
 .playwright-cli/
+
+# qe-plugin state
+.qe/coverage_history.jsonl
+coverage.json
+backend/coverage.json
+frontend/coverage/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "@typescript-eslint/eslint-plugin": "^6.19.0",
         "@typescript-eslint/parser": "^6.19.0",
         "@vitejs/plugin-vue": "^5.0.3",
+        "@vitest/coverage-v8": "^1.6.1",
         "@vue/test-utils": "^2.4.3",
         "@vue/tsconfig": "^0.5.1",
         "autoprefixer": "^10.4.17",
@@ -48,6 +49,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -95,6 +110,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -681,6 +703,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jest/schemas": {
@@ -1489,6 +1521,34 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz",
+      "integrity": "sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.1",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.4",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.4",
+        "istanbul-reports": "^3.1.6",
+        "magic-string": "^0.30.5",
+        "magicast": "^0.3.3",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "test-exclude": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "1.6.1"
       }
     },
     "node_modules/@vitest/expect": {
@@ -3138,6 +3198,13 @@
         "he": "bin/he"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -3321,6 +3388,60 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -3546,6 +3667,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {
@@ -4827,6 +4976,67 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/text-table": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "@typescript-eslint/eslint-plugin": "^6.19.0",
     "@typescript-eslint/parser": "^6.19.0",
     "@vitejs/plugin-vue": "^5.0.3",
+    "@vitest/coverage-v8": "^1.6.1",
     "@vue/test-utils": "^2.4.3",
     "@vue/tsconfig": "^0.5.1",
     "autoprefixer": "^10.4.17",


### PR DESCRIPTION
Onboards myrunstreak.run to the [qe-plugin](https://github.com/silverbeer/qe-plugin) QE toolkit.

## What
- `.claude/qe.yml` — three suites (root / backend / frontend) with per-suite quality goals mirroring the existing CI floors (root ≥60%, backend ≥80%)
- `.claude/agents/qe-engineer.md` — repo conventions: uv-only, backend tests import `backend.*` so they run from repo root, happy-dom env, mock at Smashrun/Supabase client boundary
- `frontend/`: adds `@vitest/coverage-v8@1.6.1` (coverage was configured nowhere and impossible to run without it)
- `.gitignore` — per-machine QE state + coverage artifacts

## Baselines (2026-07-12)
| Suite | Tests | Coverage | Gate |
|-------|-------|---------:|------|
| root | 52 passed | 61.3% | PASS |
| backend | 220 passed | 88.7% | PASS |
| frontend | 194 passed, **7 failed** | 55.8% | PASS (no floor yet) |

## ⚠️ Findings
1. **7 frontend tests fail** (`useSync`, `useUserPreferences`) — `window.localStorage` undefined under happy-dom. **CI never runs the frontend suite**, so these are invisible on main.
2. Consider adding a frontend job to `.github/workflows/test.yml` (vitest + the new coverage provider), then set a hard `coverage_total_min` for frontend in qe.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)