### PR TITLE
feat: /stk chat skill — on-this-day, fun stats, hype (SB-274)

### DIFF
--- a/.claude/skills/stk/SKILL.md
+++ b/.claude/skills/stk/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: stk
+description: >-
+  Chat with the user's running-streak data (4,300+ day streak) via the `stk`
+  CLI — nostalgia, trivia, and hype. Use when the user wants their streak
+  status ("how's my streak", "streak check"), on-this-day nostalgia ("on this
+  day", "what did I run a year ago today"), fun stats ("fun stat", "hottest
+  run ever", "surprise me"), motivation ("hype me", "motivate me"), or a
+  daily briefing ("morning briefing", "stk briefing"). The API owns every
+  number; this skill only narrates — it never computes or invents stats.
+---
+
+# stk — chat with your streak
+
+Turn `stk --json` output into fun, motivating conversation about a 4,300+ day
+running streak. Four moves: **on-this-day** nostalgia, **fun stats**,
+**hype**, and a composite **daily briefing**. The streak is the product — every
+message should make tomorrow's run feel inevitable.
+
+## The one rule
+
+> **The API owns every number. You only narrate them.**
+
+Never aggregate runs yourself — no summing distances, no averaging paces, no
+counting matches. If you're tempted to do arithmetic over a list of runs, stop:
+`stk summary` with the right filter *is* that arithmetic. Two things are yours:
+
+- **Unit conversion**: km→mi, °C→°F, min/km→min/mi pace (see Units).
+- **Calendar math**: today's MM-DD, "day X of the streak", days until the next
+  round-number milestone (from the API's `current_streak`).
+
+Landmark color ("that's 3 Everests", "a quarter of the way around the earth")
+is welcome — as narration wrapped around an API number, never as a new number
+presented as data.
+
+## Prerequisite
+
+`stk` on PATH and logged in (`stk auth status`; if not, `stk auth login`).
+Always pass `--json` and parse — never scrape the human tables. All these reads
+are backed by a local SQLite response cache gated on the run-version token, so
+repeated calls in one chat cost nothing.
+
+## Units: store km, speak miles
+
+API is canonical **km / °C / min-per-km**; the runner thinks in
+**miles / °F / min-per-mile**:
+
+- `miles = km × 0.621371` (1 decimal)
+- `°F = °C × 9/5 + 32` (whole degrees)
+- `pace min/mi = (min/km) ÷ 0.621371`, shown `M:SS`
+
+Filter flags going *in* are km/°C too — convert the user's "over 80°F" to
+`--temp-min 26.7` before calling.
+
+## Data cookbook
+
+| Want | Call |
+|---|---|
+| Streak status (current, longest, km) | `stk streak --json` |
+| Lifetime totals | `stk stats --json` |
+| Personal records (longest, fastest, best week/month) | `stk records --json` |
+| On this day, every year | `stk runs --on-this-day today --order asc --json` |
+| On-this-day aggregate | `stk summary --on-this-day today --json` |
+| Hottest / coldest runs ever | `stk runs --sort temperature --order desc\|asc --limit 5 --json` |
+| Pre-dawn runs | `stk runs --hour-max 5 --limit 10 --json` (start hour is local) |
+| Conditions impact ("rainy runs slower?") | `stk summary --weather rainy --json` |
+| Monthly volume/pace trend | `stk monthly --json` |
+| Goal progress (year + month) | `stk goals --json` (`--history` for past periods) |
+| Negative-split rate, fade | `stk splits show --json` |
+| A specific era | `stk runs --date-from 2014-01-01 --date-to 2014-12-31 --limit 366 --json` |
+| Recent runs | `stk recent --json` |
+
+Filter notes:
+
+- `--weather` must be one of `sunny cloudy rainy snowy windy hot cold`
+  (Postgres enum — anything else errors).
+- `--pace-min` = slower bound, `--pace-max` = faster bound, both min/km.
+- `--limit` caps at 366. Full history = pagination (see Cache warming).
+- `summary` responses carry `avg_pace_min_per_km` **and**
+  `overall_avg_pace_min_per_km` — quote the comparison, it's the fun part.
+
+## The four features
+
+### 1. On this day
+
+`stk runs --on-this-day today --order asc --json` → one run per year of the
+streak (the year is in each run's `date`). Walk the years chronologically,
+call out that date's extremes (longest, fastest, hottest — read from the rows,
+don't compute ranks beyond picking the obvious max/min of what's displayed),
+and close with the anniversary framing:
+
+> "July 18th, thirteen years running — literally. 2014: 5.1 miles. 2018 was
+> the big one, 6.9. Today's 1.9 in 84° heat makes 13-for-13 on this date."
+
+### 2. Fun stats / trivia
+
+Rotate angles — never repeat one in a session:
+
+- **Milestone proximity**: `current_streak` from `stk streak` → "day 4,347 —
+  653 from 5,000". Round total-mile numbers from `stk stats`. Careful:
+  `current_streak` (days) ≠ `total_runs` from `stk stats` (includes
+  pre-streak runs) — never conflate them.
+- **Temperature extremes**: `--sort temperature` both directions; convert to °F.
+- **Pre-dawn club**: `--hour-max 5` → total count of before-6am runs.
+- **Conditions impact**: `stk summary --weather rainy` → "300 rainy runs,
+  23s/mi slower than your overall — rain costs you 23 seconds a mile."
+- **Best-month lore**: `stk records` `most_km_month` + `stk monthly` context.
+- **Era contrast**: `stk summary --date-from/--date-to` for 2014 vs this year.
+- **Negative splits**: `stk splits show --json` summary block.
+
+### 3. Motivate / hype
+
+Hype must hang on a real number. Pick the voice from the data:
+
+| Data state | Voice |
+|---|---|
+| Round or near-round streak day | Celebrate loudly. "Day 4,800. Most people's streaks die at 3." |
+| Ordinary day | Find one concrete recent win in `stk recent` (a quick pace, a hot-day grind, consistency itself) and name it. |
+| Goal `percent` climbing (`stk goals`) | Project confidence: "62% of the year's 1,200 by mid-July — ahead of the calendar." |
+| Goal behind | Honest + forward: quote the real gap, frame the daily chunk as small. Never fake-cheerful, never invent a catch-up plan — that's the `plan` skill's engine. |
+| Rough conditions today (heat, rain) | Armor framing: quote their record in worse (`--sort temperature`, `--weather`). "You've run in 90°. This is nothing." |
+
+### 4. Daily briefing
+
+Composite, in this order, kept tight:
+
+1. Streak day count (`stk streak`)
+2. One on-this-day highlight (`stk runs --on-this-day today`)
+3. Goal progress one-liner (`stk goals`)
+4. Today's prescription — hand off to the **plan** skill (`stk plan show
+   --json`); don't restate its coaching logic here
+5. One line of hype
+
+## Message shape
+
+Lead with where they stand, one concrete detail, end with the streak or the
+win. Short — a runner reads this between waking up and lacing up. Emoji
+sparingly (🔥 for the streak earns its place; confetti walls don't).
+
+## Cache warming (optional)
+
+First deep-history question in a fresh cache? Pre-warm all pages:
+
+```bash
+for o in $(seq 0 366 4770); do stk runs --offset $o --limit 366 --json >/dev/null; done
+```
+
+~14 pages, then every full-history angle is served from disk. The cache
+invalidates itself when a new run syncs (version token) — never worry about
+staleness.
+
+## Distribution
+
+This skill is version-controlled with the project at `.claude/skills/stk/`. To
+use it outside this repo, copy or symlink it into `~/.claude/skills/stk/`
+(same as `linear-crud` / `todo`). It needs only the `stk` CLI — no extra deps.

--- a/stk/src/cli/commands/runs.py
+++ b/stk/src/cli/commands/runs.py
@@ -1,8 +1,25 @@
 """Runs commands for stk CLI."""
 
+from datetime import datetime
+from typing import Any
+
 import typer
 
 from cli import api, display
+
+
+def _filter_params(**kwargs: Any) -> dict[str, Any]:
+    """Drop None-valued params before hitting the API.
+
+    httpx serializes ``None`` query values as empty strings, which FastAPI's
+    typed params reject with a 422 — and None-laden dicts would also pollute
+    the local cache keys (params are part of the key). Also resolves the
+    ``--on-this-day today`` shorthand to the current MM-DD client-side, so the
+    cache key stays stable for the whole day.
+    """
+    if kwargs.get("on_this_day") == "today":
+        kwargs["on_this_day"] = datetime.now().strftime("%m-%d")
+    return {k: v for k, v in kwargs.items() if v is not None}
 
 
 def recent(
@@ -22,11 +39,55 @@ def recent(
 
 def list_runs(
     offset: int = typer.Option(0, "--offset", "-o", help="Pagination offset"),
-    limit: int = typer.Option(50, "--limit", "-n", help="Number of runs"),
+    limit: int = typer.Option(50, "--limit", "-n", help="Number of runs (max 366)"),
+    on_this_day: str | None = typer.Option(
+        None, "--on-this-day", help='MM-DD across all years, or "today"'
+    ),
+    date_from: str | None = typer.Option(
+        None, "--date-from", help="Runs on/after this date (YYYY-MM-DD)"
+    ),
+    date_to: str | None = typer.Option(
+        None, "--date-to", help="Runs on/before this date (YYYY-MM-DD)"
+    ),
+    distance_min: float | None = typer.Option(None, "--distance-min", help="Min distance (km)"),
+    distance_max: float | None = typer.Option(None, "--distance-max", help="Max distance (km)"),
+    weather: str | None = typer.Option(
+        None, "--weather", help="One of: sunny, cloudy, rainy, snowy, windy, hot, cold"
+    ),
+    temp_min: float | None = typer.Option(None, "--temp-min", help="Min temperature (°C)"),
+    temp_max: float | None = typer.Option(None, "--temp-max", help="Max temperature (°C)"),
+    pace_min: float | None = typer.Option(
+        None, "--pace-min", help="Slower pace bound (min/km — larger number = slower)"
+    ),
+    pace_max: float | None = typer.Option(
+        None, "--pace-max", help="Faster pace bound (min/km — smaller number = faster)"
+    ),
+    hour_min: int | None = typer.Option(None, "--hour-min", help="Earliest start hour (0-23)"),
+    hour_max: int | None = typer.Option(None, "--hour-max", help="Latest start hour (0-23)"),
+    sort: str = typer.Option("date", "--sort", help="date|distance|pace|temperature"),
+    order: str = typer.Option("desc", "--order", help="asc|desc"),
     json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
 ) -> None:
-    """List all runs with pagination."""
-    data = api.request("runs", {"offset": offset, "limit": limit})
+    """List runs with pagination, filters, and sorting."""
+    params = _filter_params(
+        offset=offset,
+        limit=limit,
+        on_this_day=on_this_day,
+        date_from=date_from,
+        date_to=date_to,
+        distance_min=distance_min,
+        distance_max=distance_max,
+        weather_type=weather,
+        temp_min=temp_min,
+        temp_max=temp_max,
+        pace_min=pace_min,
+        pace_max=pace_max,
+        hour_min=hour_min,
+        hour_max=hour_max,
+        sort=sort,
+        order=order,
+    )
+    data = api.request("runs", params)
 
     if json_output:
         import json
@@ -37,3 +98,55 @@ def list_runs(
         count = data.get("count", 0)
         display.display_info(f"Showing {offset + 1}-{offset + count} of {total}")
         display.display_recent_runs(data)
+
+
+def summary(
+    on_this_day: str | None = typer.Option(
+        None, "--on-this-day", help='MM-DD across all years, or "today"'
+    ),
+    date_from: str | None = typer.Option(
+        None, "--date-from", help="Runs on/after this date (YYYY-MM-DD)"
+    ),
+    date_to: str | None = typer.Option(
+        None, "--date-to", help="Runs on/before this date (YYYY-MM-DD)"
+    ),
+    distance_min: float | None = typer.Option(None, "--distance-min", help="Min distance (km)"),
+    distance_max: float | None = typer.Option(None, "--distance-max", help="Max distance (km)"),
+    weather: str | None = typer.Option(
+        None, "--weather", help="One of: sunny, cloudy, rainy, snowy, windy, hot, cold"
+    ),
+    temp_min: float | None = typer.Option(None, "--temp-min", help="Min temperature (°C)"),
+    temp_max: float | None = typer.Option(None, "--temp-max", help="Max temperature (°C)"),
+    pace_min: float | None = typer.Option(
+        None, "--pace-min", help="Slower pace bound (min/km — larger number = slower)"
+    ),
+    pace_max: float | None = typer.Option(
+        None, "--pace-max", help="Faster pace bound (min/km — smaller number = faster)"
+    ),
+    hour_min: int | None = typer.Option(None, "--hour-min", help="Earliest start hour (0-23)"),
+    hour_max: int | None = typer.Option(None, "--hour-max", help="Latest start hour (0-23)"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
+) -> None:
+    """Aggregate stats for a filtered set of runs, compared against overall."""
+    params = _filter_params(
+        on_this_day=on_this_day,
+        date_from=date_from,
+        date_to=date_to,
+        distance_min=distance_min,
+        distance_max=distance_max,
+        weather_type=weather,
+        temp_min=temp_min,
+        temp_max=temp_max,
+        pace_min=pace_min,
+        pace_max=pace_max,
+        hour_min=hour_min,
+        hour_max=hour_max,
+    )
+    data = api.request("runs/summary", params)
+
+    if json_output:
+        import json
+
+        print(json.dumps(data, indent=2))
+    else:
+        display.display_summary(data)

--- a/stk/src/cli/commands/stats.py
+++ b/stk/src/cli/commands/stats.py
@@ -60,3 +60,22 @@ def monthly(
         print(json.dumps(data, indent=2))
     else:
         display.display_monthly_stats(data)
+
+
+def goals(
+    history: bool = typer.Option(
+        False, "--history", help="All past goal periods (target vs achieved)"
+    ),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
+) -> None:
+    """Show distance-goal progress (current year + month, or full history)."""
+    data = api.request("stats/goals/history" if history else "stats/goals")
+
+    if json_output:
+        import json
+
+        print(json.dumps(data, indent=2))
+    elif history:
+        display.display_goal_history(data)
+    else:
+        display.display_goals(data)

--- a/stk/src/cli/display.py
+++ b/stk/src/cli/display.py
@@ -290,6 +290,83 @@ def display_records(data: dict[str, Any]) -> None:
     console.print(table)
 
 
+def display_summary(data: dict[str, Any]) -> None:
+    """Display a filtered-runs aggregate vs overall (the conditions-impact readout)."""
+    count = data.get("count", 0)
+    total_miles = km_to_miles(data.get("total_km", 0))
+
+    table = Table(title=f"Run Summary ({count} runs)", show_header=True, border_style="cyan")
+    table.add_column("Metric", style="cyan")
+    table.add_column("Value", justify="right", style="green")
+
+    table.add_row("Runs", str(count))
+    table.add_row("Total", f"{total_miles:.1f} mi")
+
+    pace = data.get("avg_pace_min_per_km")
+    overall = data.get("overall_avg_pace_min_per_km")
+    if pace is not None:
+        table.add_row("Avg Pace", f"{format_pace(pace)} /mi")
+    if pace is not None and overall is not None:
+        # Delta in sec/mi — the arithmetic lives here, not in any narration layer.
+        delta_sec = round((pace - overall) / KM_TO_MILES * 60)
+        vs = f"{abs(delta_sec)}s/mi {'slower' if delta_sec > 0 else 'faster'} than overall"
+        table.add_row("vs Overall", f"{format_pace(overall)} /mi ({vs})")
+
+    console.print(table)
+
+
+def _goal_row(table: Table, label: str, goal: dict[str, Any] | None) -> None:
+    """Add one GoalProgress payload (already in miles) to a goals table."""
+    if goal is None:
+        table.add_row(label, "-", "-", "[dim]no goal set[/dim]")
+        return
+    pct = goal.get("percent")
+    table.add_row(
+        label,
+        f"{goal.get('goal_mi', 0):.0f} mi",
+        f"{goal.get('progress_mi', 0):.1f} mi",
+        f"{pct:.1f}%" if pct is not None else "-",
+    )
+
+
+def display_goals(data: dict[str, Any]) -> None:
+    """Display current-year and current-month goal progress."""
+    table = Table(title="Distance Goals", show_header=True, border_style="cyan")
+    table.add_column("Period", style="cyan")
+    table.add_column("Target", justify="right")
+    table.add_column("Progress", justify="right", style="green")
+    table.add_column("%", justify="right", style="yellow")
+
+    _goal_row(table, "Year", data.get("yearly"))
+    _goal_row(table, "Month", data.get("monthly"))
+    console.print(table)
+
+
+def display_goal_history(data: list[dict[str, Any]]) -> None:
+    """Display every goal period: target vs achieved, hit/miss."""
+    table = Table(title="Goal History", show_header=True, border_style="cyan")
+    table.add_column("Period", style="cyan")
+    table.add_column("Target", justify="right")
+    table.add_column("Achieved", justify="right", style="green")
+    table.add_column("%", justify="right", style="yellow")
+    table.add_column("Hit", justify="center")
+
+    for goal in data:
+        year = goal.get("year", "")
+        month = goal.get("month")
+        period = f"{year}" if month is None else f"{year}-{int(month):02d}"
+        pct = goal.get("percent")
+        table.add_row(
+            period,
+            f"{goal.get('goal_mi', 0):.0f} mi",
+            f"{goal.get('progress_mi', 0):.1f} mi",
+            f"{pct:.1f}%" if pct is not None else "-",
+            "[green]✓[/green]" if goal.get("hit") else "[red]✗[/red]",
+        )
+
+    console.print(table)
+
+
 def display_sync_progress(message: str, done: bool = False) -> None:
     """Display sync progress message."""
     if done:

--- a/stk/src/cli/main.py
+++ b/stk/src/cli/main.py
@@ -9,6 +9,9 @@ Usage:
     stk stats            # Overall statistics
     stk recent           # Recent runs
     stk records          # Personal records
+    stk runs             # List runs (filters: --on-this-day, --weather, --sort, ...)
+    stk summary          # Aggregate of a filtered set vs overall
+    stk goals            # Distance-goal progress
     stk sync             # Sync runs from SmashRun
     stk auth login       # Authenticate with SmashRun
 """
@@ -78,6 +81,8 @@ app.command(name="recent")(runs.recent)
 app.command(name="records")(stats.records)
 app.command(name="monthly")(stats.monthly)
 app.command(name="runs")(runs.list_runs)
+app.command(name="summary")(runs.summary)
+app.command(name="goals")(stats.goals)
 app.command(name="sync")(sync.sync_runs)
 
 

--- a/stk/tests/test_runs_filters.py
+++ b/stk/tests/test_runs_filters.py
@@ -1,0 +1,171 @@
+"""Tests for the stk runs filter flags, `stk summary`, and `stk goals` (SB-274)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from cli.commands import runs as runs_cmd
+from cli.main import app
+
+runner = CliRunner()
+
+
+@pytest.fixture()
+def captured(monkeypatch):  # type: ignore[no-untyped-def]
+    """Capture (endpoint, params) sent by any command; return canned bodies."""
+    calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    def fake_request(endpoint: str, params: dict[str, Any] | None = None) -> Any:
+        calls.append((endpoint, params))
+        if endpoint == "runs":
+            return {"total": 0, "offset": 0, "limit": 50, "count": 0, "runs": []}
+        if endpoint == "runs/summary":
+            return {
+                "count": 3,
+                "total_km": 10.0,
+                "avg_pace_min_per_km": 6.5,
+                "overall_avg_pace_min_per_km": 6.2,
+            }
+        if endpoint == "stats/goals":
+            return {"yearly": None, "monthly": None}
+        if endpoint == "stats/goals/history":
+            return []
+        return {}
+
+    monkeypatch.setattr("cli.commands.runs.api.request", fake_request)
+    monkeypatch.setattr("cli.commands.stats.api.request", fake_request)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# _filter_params
+# ---------------------------------------------------------------------------
+
+
+def test_filter_params_drops_nones() -> None:
+    assert runs_cmd._filter_params(a=1, b=None, c="x") == {"a": 1, "c": "x"}
+
+
+def test_filter_params_resolves_today() -> None:
+    params = runs_cmd._filter_params(on_this_day="today")
+    assert params["on_this_day"] == datetime.now().strftime("%m-%d")
+
+
+def test_filter_params_keeps_explicit_mm_dd() -> None:
+    assert runs_cmd._filter_params(on_this_day="07-04") == {"on_this_day": "07-04"}
+
+
+# ---------------------------------------------------------------------------
+# stk runs
+# ---------------------------------------------------------------------------
+
+
+def test_runs_default_params_have_no_none_keys(captured) -> None:  # type: ignore[no-untyped-def]
+    result = runner.invoke(app, ["runs", "--json"])
+    assert result.exit_code == 0
+    endpoint, params = captured[0]
+    assert endpoint == "runs"
+    assert params == {"offset": 0, "limit": 50, "sort": "date", "order": "desc"}
+    assert None not in params.values()
+
+
+def test_runs_filters_sent_exactly(captured) -> None:  # type: ignore[no-untyped-def]
+    result = runner.invoke(
+        app,
+        [
+            "runs",
+            "--on-this-day",
+            "07-18",
+            "--sort",
+            "temperature",
+            "--order",
+            "asc",
+            "--hour-max",
+            "5",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0
+    _, params = captured[0]
+    assert params == {
+        "offset": 0,
+        "limit": 50,
+        "on_this_day": "07-18",
+        "hour_max": 5,
+        "sort": "temperature",
+        "order": "asc",
+    }
+
+
+def test_runs_weather_flag_maps_to_weather_type(captured) -> None:  # type: ignore[no-untyped-def]
+    result = runner.invoke(app, ["runs", "--weather", "rain", "--json"])
+    assert result.exit_code == 0
+    _, params = captured[0]
+    assert params["weather_type"] == "rain"
+    assert "weather" not in params
+
+
+def test_runs_on_this_day_today_resolves(captured) -> None:  # type: ignore[no-untyped-def]
+    result = runner.invoke(app, ["runs", "--on-this-day", "today", "--json"])
+    assert result.exit_code == 0
+    _, params = captured[0]
+    assert params["on_this_day"] == datetime.now().strftime("%m-%d")
+
+
+# ---------------------------------------------------------------------------
+# stk summary
+# ---------------------------------------------------------------------------
+
+
+def test_summary_no_flags_sends_empty_params(captured) -> None:  # type: ignore[no-untyped-def]
+    result = runner.invoke(app, ["summary", "--json"])
+    assert result.exit_code == 0
+    endpoint, params = captured[0]
+    assert endpoint == "runs/summary"
+    assert params == {}
+
+
+def test_summary_sends_only_given_filters(captured) -> None:  # type: ignore[no-untyped-def]
+    result = runner.invoke(app, ["summary", "--weather", "rain", "--temp-min", "25", "--json"])
+    assert result.exit_code == 0
+    _, params = captured[0]
+    assert params == {"weather_type": "rain", "temp_min": 25.0}
+
+
+def test_summary_table_renders(captured) -> None:  # type: ignore[no-untyped-def]
+    result = runner.invoke(app, ["summary"])
+    assert result.exit_code == 0
+    assert "Run Summary" in result.output
+    # 6.5 vs 6.2 min/km → slower than overall
+    assert "slower" in result.output
+
+
+# ---------------------------------------------------------------------------
+# stk goals
+# ---------------------------------------------------------------------------
+
+
+def test_goals_hits_stats_goals(captured) -> None:  # type: ignore[no-untyped-def]
+    result = runner.invoke(app, ["goals", "--json"])
+    assert result.exit_code == 0
+    endpoint, params = captured[0]
+    assert endpoint == "stats/goals"
+    assert params is None
+
+
+def test_goals_history_hits_history_endpoint(captured) -> None:  # type: ignore[no-untyped-def]
+    result = runner.invoke(app, ["goals", "--history", "--json"])
+    assert result.exit_code == 0
+    endpoint, _ = captured[0]
+    assert endpoint == "stats/goals/history"
+
+
+def test_goals_table_renders_no_goal(captured) -> None:  # type: ignore[no-untyped-def]
+    result = runner.invoke(app, ["goals"])
+    assert result.exit_code == 0
+    assert "Distance Goals" in result.output
+    assert "no goal set" in result.output


### PR DESCRIPTION
## Summary
- New `/stk` Claude Code skill (`.claude/skills/stk/SKILL.md`): chat with the streak — on-this-day nostalgia, fun stats/trivia, motivation/hype, daily briefing. Modeled on `plan`/`log-workout`; API owns every number, skill only narrates.
- stk CLI extensions powering it (zero backend changes — endpoints already existed):
  - `stk runs` filter flags: `--on-this-day` (MM-DD or `today`), `--date-from/to`, `--distance-min/max`, `--weather`, `--temp-min/max`, `--pace-min/max`, `--hour-min/max`, `--sort`, `--order`
  - `stk summary` → `GET /runs/summary` (filtered vs overall pace, sec/mi delta)
  - `stk goals [--history]` → `GET /stats/goals[/history]`
  - `_filter_params()` strips None params (httpx None → empty string → 422; None keys would pollute local cache keys)
- All new reads auto-cached by the version-gated response cache (#165); `--on-this-day today` resolves client-side for a stable per-day cache key.
- Found & filed SB-275: 500 on invalid `weather_type` (Postgres enum cast unhandled).

## Test plan
- [x] `uv run pytest` — 54 pass (13 new: filter passthrough, no-None guarantee, today resolution, weather→weather_type mapping, endpoints, display smoke)
- [x] Live: `stk runs --on-this-day 07-18 --order asc` → 13 runs, one per year 2014–2026
- [x] Live: `stk summary --weather rainy` → 300 runs, 23s/mi slower than overall
- [x] Live: `stk goals` / `--history`, `--hour-max 5`, `--sort temperature`
- [x] Skill loads in-session; cache rows written for all new param combos

Fixes SB-274

🤖 Generated with [Claude Code](https://claude.com/claude-code)