### PR TITLE
fix: make coach assign() idempotent (SB-271)

### DIFF
--- a/backend/tests/test_coach_foundation.py
+++ b/backend/tests/test_coach_foundation.py
@@ -320,3 +320,80 @@ def test_list_coaches_tolerates_missing_user() -> None:
     assert len(out) == 1
     assert out[0].coach_display_name is None
     assert out[0].coach_email is None
+
+
+class _FakeCoachLinks:
+    """Minimal Supabase table double for CoachAthletesRepository.assign (SB-271).
+
+    Records whether an INSERT happened and returns a preset row for the active
+    lookup, so the test can assert the idempotent no-op path.
+    """
+
+    def __init__(self, existing: list[dict[str, Any]]):
+        self._existing = existing
+        self._mode = "select"
+        self.inserted = False
+
+    def table(self, _name: str) -> _FakeCoachLinks:
+        self._mode = "select"
+        return self
+
+    def select(self, *a: Any, **k: Any) -> _FakeCoachLinks:
+        self._mode = "select"
+        return self
+
+    def eq(self, *a: Any, **k: Any) -> _FakeCoachLinks:
+        return self
+
+    def insert(self, payload: Any) -> _FakeCoachLinks:
+        self._mode = "insert"
+        self.inserted = True
+        self._payload = payload
+        return self
+
+    def execute(self) -> Any:
+        if self._mode == "select":
+            return SimpleNamespace(data=list(self._existing))
+        row = {
+            "id": str(uuid4()),
+            "status": "active",
+            "started_at": "2026-07-13T00:00:00+00:00",
+            "ended_at": None,
+            "created_at": "2026-07-13T00:00:00+00:00",
+            **self._payload,
+        }
+        return SimpleNamespace(data=[row])
+
+
+def test_assign_returns_existing_active_link_without_insert() -> None:
+    """SB-271: re-adding an already-active coach is a no-op, not a duplicate INSERT."""
+    from src.shared.supabase_ops.athletes_repository import CoachAthletesRepository
+
+    coach, aid = uuid4(), uuid4()
+    existing = {
+        "id": str(uuid4()),
+        "coach_id": str(coach),
+        "athlete_id": str(aid),
+        "status": "active",
+        "started_at": "2026-07-02T00:00:00+00:00",
+        "ended_at": None,
+        "created_at": "2026-07-02T00:00:00+00:00",
+    }
+    fake = _FakeCoachLinks(existing=[existing])
+    out = CoachAthletesRepository(fake).assign(coach, aid)  # type: ignore[arg-type]
+
+    assert fake.inserted is False
+    assert out == existing
+
+
+def test_assign_inserts_when_no_active_link() -> None:
+    from src.shared.supabase_ops.athletes_repository import CoachAthletesRepository
+
+    coach, aid = uuid4(), uuid4()
+    fake = _FakeCoachLinks(existing=[])
+    out = CoachAthletesRepository(fake).assign(coach, aid)  # type: ignore[arg-type]
+
+    assert fake.inserted is True
+    assert out["coach_id"] == str(coach)
+    assert out["athlete_id"] == str(aid)
+    assert out["status"] == "active"

--- a/src/shared/supabase_ops/athletes_repository.py
+++ b/src/shared/supabase_ops/athletes_repository.py
@@ -165,7 +165,23 @@ class CoachAthletesRepository:
         return bool(cast(list[dict[str, Any]], result.data))
 
     def assign(self, coach_id: UUID, athlete_id: UUID) -> dict[str, Any]:
-        """Start an active coaching link (idempotent on the active uniqueness)."""
+        """Start an active coaching link, returning the existing one if already active.
+
+        Idempotent: a coach already active on the athlete is a no-op that returns
+        the current link rather than a duplicate INSERT, which would violate the
+        ``idx_coach_athletes_active`` partial unique index and surface as a 500.
+        """
+        existing = (
+            self.supabase.table("coach_athletes")
+            .select("*")
+            .eq("coach_id", str(coach_id))
+            .eq("athlete_id", str(athlete_id))
+            .eq("status", "active")
+            .execute()
+        )
+        rows = cast(list[dict[str, Any]], existing.data)
+        if rows:
+            return rows[0]
         result = (
             self.supabase.table("coach_athletes")
             .insert({"coach_id": str(coach_id), "athlete_id": str(athlete_id)})


### PR DESCRIPTION
## Problem

`POST /athletes/{id}/coaches` returned **HTTP 500** when the coach was already active on the athlete (e.g. re-adding a coach who was auto-linked at invite redemption). Hit in the wild adding Matthew as Gabe's coach after he redeemed his invite.

`CoachAthletesRepository.assign()` claimed idempotency in its docstring but ran a plain `.insert()`. A duplicate active link violates the partial unique index `idx_coach_athletes_active` (`(coach_id, athlete_id) WHERE status='active'`), so the insert raises → 500. The DB link is unaffected (it already existed); the caller just gets a 500 instead of a no-op.

## Fix

`assign()` now looks up the existing active link first and returns it; it only `.insert()`s when none exists. The partial unique index still guards integrity against the narrow race.

## Tests

- `test_assign_returns_existing_active_link_without_insert` — re-add is a no-op, returns the existing row, no INSERT.
- `test_assign_inserts_when_no_active_link` — new coach still creates the link.
- Full backend suite: 222 passed.

## Deploy note

Prod runs the old code — needs deploy for the live 500 to clear. The link created in the wild is already correct.

Fixes SB-271

🤖 Generated with [Claude Code](https://claude.com/claude-code)