### PR TITLE
feat: show current coaches in athlete ACCESS panel (SB-272)

### DIFF
--- a/backend/routes/athletes.py
+++ b/backend/routes/athletes.py
@@ -199,10 +199,28 @@ def list_coaches(
     athlete_id: UUID,
     user_id: UUID = Depends(authenticate_request),
 ) -> list[CoachAthlete]:
-    """Active coaches of an athlete."""
+    """Active coaches of an athlete, each enriched with the coach's name/email."""
     require_athlete_access(user_id, athlete_id)
-    rows = CoachAthletesRepository(get_supabase_client()).list_active_for_athlete(athlete_id)
-    return [CoachAthlete(**r) for r in rows]
+    supabase = get_supabase_client()
+    rows = CoachAthletesRepository(supabase).list_active_for_athlete(athlete_id)
+    users = UsersRepository(supabase)
+    # Resolve each coach's display name/email (the link row carries only the id).
+    # Cache per coach_id so duplicate coaches don't re-query.
+    resolved: dict[str, dict[str, Any] | None] = {}
+    out: list[CoachAthlete] = []
+    for r in rows:
+        cid = r["coach_id"]
+        if cid not in resolved:
+            resolved[cid] = users.get_user_by_id(UUID(cid))
+        user = resolved[cid]
+        out.append(
+            CoachAthlete(
+                **r,
+                coach_display_name=(user or {}).get("display_name"),
+                coach_email=(user or {}).get("email"),
+            )
+        )
+    return out
 
 
 @router.delete("/{athlete_id}/coaches/{coach_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/tests/test_coach_foundation.py
+++ b/backend/tests/test_coach_foundation.py
@@ -242,3 +242,81 @@ def test_assign_coach_request_requires_id_or_email() -> None:
 
     with pytest.raises(ValueError):
         AssignCoachRequest()
+
+
+def test_list_coaches_enriches_with_name_and_email() -> None:
+    """SB-272: each coach link carries the coach's display name + email for the UI."""
+    from backend.routes.athletes import list_coaches
+
+    aid = uuid4()
+    coach_a, coach_b = uuid4(), uuid4()
+    links_repo = MagicMock()
+    links_repo.list_active_for_athlete.return_value = [
+        {
+            "id": str(uuid4()),
+            "coach_id": str(coach_a),
+            "athlete_id": str(aid),
+            "status": "active",
+            "started_at": "2026-07-02T00:00:00+00:00",
+            "ended_at": None,
+            "created_at": "2026-07-02T00:00:00+00:00",
+        },
+        {
+            "id": str(uuid4()),
+            "coach_id": str(coach_b),
+            "athlete_id": str(aid),
+            "status": "active",
+            "started_at": "2026-07-13T00:00:00+00:00",
+            "ended_at": None,
+            "created_at": "2026-07-13T00:00:00+00:00",
+        },
+    ]
+    users_repo = MagicMock()
+    users_repo.get_user_by_id.side_effect = lambda cid: {
+        str(coach_a): {"display_name": "Tom", "email": "tom@example.com"},
+        str(coach_b): {"display_name": "Matthew", "email": "matthew@example.com"},
+    }[str(cid)]
+
+    with (
+        _admin_env(roles={"admin"}, athlete={"id": str(aid), "linked_user_id": None}),
+        patch("backend.routes.athletes.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.athletes.CoachAthletesRepository", return_value=links_repo),
+        patch("backend.routes.athletes.UsersRepository", return_value=users_repo),
+    ):
+        out = list_coaches(aid, user_id=uuid4())
+
+    assert [c.coach_display_name for c in out] == ["Tom", "Matthew"]
+    assert [c.coach_email for c in out] == ["tom@example.com", "matthew@example.com"]
+
+
+def test_list_coaches_tolerates_missing_user() -> None:
+    """A coach link whose user row can't be resolved still returns (name/email None)."""
+    from backend.routes.athletes import list_coaches
+
+    aid, coach = uuid4(), uuid4()
+    links_repo = MagicMock()
+    links_repo.list_active_for_athlete.return_value = [
+        {
+            "id": str(uuid4()),
+            "coach_id": str(coach),
+            "athlete_id": str(aid),
+            "status": "active",
+            "started_at": "2026-07-13T00:00:00+00:00",
+            "ended_at": None,
+            "created_at": "2026-07-13T00:00:00+00:00",
+        }
+    ]
+    users_repo = MagicMock()
+    users_repo.get_user_by_id.return_value = None
+
+    with (
+        _admin_env(roles={"admin"}, athlete={"id": str(aid), "linked_user_id": None}),
+        patch("backend.routes.athletes.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.athletes.CoachAthletesRepository", return_value=links_repo),
+        patch("backend.routes.athletes.UsersRepository", return_value=users_repo),
+    ):
+        out = list_coaches(aid, user_id=uuid4())
+
+    assert len(out) == 1
+    assert out[0].coach_display_name is None
+    assert out[0].coach_email is None

--- a/frontend/src/components/AthleteAccessPanel.vue
+++ b/frontend/src/components/AthleteAccessPanel.vue
@@ -31,6 +31,36 @@
       {{ athlete.display_name }} has their own login. ✓
     </p>
 
+    <!-- Current coaches -->
+    <div class="space-y-2 border-t border-gray-100 pt-5">
+      <p class="text-sm font-medium text-gray-700">Coaches</p>
+      <p v-if="loadingCoaches" class="text-sm text-gray-400">Loading…</p>
+      <p v-else-if="!coaches.length" class="text-sm text-gray-400">
+        No coaches yet — add one below.
+      </p>
+      <ul v-else class="divide-y divide-gray-100">
+        <li v-for="c in coaches" :key="c.id" class="flex items-center justify-between py-2">
+          <div class="min-w-0">
+            <p class="text-sm font-medium text-gray-800 truncate">
+              {{ c.coach_display_name || c.coach_email || 'Unknown coach' }}
+            </p>
+            <p class="text-xs text-gray-400 truncate">
+              <span v-if="c.coach_display_name && c.coach_email">{{ c.coach_email }} · </span>since
+              {{ formatDate(c.started_at) }}
+            </p>
+          </div>
+          <button
+            type="button"
+            :disabled="removingId === c.coach_id"
+            class="btn-secondary text-xs shrink-0"
+            @click="doRemoveCoach(c)"
+          >
+            {{ removingId === c.coach_id ? 'Removing…' : 'Remove' }}
+          </button>
+        </li>
+      </ul>
+    </div>
+
     <!-- Add an existing user as a coach -->
     <div class="space-y-2 border-t border-gray-100 pt-5">
       <p class="text-sm font-medium text-gray-700">Add a coach</p>
@@ -62,9 +92,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
-import { addCoachByEmail, inviteAthlete } from '@/composables/useCoach'
-import type { Athlete } from '@/types/coach'
+import { onMounted, ref } from 'vue'
+import {
+  addCoachByEmail,
+  inviteAthlete,
+  listCoaches,
+  removeCoach,
+} from '@/composables/useCoach'
+import type { Athlete, CoachAthlete } from '@/types/coach'
 
 const props = defineProps<{ athlete: Athlete }>()
 
@@ -76,8 +111,45 @@ const copied = ref(false)
 const coachEmail = ref('')
 const addingCoach = ref(false)
 
+const coaches = ref<CoachAthlete[]>([])
+const loadingCoaches = ref(false)
+const removingId = ref<string | null>(null)
+
 const error = ref<string | null>(null)
 const success = ref<string | null>(null)
+
+const formatDate = (iso: string): string =>
+  new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+
+const loadCoaches = async (): Promise<void> => {
+  loadingCoaches.value = true
+  try {
+    coaches.value = await listCoaches(props.athlete.id)
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to load coaches'
+  } finally {
+    loadingCoaches.value = false
+  }
+}
+
+onMounted(loadCoaches)
+
+const doRemoveCoach = async (coach: CoachAthlete): Promise<void> => {
+  const who = coach.coach_display_name || coach.coach_email || 'this coach'
+  if (!window.confirm(`Remove ${who} as a coach of ${props.athlete.display_name}?`)) return
+  removingId.value = coach.coach_id
+  error.value = null
+  success.value = null
+  try {
+    await removeCoach(props.athlete.id, coach.coach_id)
+    success.value = `Removed ${who}.`
+    await loadCoaches()
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to remove coach'
+  } finally {
+    removingId.value = null
+  }
+}
 
 const copy = async (text: string) => {
   await navigator.clipboard?.writeText(text)
@@ -109,6 +181,7 @@ const doAddCoach = async () => {
     await addCoachByEmail(props.athlete.id, coachEmail.value)
     success.value = `Added ${coachEmail.value} as a coach.`
     coachEmail.value = ''
+    await loadCoaches()
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Failed to add coach'
   } finally {

--- a/frontend/src/composables/useCoach.ts
+++ b/frontend/src/composables/useCoach.ts
@@ -4,6 +4,7 @@ import type {
   Athlete,
   AthleteCreate,
   AthleteProfileUpdate,
+  CoachAthlete,
   Invite,
   MyRoles,
   WorkoutSession,
@@ -96,6 +97,14 @@ export async function addCoachByEmail(athleteId: string, email: string): Promise
     method: 'POST',
     body: JSON.stringify({ coach_email: email }),
   })
+}
+
+export async function listCoaches(athleteId: string): Promise<CoachAthlete[]> {
+  return apiCall<CoachAthlete[]>(`/athletes/${athleteId}/coaches`)
+}
+
+export async function removeCoach(athleteId: string, coachId: string): Promise<void> {
+  await apiCall(`/athletes/${athleteId}/coaches/${coachId}`, { method: 'DELETE' })
 }
 
 export function useCoach() {

--- a/frontend/src/types/coach.ts
+++ b/frontend/src/types/coach.ts
@@ -68,6 +68,18 @@ export interface AthleteCreate {
   notes?: string | null
 }
 
+export interface CoachAthlete {
+  id: string
+  coach_id: string
+  athlete_id: string
+  status: 'active' | 'ended'
+  started_at: string
+  ended_at: string | null
+  created_at: string
+  coach_display_name: string | null
+  coach_email: string | null
+}
+
 export type WorkoutType = 'circuit' | 'intervals' | 'test' | string
 
 export interface ExerciseSet {

--- a/src/shared/models/athlete.py
+++ b/src/shared/models/athlete.py
@@ -120,6 +120,9 @@ class CoachAthlete(BaseModel):
     started_at: datetime
     ended_at: datetime | None = None
     created_at: datetime
+    # Resolved from the users table for display; the DB row carries only coach_id.
+    coach_display_name: str | None = None
+    coach_email: str | None = None
 
 
 # Resolve the forward reference to AthleteProfile on Athlete.profile.


### PR DESCRIPTION
## Problem

The athlete ACCESS panel showed an "Add a coach" form but **never listed the athlete's current coaches** — so a coach viewing an athlete couldn't confirm who already coaches them. Surfaced when adding Matthew as Gabe's coach: the link was correct in the DB, but the UI gave no confirmation. (The card's "Coached by …" is the template `source`, unrelated to the `coach_athletes` link.)

## Changes

**Backend**
- `GET /athletes/{id}/coaches` enriches each link with the coach's `display_name` + `email`, resolved via `UsersRepository.get_user_by_id` (cached per `coach_id` so duplicate coaches don't re-query).
- `CoachAthlete` model gains optional `coach_display_name` / `coach_email`.

**Frontend**
- `AthleteAccessPanel.vue` fetches and renders a **Coaches** list (name/email + "since" date), each with a **Remove** control wired to the existing `DELETE /athletes/{id}/coaches/{coach_id}`. List refreshes after add/remove.
- `useCoach`: new `listCoaches` + `removeCoach`; `CoachAthlete` type added.

## Tests

- `test_list_coaches_enriches_with_name_and_email` — links carry name + email, in order.
- `test_list_coaches_tolerates_missing_user` — unresolvable coach → name/email `None`, still returned.
- Backend coach suite: 17 passed. Frontend `vue-tsc` type-check clean. (Pre-existing unrelated vitest failures in `useSync`/`useUserPreferences` are not touched here.)

## Deploy note

Needs deploy to see the list live in prod.

Fixes SB-272

🤖 Generated with [Claude Code](https://claude.com/claude-code)