### PR TITLE
feat: version-gated client cache for stk (SQLite)

### DIFF
--- a/backend/jobs/sync_runs.py
+++ b/backend/jobs/sync_runs.py
@@ -7,10 +7,12 @@ the HTTP endpoint.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import sys
 from uuid import UUID
 
+from backend.cache import invalidate_user
 from backend.config import get_settings
 from backend.routes.sync import run_user_sync
 from src.shared.supabase_client import get_supabase_client
@@ -33,6 +35,12 @@ def main() -> int:
     for user_id in user_ids:
         try:
             result = run_user_sync(user_id)
+            # The HTTP "Sync now" path invalidates the user's Redis cache; the
+            # cron path must too, else read endpoints (and the /runs/head
+            # version token) serve stale data for up to their TTL after a new
+            # run lands — which would pin stale data in clients' local caches
+            # under a freshly-advanced token.
+            asyncio.run(invalidate_user(user_id))
             logger.info(f"Synced {result['runs_synced']} runs for {user_id}")
         except Exception as exc:  # noqa: BLE001
             failures += 1

--- a/backend/routes/runs.py
+++ b/backend/routes/runs.py
@@ -211,7 +211,24 @@ async def runs_summary(
     )
 
 
-# NOTE: registered after /recent and "" so the static paths keep priority.
+@cached(ttl=60, key_prefix="runs:head")
+async def _head(user_id: UUID) -> dict[str, Any]:
+    return RunsRepository(get_supabase_client()).get_runs_head(user_id)
+
+
+@router.get("/head")
+async def runs_head(
+    user_id: UUID = Depends(authenticate_request),
+) -> dict[str, Any]:
+    """Cheap version token for the caller's run history — ``{count,
+    latest_run_date}``. Clients (the ``stk`` CLI) hit this once per invocation
+    and gate their local response cache on the pair: unchanged → serve from
+    cache, changed → a run was added/removed → refetch. Cleared alongside the
+    other run caches whenever a sync invalidates the user (SB run cache)."""
+    return await _head(user_id)
+
+
+# NOTE: registered after /recent, /head, and "" so the static paths keep priority.
 @router.get("/{activity_id}")
 async def get_run_detail(
     activity_id: str,

--- a/backend/tests/test_runs_head.py
+++ b/backend/tests/test_runs_head.py
@@ -1,0 +1,46 @@
+"""Tests for GET /runs/head — the cheap version token for client cache gating."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from uuid import uuid4
+
+from backend.routes import runs as runs_module
+
+USER = uuid4()
+
+
+class _Repo:
+    """Stand-in for RunsRepository that records the head call."""
+
+    def __init__(self, head: dict[str, Any]) -> None:
+        self._head = head
+        self.calls: list[Any] = []
+
+    def __call__(self, _supabase: Any) -> _Repo:
+        return self
+
+    def get_runs_head(self, user_id: Any) -> dict[str, Any]:
+        self.calls.append(user_id)
+        return self._head
+
+
+def test_runs_head_returns_count_and_latest(monkeypatch: Any) -> None:
+    repo = _Repo({"count": 842, "latest_run_date": "2026-07-16T06:45:00"})
+    monkeypatch.setattr(runs_module, "get_supabase_client", lambda: object())
+    monkeypatch.setattr(runs_module, "RunsRepository", repo)
+
+    out = asyncio.run(runs_module.runs_head(user_id=USER))
+
+    assert out == {"count": 842, "latest_run_date": "2026-07-16T06:45:00"}
+    assert repo.calls == [USER]  # scoped to the authenticated user
+
+
+def test_runs_head_empty_history(monkeypatch: Any) -> None:
+    monkeypatch.setattr(runs_module, "get_supabase_client", lambda: object())
+    monkeypatch.setattr(runs_module, "RunsRepository", _Repo({"count": 0, "latest_run_date": None}))
+
+    out = asyncio.run(runs_module.runs_head(user_id=USER))
+
+    assert out == {"count": 0, "latest_run_date": None}

--- a/src/shared/supabase_ops/runs_repository.py
+++ b/src/shared/supabase_ops/runs_repository.py
@@ -208,6 +208,30 @@ class RunsRepository:
         result = query.execute()
         return cast(int, result.count or 0)
 
+    def get_runs_head(self, user_id: UUID) -> dict[str, Any]:
+        """Cheap change-signal for a user's run history: total count and the
+        latest run's local date.
+
+        Used by ``GET /runs/head`` to build a version token
+        (``"{count}:{latest_run_date}"``) that clients use to gate their local
+        cache — it advances only when a run is added or removed, so re-syncs
+        that merely re-upsert existing runs (bumping ``updated_at``) do not
+        needlessly bust the cache. In-place edits to an existing run are
+        intentionally NOT reflected (rare; clients can force a refresh).
+        """
+        count = self.count_runs_by_user(user_id)
+        result = (
+            self.supabase.table("runs")
+            .select("start_date_time_local")
+            .eq("user_id", str(user_id))
+            .order("start_date_time_local", desc=True)
+            .limit(1)
+            .execute()
+        )
+        rows = cast(list[dict[str, Any]], result.data)
+        latest = rows[0]["start_date_time_local"] if rows else None
+        return {"count": count, "latest_run_date": latest}
+
     def summarize_runs(self, user_id: UUID, **filters: Any) -> dict[str, Any]:
         """Aggregate the FULL filtered set (SB-269 conditions impact): count,
         total km, and distance-weighted avg pace. Fetches only two columns."""

--- a/stk/src/cli/api.py
+++ b/stk/src/cli/api.py
@@ -12,12 +12,19 @@ from typing import Any
 
 import httpx
 
+from cli import cache as cache_mod
 from cli import config as config_mod
 from cli import session as session_mod
 from cli.display import display_error, display_info
 
 DEFAULT_API_URL = "https://api.myrunstreak.run"
 TIMEOUT = 30.0
+
+# Per-process memo of the run-version token, keyed by session scope. One
+# ``GET /runs/head`` per CLI invocation gates every version-cached read.
+_run_version: dict[str, str | None] = {}
+# Scopes whose stale cache rows have already been swept this invocation.
+_swept: set[str] = set()
 
 
 def get_api_url() -> str:
@@ -121,9 +128,59 @@ def _exit_with_error(response: httpx.Response) -> None:
     sys.exit(1)
 
 
+def get_run_version(s: session_mod.Session, scope: str) -> str | None:
+    """Run-history version token (``count:latest_run_date``) for local-cache gating.
+
+    One tiny live ``GET /runs/head`` per process (memoized by scope). Returns
+    None on any failure — endpoint missing (backend not yet deployed), network
+    error, or non-2xx — so the caller falls back to a live, uncached read. We
+    never serve possibly-stale data we couldn't verify.
+    """
+    if scope in _run_version:
+        return _run_version[scope]
+    token: str | None = None
+    try:
+        response = httpx.get(
+            f"{get_api_url()}/runs/head", headers=_auth_headers(s), timeout=TIMEOUT
+        )
+        if response.status_code == 200:
+            data = response.json()
+            token = f"{data.get('count')}:{data.get('latest_run_date')}"
+    except (httpx.HTTPError, ValueError):
+        token = None
+    _run_version[scope] = token
+    return token
+
+
 def request(endpoint: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
-    """Authenticated GET. Refreshes the access token transparently on expiry/401."""
+    """Authenticated GET. Refreshes the access token transparently on expiry/401.
+
+    Read-through the local cache (``cli.cache``) for cacheable endpoints: a hit
+    returns immediately with no network round-trip; a miss fetches live and
+    stores the result. Gated by a run-version token so a newly-synced run busts
+    the cache automatically. Bypass with ``--no-cache`` / ``STK_NO_CACHE``.
+    """
     s = _ensure_fresh(_require_session())
+    scope = s.email or "anon"
+
+    cls = cache_mod.policy(endpoint)
+    token: str | None = None
+    use_cache = cls is not None and not cache_mod.bypassed()
+    if use_cache:
+        if cls == "versioned":
+            token = get_run_version(s, scope)
+            if token is None:
+                use_cache = False  # can't verify freshness → go live, don't cache
+            elif scope not in _swept:
+                cache_mod.sweep_stale(scope, token)
+                _swept.add(scope)
+        else:  # reference
+            token = cache_mod.REFERENCE_TOKEN
+    if use_cache and token is not None:
+        hit = cache_mod.get(endpoint, params, scope, token)
+        if hit is not None:
+            return hit  # type: ignore[return-value]
+
     url = f"{get_api_url()}/{endpoint.lstrip('/')}"
     try:
         response = httpx.get(url, params=params, headers=_auth_headers(s), timeout=TIMEOUT)
@@ -146,6 +203,8 @@ def request(endpoint: str, params: dict[str, Any] | None = None) -> dict[str, An
         _exit_with_error(response)
 
     result: dict[str, Any] = response.json()
+    if use_cache and token is not None:
+        cache_mod.set(endpoint, params, scope, token, result)
     return result
 
 
@@ -173,6 +232,10 @@ def delete_request(endpoint: str, timeout: float | None = None) -> None:
 
     if response.status_code >= 400:
         _exit_with_error(response)
+
+    # A write may change reference data (version-gating only covers run data);
+    # drop this scope's local cache so the next read refetches.
+    cache_mod.invalidate_scope(s.email or "anon")
 
 
 def post_request(
@@ -217,5 +280,6 @@ def post_request(
     if response.status_code >= 400:
         _exit_with_error(response)
 
+    cache_mod.invalidate_scope(s.email or "anon")
     result: dict[str, Any] = response.json()
     return result

--- a/stk/src/cli/cache.py
+++ b/stk/src/cli/cache.py
@@ -1,0 +1,214 @@
+"""Local response cache for stk (SQLite).
+
+The CLI re-reads immutable data — your run history never changes; only the tail
+grows when a new run is synced. So instead of an arbitrary time-based TTL, this
+cache is *version-gated*: large read payloads are stored keyed by a cheap version
+token (``GET /runs/head`` → ``count:latest_run_date``). Unchanged token → serve
+from disk; changed token → a run was added/removed → the old key misses and the
+data is refetched. See ``cli.api.get_run_version`` for the token source.
+
+Stored at ``~/.config/stk/cache.db`` alongside ``config.json`` / ``session.json``.
+Everything here fails *open*: any SQLite error is swallowed and treated as a miss,
+so the cache can never break a command. Bypass entirely with ``--no-cache`` or
+``STK_NO_CACHE=1``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Literal
+
+from cli import config as config_mod
+
+CACHE_DB: Path = config_mod.CONFIG_DIR / "cache.db"
+
+
+def db_path() -> Path:
+    """Resolve where the cache DB lives.
+
+    Precedence: ``$STK_CACHE_DB`` (one-off override) → the path persisted by
+    ``stk cache path`` → the default ``~/.config/stk/cache.db``. Lets the DB be
+    parked on a synced volume (iCloud/Dropbox) to share across machines — see
+    the ``stk cache path`` warning about SQLite on sync services.
+    """
+    override = os.getenv("STK_CACHE_DB") or config_mod.get_cache_db()
+    return Path(override).expanduser() if override else CACHE_DB
+
+
+# The literal token stored on reference-class rows (no run-version link).
+REFERENCE_TOKEN = "ref"
+
+PolicyClass = Literal["versioned", "reference"]
+
+# Endpoint classification (prefixes match a full path segment).
+# Order matters: NEVER is checked before VERSIONED so "runs/head" (the token
+# endpoint itself) is never cached even though it starts with "runs".
+_NEVER_PREFIXES = ("runs/head", "plan", "auth", "sync-splits")
+_VERSIONED_PREFIXES = ("runs", "stats")
+_REFERENCE_PREFIXES = ("workouts/exercises", "workouts/templates", "me/roles", "athletes")
+
+# --no-cache flag (set from the root Typer callback in main.py).
+_no_cache = False
+
+
+def set_no_cache(value: bool) -> None:
+    global _no_cache
+    _no_cache = value
+
+
+def bypassed() -> bool:
+    """True when caching is off for this invocation (flag or env)."""
+    return _no_cache or bool(os.getenv("STK_NO_CACHE"))
+
+
+def _matches(endpoint: str, prefixes: tuple[str, ...]) -> bool:
+    e = endpoint.lstrip("/")
+    return any(e == p or e.startswith(f"{p}/") for p in prefixes)
+
+
+def policy(endpoint: str) -> PolicyClass | None:
+    """How an endpoint may be cached: version-gated, reference, or not at all."""
+    if _matches(endpoint, _NEVER_PREFIXES):
+        return None
+    if _matches(endpoint, _VERSIONED_PREFIXES):
+        return "versioned"
+    if _matches(endpoint, _REFERENCE_PREFIXES):
+        return "reference"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS cache (
+    key        TEXT PRIMARY KEY,
+    endpoint   TEXT NOT NULL,
+    scope      TEXT,
+    token      TEXT,
+    body       TEXT NOT NULL,
+    fetched_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_cache_endpoint ON cache(endpoint);
+CREATE INDEX IF NOT EXISTS idx_cache_scope    ON cache(scope);
+"""
+
+
+def _connect() -> sqlite3.Connection:
+    path = db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    # DELETE (rollback) journal, not WAL: WAL's persistent -wal/-shm sidecars
+    # sync independently on iCloud/Dropbox and can tear the DB. A single-file
+    # rollback journal is far safer when the DB lives on a synced volume, and
+    # WAL buys nothing for this tiny single-process workload.
+    conn.execute("PRAGMA journal_mode=DELETE")
+    conn.executescript(_SCHEMA)
+    return conn
+
+
+def _make_key(endpoint: str, params: dict[str, Any] | None, scope: str, token: str) -> str:
+    params_norm = json.dumps(params or {}, sort_keys=True, default=str)
+    raw = "|".join([endpoint.lstrip("/"), params_norm, scope, token])
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def get(
+    endpoint: str, params: dict[str, Any] | None, scope: str, token: str
+) -> dict[str, Any] | list[Any] | None:
+    """Return the cached body for this (endpoint, params, scope, token), or None."""
+    key = _make_key(endpoint, params, scope, token)
+    try:
+        with _connect() as conn:
+            row = conn.execute("SELECT body FROM cache WHERE key = ?", (key,)).fetchone()
+        if row is None:
+            return None
+        return json.loads(row[0])  # type: ignore[no-any-return]
+    except (sqlite3.Error, ValueError, OSError):
+        return None
+
+
+def set(
+    endpoint: str,
+    params: dict[str, Any] | None,
+    scope: str,
+    token: str,
+    body: dict[str, Any] | list[Any],
+) -> None:
+    """Store a response body. Silently no-ops on any storage error (fail-open)."""
+    key = _make_key(endpoint, params, scope, token)
+    try:
+        with _connect() as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO cache "
+                "(key, endpoint, scope, token, body, fetched_at) VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    key,
+                    endpoint.lstrip("/"),
+                    scope,
+                    token,
+                    json.dumps(body, default=str),
+                    time.time(),
+                ),
+            )
+    except (sqlite3.Error, ValueError, OSError):
+        return
+
+
+def sweep_stale(scope: str, current_token: str) -> int:
+    """Drop version-gated rows for ``scope`` whose token isn't ``current_token``.
+
+    Reference rows (``token = 'ref'``) are preserved. Housekeeping only —
+    correctness already comes from the token being part of the key.
+    """
+    try:
+        with _connect() as conn:
+            cur = conn.execute(
+                "DELETE FROM cache WHERE scope = ? AND token NOT IN (?, ?)",
+                (scope, current_token, REFERENCE_TOKEN),
+            )
+            return cur.rowcount or 0
+    except (sqlite3.Error, OSError):
+        return 0
+
+
+def invalidate_scope(scope: str) -> int:
+    """Delete every cached row for a scope — called after a successful write."""
+    try:
+        with _connect() as conn:
+            cur = conn.execute("DELETE FROM cache WHERE scope = ?", (scope,))
+            return cur.rowcount or 0
+    except (sqlite3.Error, OSError):
+        return 0
+
+
+def clear_all() -> int:
+    try:
+        with _connect() as conn:
+            cur = conn.execute("DELETE FROM cache")
+            return cur.rowcount or 0
+    except (sqlite3.Error, OSError):
+        return 0
+
+
+def stats() -> dict[str, Any]:
+    """Summary for ``stk cache stats``: row count, db size, per-endpoint breakdown."""
+    try:
+        with _connect() as conn:
+            rows = conn.execute("SELECT COUNT(*) FROM cache").fetchone()[0]
+            by_endpoint = dict(
+                conn.execute(
+                    "SELECT endpoint, COUNT(*) FROM cache GROUP BY endpoint ORDER BY 2 DESC"
+                ).fetchall()
+            )
+        path = db_path()
+        size_bytes = path.stat().st_size if path.exists() else 0
+        return {"rows": rows, "size_bytes": size_bytes, "by_endpoint": by_endpoint}
+    except (sqlite3.Error, OSError):
+        return {"rows": 0, "size_bytes": 0, "by_endpoint": {}}

--- a/stk/src/cli/commands/cache.py
+++ b/stk/src/cli/commands/cache.py
@@ -1,0 +1,81 @@
+"""stk cache — inspect, relocate, and clear the local response cache."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from cli import cache
+from cli import config as config_mod
+
+cache_app = typer.Typer(help="Local response cache")
+console = Console()
+
+# Path fragments that mean "this lives on a file-sync service".
+_SYNC_HINTS = ("Mobile Documents", "com~apple~CloudDocs", "CloudStorage", "Dropbox", "OneDrive")
+
+
+def clear() -> None:
+    """Delete every cached response."""
+    n = cache.clear_all()
+    console.print(f"[green]Cleared {n} cached entr{'y' if n == 1 else 'ies'}.[/green]")
+
+
+def stats() -> None:
+    """Show cache size and a per-endpoint breakdown."""
+    data = cache.stats()
+    kb = data["size_bytes"] / 1024
+    console.print(f"[bold]Local response cache[/bold] — {data['rows']} rows, {kb:.1f} KB")
+    console.print(f"[dim]{cache.db_path()}[/dim]")
+    by_endpoint = data["by_endpoint"]
+    if by_endpoint:
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("Endpoint")
+        table.add_column("Rows", justify="right")
+        for endpoint, count in by_endpoint.items():
+            table.add_row(endpoint, str(count))
+        console.print(table)
+
+
+def path(
+    location: str = typer.Argument(
+        None, help="Directory or .db file for the cache. Omit to show the current path."
+    ),
+    reset: bool = typer.Option(False, "--reset", help="Revert to the default location."),
+) -> None:
+    """Show or change where the cache DB is stored.
+
+    Point it at a synced folder to share the cache across machines — but note
+    SQLite on iCloud/Dropbox can corrupt if both machines write at once. It's a
+    disposable cache (fails open and refetches), so corruption never breaks
+    stk, but don't run stk on two synced machines at the same time.
+    """
+    if reset:
+        config_mod.clear_cache_db()
+        console.print(f"[green]Cache location reset to default:[/green] {cache.CACHE_DB}")
+        return
+    if location is None:
+        console.print(f"[bold]Cache DB:[/bold] {cache.db_path()}")
+        return
+
+    p = Path(location).expanduser()
+    target = p if p.suffix == ".db" else p / "cache.db"
+    config_mod.set_cache_db(str(target))
+    console.print(f"[green]Cache will be stored at:[/green] {target}")
+    console.print(
+        "[dim]Existing entries aren't migrated; the new location rebuilds on demand.[/dim]"
+    )
+    if any(hint in str(target) for hint in _SYNC_HINTS):
+        console.print(
+            "[yellow]Heads up:[/yellow] that's a file-sync location. SQLite can corrupt if two "
+            "machines write at once — don't run stk on both simultaneously. (It fails open and "
+            "refetches, so this never breaks commands.)"
+        )
+
+
+cache_app.command(name="clear")(clear)
+cache_app.command(name="stats")(stats)
+cache_app.command(name="path")(path)

--- a/stk/src/cli/config.py
+++ b/stk/src/cli/config.py
@@ -49,3 +49,21 @@ def get_api_url_override() -> str | None:
     """Persisted API base set by ``stk auth login --env`` (None if unset)."""
     url = _load().get("api_url")
     return url if isinstance(url, str) else None
+
+
+def get_cache_db() -> str | None:
+    """Persisted local-cache DB path set by ``stk cache path`` (None = default)."""
+    path = _load().get("cache_db")
+    return path if isinstance(path, str) else None
+
+
+def set_cache_db(path: str) -> None:
+    data = _load()
+    data["cache_db"] = path
+    _save(data)
+
+
+def clear_cache_db() -> None:
+    data = _load()
+    data.pop("cache_db", None)
+    _save(data)

--- a/stk/src/cli/main.py
+++ b/stk/src/cli/main.py
@@ -17,7 +17,8 @@ import typer
 from rich.console import Console
 
 from cli import __version__
-from cli.commands import athlete, auth, invite, plan, runs, splits, stats, sync, workout
+from cli import cache as cache_lib
+from cli.commands import athlete, auth, cache, invite, plan, runs, splits, stats, sync, workout
 
 # Create the main app
 app = typer.Typer(
@@ -36,6 +37,7 @@ app.add_typer(splits.splits_app, name="splits", help="Per-mile splits")
 app.add_typer(workout.workout_app, name="workout", help="Athlete workout tracker")
 app.add_typer(invite.invite_app, name="invite", help="Invite-only onboarding (admin)")
 app.add_typer(athlete.athlete_app, name="athlete", help="Athletes you coach")
+app.add_typer(cache.cache_app, name="cache", help="Local response cache")
 
 # Console for output
 console = Console()
@@ -54,12 +56,16 @@ def main(
     version: bool = typer.Option(
         False, "--version", "-v", callback=version_callback, help="Show version"
     ),
+    no_cache: bool = typer.Option(
+        False, "--no-cache", help="Bypass the local response cache for this command"
+    ),
 ) -> None:
     """
     stk - Track your running streak from the terminal.
 
     Run without arguments to see your current streak.
     """
+    cache_lib.set_no_cache(no_cache)
     if ctx.invoked_subcommand is None:
         # Default action: show streak
         stats.streak()

--- a/stk/tests/test_cache.py
+++ b/stk/tests/test_cache.py
@@ -1,0 +1,255 @@
+"""Tests for the stk local response cache (cli.cache) and its wiring into cli.api."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+
+from cli import api, cache
+from cli import session as session_mod
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache(tmp_path, monkeypatch):  # type: ignore[no-untyped-def]
+    """Point the cache DB at a temp file and reset per-process memo state."""
+    monkeypatch.setattr(cache, "CACHE_DB", tmp_path / "cache.db")
+    monkeypatch.setattr(cache, "_no_cache", False)
+    monkeypatch.delenv("STK_NO_CACHE", raising=False)
+    # Isolate db_path() resolution from the real user config / env.
+    monkeypatch.delenv("STK_CACHE_DB", raising=False)
+    monkeypatch.setattr(cache.config_mod, "get_cache_db", lambda: None)
+    monkeypatch.setattr(api, "_run_version", {})
+    monkeypatch.setattr(api, "_swept", set())
+
+
+# ---------------------------------------------------------------------------
+# policy()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "expected"),
+    [
+        ("runs", "versioned"),
+        ("runs/recent", "versioned"),
+        ("stats/streaks", "versioned"),
+        ("stats/splits", "versioned"),
+        ("workouts/exercises", "reference"),
+        ("workouts/templates", "reference"),
+        ("workouts/templates/abc", "reference"),
+        ("me/roles", "reference"),
+        ("athletes", "reference"),
+        ("athletes/123/coaches", "reference"),
+        ("runs/head", None),
+        ("plan/2026-07", None),
+        ("auth/refresh", None),
+        ("sync-splits/status", None),
+        ("workouts/sessions", None),  # mutates independently of run token — uncached in v1
+    ],
+)
+def test_policy_classification(endpoint: str, expected: str | None) -> None:
+    assert cache.policy(endpoint) == expected
+
+
+# ---------------------------------------------------------------------------
+# storage round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_get_set_round_trip() -> None:
+    body = {"count": 2, "runs": [{"id": "a"}, {"id": "b"}]}
+    assert cache.get("runs/recent", {"limit": 10}, "me@x.com", "842:2026-07-16") is None
+    cache.set("runs/recent", {"limit": 10}, "me@x.com", "842:2026-07-16", body)
+    assert cache.get("runs/recent", {"limit": 10}, "me@x.com", "842:2026-07-16") == body
+
+
+def test_params_are_part_of_key() -> None:
+    cache.set("runs", {"offset": 0}, "me@x.com", "t", {"page": 0})
+    assert cache.get("runs", {"offset": 50}, "me@x.com", "t") is None
+
+
+def test_token_change_is_a_miss_and_sweeps_old() -> None:
+    cache.set("runs/recent", None, "me@x.com", "tokenA", {"v": "A"})
+    # New token → miss.
+    assert cache.get("runs/recent", None, "me@x.com", "tokenB") is None
+    # Old row still present until swept.
+    assert cache.get("runs/recent", None, "me@x.com", "tokenA") == {"v": "A"}
+    removed = cache.sweep_stale("me@x.com", "tokenB")
+    assert removed == 1
+    assert cache.get("runs/recent", None, "me@x.com", "tokenA") is None
+
+
+def test_sweep_preserves_reference_rows() -> None:
+    cache.set("workouts/exercises", None, "me@x.com", cache.REFERENCE_TOKEN, {"ref": True})
+    cache.set("runs", None, "me@x.com", "old", {"stale": True})
+    cache.sweep_stale("me@x.com", "current")
+    # Reference row survives; stale versioned row is gone.
+    assert cache.get("workouts/exercises", None, "me@x.com", cache.REFERENCE_TOKEN) == {"ref": True}
+    assert cache.get("runs", None, "me@x.com", "old") is None
+
+
+def test_scope_isolates_entries() -> None:
+    cache.set("runs/recent", None, "coach@x.com", "t", {"who": "coach"})
+    assert cache.get("runs/recent", None, "athlete@x.com", "t") is None
+    assert cache.get("runs/recent", None, "coach@x.com", "t") == {"who": "coach"}
+
+
+def test_invalidate_scope() -> None:
+    cache.set("runs", None, "a@x.com", "t", {"1": 1})
+    cache.set("stats/overall", None, "a@x.com", "t", {"2": 2})
+    cache.set("runs", None, "b@x.com", "t", {"3": 3})
+    removed = cache.invalidate_scope("a@x.com")
+    assert removed == 2
+    assert cache.get("runs", None, "a@x.com", "t") is None
+    assert cache.get("runs", None, "b@x.com", "t") == {"3": 3}
+
+
+def test_clear_all_and_stats() -> None:
+    cache.set("runs", None, "a@x.com", "t", {"1": 1})
+    cache.set("stats/overall", None, "a@x.com", "t", {"2": 2})
+    s = cache.stats()
+    assert s["rows"] == 2
+    assert s["by_endpoint"] == {"runs": 1, "stats/overall": 1}
+    assert cache.clear_all() == 2
+    assert cache.stats()["rows"] == 0
+
+
+# ---------------------------------------------------------------------------
+# db_path() resolution
+# ---------------------------------------------------------------------------
+
+
+def test_db_path_defaults_to_constant(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    assert cache.db_path() == cache.CACHE_DB
+
+
+def test_db_path_env_overrides_config(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(cache.config_mod, "get_cache_db", lambda: str(tmp_path / "cfg.db"))
+    monkeypatch.setenv("STK_CACHE_DB", str(tmp_path / "env.db"))
+    assert cache.db_path() == tmp_path / "env.db"
+
+
+def test_db_path_uses_config_when_no_env(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(cache.config_mod, "get_cache_db", lambda: str(tmp_path / "cfg.db"))
+    assert cache.db_path() == tmp_path / "cfg.db"
+
+
+def test_configured_path_is_where_data_lands(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    target = tmp_path / "synced" / "cache.db"
+    monkeypatch.setattr(cache.config_mod, "get_cache_db", lambda: str(target))
+    cache.set("runs", None, "me@x.com", "t", {"ok": 1})
+    assert target.exists()
+    assert cache.get("runs", None, "me@x.com", "t") == {"ok": 1}
+
+
+# ---------------------------------------------------------------------------
+# bypass
+# ---------------------------------------------------------------------------
+
+
+def test_bypassed_honors_flag_and_env(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    assert cache.bypassed() is False
+    cache.set_no_cache(True)
+    assert cache.bypassed() is True
+    cache.set_no_cache(False)
+    assert cache.bypassed() is False
+    monkeypatch.setenv("STK_NO_CACHE", "1")
+    assert cache.bypassed() is True
+
+
+# ---------------------------------------------------------------------------
+# request() integration — the first httpx-mock in this package
+# ---------------------------------------------------------------------------
+
+
+class _Resp:
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Any:
+        return self._payload
+
+
+def _install_fakes(monkeypatch, *, head_payload: Any, head_status: int = 200):  # type: ignore[no-untyped-def]
+    """Wire a fresh session, no act-as, and a counting fake httpx.get.
+
+    Returns a dict of call counters: {"head": n, "data": n}.
+    """
+    fresh = session_mod.Session(
+        access_token="a", refresh_token="r", expires_at=time.time() + 9999, email="me@x.com"
+    )
+    monkeypatch.setattr(api.session_mod, "load", lambda: fresh)
+    monkeypatch.setattr(api.config_mod, "get_active_athlete", lambda: None)
+
+    calls = {"head": 0, "data": 0}
+
+    def fake_get(url: str, **kwargs: Any) -> _Resp:
+        if url.endswith("/runs/head"):
+            calls["head"] += 1
+            return _Resp(head_status, head_payload)
+        calls["data"] += 1
+        return _Resp(200, {"count": 1, "runs": [{"id": "x"}]})
+
+    monkeypatch.setattr(api.httpx, "get", fake_get)
+    return calls
+
+
+def test_request_serves_second_call_from_cache(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls = _install_fakes(
+        monkeypatch, head_payload={"count": 842, "latest_run_date": "2026-07-16"}
+    )
+
+    first = api.request("runs/recent", {"limit": 10})
+    second = api.request("runs/recent", {"limit": 10})
+
+    assert first == second == {"count": 1, "runs": [{"id": "x"}]}
+    assert calls["data"] == 1  # second call hit the cache — no data round-trip
+    assert calls["head"] == 1  # head fetched once per process (memoized)
+
+
+def test_request_refetches_when_token_changes(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls = _install_fakes(
+        monkeypatch, head_payload={"count": 842, "latest_run_date": "2026-07-16"}
+    )
+    api.request("runs/recent", {"limit": 10})
+    assert calls["data"] == 1
+
+    # A new run lands → token advances. Reset the per-process memo (mimics a new
+    # invocation) and bump the head count.
+    monkeypatch.setattr(api, "_run_version", {})
+    monkeypatch.setattr(api, "_swept", set())
+    calls2 = _install_fakes(
+        monkeypatch, head_payload={"count": 843, "latest_run_date": "2026-07-17"}
+    )
+    api.request("runs/recent", {"limit": 10})
+    assert calls2["data"] == 1  # refetched under the new token
+
+
+def test_request_no_cache_env_always_fetches(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("STK_NO_CACHE", "1")
+    calls = _install_fakes(
+        monkeypatch, head_payload={"count": 842, "latest_run_date": "2026-07-16"}
+    )
+    api.request("runs/recent", {"limit": 10})
+    api.request("runs/recent", {"limit": 10})
+    assert calls["data"] == 2  # never cached
+    assert calls["head"] == 0  # head not even consulted when bypassed
+
+
+def test_request_fails_open_when_head_unavailable(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    # Backend without /runs/head yet → 500/404 → token None → go live, don't cache.
+    calls = _install_fakes(monkeypatch, head_payload={}, head_status=500)
+    api.request("runs/recent", {"limit": 10})
+    api.request("runs/recent", {"limit": 10})
+    assert calls["data"] == 2  # no caching without a verifiable token
+
+
+def test_reference_endpoint_cached_without_head(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls = _install_fakes(monkeypatch, head_payload={}, head_status=500)
+    api.request("workouts/exercises")
+    api.request("workouts/exercises")
+    assert calls["data"] == 1  # reference class doesn't need the run token
+    assert calls["head"] == 0


### PR DESCRIPTION
## Summary
- **stk** re-fetched immutable run history on every read. This adds a local response cache gated on a cheap **version token** instead of an arbitrary TTL — history is cached indefinitely and only refetched when a run is actually added/removed.
- **How it works:** one tiny `GET /runs/head` per invocation returns `{count, latest_run_date}`; the cache key includes that token, so an unchanged token serves from disk (no big transfer) and a changed token (new/removed run) refetches automatically. Correct under background sync, no arbitrary expiry.
- Built as reusable infra — a future `stk chat` re-assembling history/stats context every turn rides the single per-invocation token check.

### Backend (`main` repo)
- `runs_repository.get_runs_head()` → `{count, latest_run_date}`. Uses **latest run date, not `updated_at`**, so daily re-syncs that re-upsert the last 7 days don't needlessly bust the whole cache.
- `GET /runs/head` route (`@cached(ttl=60)`), registered before `/{activity_id}`.
- **Cron sync** (`jobs/sync_runs.py`) now calls `invalidate_user` like the HTTP sync path — closes a gap where a background sync left server caches stale under a freshly-advanced token.

### stk client
- `cli/cache.py` — SQLite store, key `sha256(endpoint|params|scope|token)`, **fails open** on any error (never breaks a command). DELETE journal (not WAL) for file-sync safety.
- `cli/api.py` — `get_run_version()` (one memoized `/runs/head` per process); read-through in `request()`; write-invalidation in `post`/`delete`. Scope = **logged-in identity** (runs/stats ignore act-as).
- **Configurable location:** `STK_CACHE_DB` env → `stk cache path <dir|file>` → default `~/.config/stk/cache.db`. Can live on a synced volume (with an iCloud/Dropbox corruption caveat printed on set).
- `--no-cache` / `STK_NO_CACHE` bypass; `stk cache clear|stats|path` command group.
- `workouts/sessions` deliberately left uncached — it mutates via act-as writes independently of the run token.

## Deployment note
Safe to merge as one PR: stk fails open, so it simply won't cache run data until `/runs/head` is live (same backend deploy). Order doesn't matter for safety.

## Test plan
- [x] stk: 41 tests pass (30 new cache/api), ruff + format clean, new files mypy-clean
- [x] backend: `/runs/head` route tests + 18 related run/sync/cache tests pass; ruff clean
- [x] CLI smoke: `--no-cache` flag, `cache clear|stats|path`, iCloud warning, `--reset`
- [ ] Live end-to-end (needs backend deployed with `/runs/head` + a login): `time stk runs recent` cold vs warm; add a run → token advances → auto-refetch; `stk --no-cache runs recent` always live

🤖 Generated with [Claude Code](https://claude.com/claude-code)