### PR TITLE
feat: stk CLI UX overhaul — dashboard, help panels, richer tables (SB-276)

### DIFF
--- a/stk/src/cli/commands/stats.py
+++ b/stk/src/cli/commands/stats.py
@@ -1,8 +1,36 @@
 """Stats commands for stk CLI."""
 
+from datetime import datetime
+from typing import Any
+
 import typer
 
 from cli import api, display
+
+
+def dashboard() -> None:
+    """One-screen morning glance (the bare ``stk`` default).
+
+    Streak is required; goals / last run / on-this-day are progressive
+    enhancement — a failing optional read (older backend, transient error)
+    degrades to a sparser dashboard instead of killing the command. All four
+    reads are version-cached, so the repeat cost is zero.
+    """
+    streak_data = api.request("stats/streaks")
+
+    def _try(endpoint: str, params: dict[str, Any] | None = None) -> Any:
+        try:
+            return api.request(endpoint, params)
+        except SystemExit:  # api.request exits on HTTP/network errors
+            return None
+
+    goals_data = _try("stats/goals")
+    recent = _try("runs/recent", {"limit": 1})
+    otd = _try("runs", {"on_this_day": datetime.now().strftime("%m-%d"), "limit": 1, "offset": 0})
+
+    last_run = (recent or {}).get("runs", [None])[0] if recent else None
+    otd_count = (otd or {}).get("total") if otd else None
+    display.display_dashboard(streak_data, goals_data, last_run, otd_count)
 
 
 def streak(

--- a/stk/src/cli/display.py
+++ b/stk/src/cli/display.py
@@ -1,5 +1,6 @@
 """Display utilities for stk CLI with Rich formatting."""
 
+from datetime import date, datetime
 from typing import Any
 
 from rich.console import Console
@@ -10,6 +11,49 @@ console = Console()
 
 # Conversion factors
 KM_TO_MILES = 0.621371
+
+WEATHER_EMOJI = {
+    "sunny": "☀️",
+    "cloudy": "☁️",
+    "rainy": "🌧️",
+    "snowy": "❄️",
+    "windy": "💨",
+    "hot": "🥵",
+    "cold": "🥶",
+}
+
+_WEEKDAYS = ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+
+
+def _friendly_date(iso: str) -> str:
+    """'2026-07-18T13:33:00+00:00' → 'Sat today' / 'Fri yesterday' / 'Sun 7/13'."""
+    try:
+        d = datetime.fromisoformat(iso).date()
+    except ValueError:
+        return iso[:10]
+    day = _WEEKDAYS[d.weekday()]
+    delta = (date.today() - d).days
+    if delta == 0:
+        return f"{day} [bold green]today[/bold green]"
+    if delta == 1:
+        return f"{day} [green]yesterday[/green]"
+    return f"{day} {d.month}/{d.day}"
+
+
+def _bar(value: float, max_value: float, width: int = 8, char: str = "▉") -> str:
+    """Scale value to a bar of up to `width` chars (at least 1 for non-zero)."""
+    if max_value <= 0 or value <= 0:
+        return ""
+    n = max(1, round(value / max_value * width))
+    return char * n
+
+
+def _progress_bar(percent: float | None, width: int = 16) -> str:
+    """▓▓▓▓░░░░ progress bar for a 0-100+ percent (capped at full)."""
+    if percent is None:
+        return "░" * width
+    filled = min(width, round(percent / 100 * width))
+    return "▓" * filled + "░" * (width - filled)
 
 
 def km_to_miles(km: float) -> float:
@@ -170,7 +214,7 @@ def display_overall_stats(data: dict[str, Any]) -> None:
 
 
 def display_recent_runs(data: dict[str, Any]) -> None:
-    """Display recent runs in a table."""
+    """Display runs in a table: friendly dates, distance bars, weather, totals."""
     runs = data.get("runs", [])
 
     table = Table(
@@ -180,45 +224,76 @@ def display_recent_runs(data: dict[str, Any]) -> None:
     )
     table.add_column("Date", style="cyan")
     table.add_column("Distance", justify="right", style="green")
+    table.add_column("", justify="left", style="green")  # distance bar
     table.add_column("Time", justify="right")
     table.add_column("Pace", justify="right", style="yellow")
     table.add_column("HR", justify="right", style="red")
     table.add_column("Temp", justify="right", style="blue")
 
+    max_km = max((r.get("distance_km") or 0 for r in runs), default=0)
+    paces = [r["avg_pace_min_per_km"] for r in runs if r.get("avg_pace_min_per_km")]
+    fastest = min(paces, default=None)
+
+    total_km = 0.0
+    total_minutes = 0.0
     for run in runs:
-        distance_miles = km_to_miles(run.get("distance_km", 0))
-        pace = format_pace(run.get("avg_pace_min_per_km", 0))
+        km = run.get("distance_km", 0)
+        distance_miles = km_to_miles(km)
         duration = run.get("duration_minutes", 0)
         hr = run.get("heart_rate_avg")
         temp_c = run.get("temperature_celsius")
+        total_km += km or 0
+        total_minutes += duration or 0
 
         # Format duration
         hours = int(duration // 60)
         mins = int(duration % 60)
-        if hours > 0:
-            time_str = f"{hours}h {mins}m"
-        else:
-            time_str = f"{mins}m"
+        time_str = f"{hours}h {mins}m" if hours > 0 else f"{mins}m"
+
+        # Highlight the fastest pace in the window
+        raw_pace = run.get("avg_pace_min_per_km")
+        pace = format_pace(raw_pace or 0)
+        if raw_pace is not None and raw_pace == fastest and len(paces) > 1:
+            pace = f"[bold bright_green]{pace} ⚡[/bold bright_green]"
 
         # Format optional fields
         hr_str = str(int(hr)) if hr else "-"
-        temp_str = f"{int(celsius_to_fahrenheit(temp_c))}°" if temp_c else "-"
+        weather = WEATHER_EMOJI.get(run.get("weather") or "", "")
+        temp_str = (
+            f"{weather} {int(celsius_to_fahrenheit(temp_c))}°".strip() if temp_c else weather or "-"
+        )
 
         table.add_row(
-            run.get("date", "")[:10],
+            _friendly_date(run.get("date", "")),
             f"{distance_miles:.2f} mi",
+            _bar(km or 0, max_km),
             time_str,
             pace,
             hr_str,
             temp_str,
         )
 
+    # Totals footer for the shown window (display-layer arithmetic only)
+    if len(runs) > 1:
+        hours = int(total_minutes // 60)
+        mins = int(total_minutes % 60)
+        table.add_section()
+        table.add_row(
+            f"[bold]{len(runs)} runs[/bold]",
+            f"[bold]{km_to_miles(total_km):.1f} mi[/bold]",
+            "",
+            f"[bold]{hours}h {mins}m[/bold]" if hours else f"[bold]{mins}m[/bold]",
+            "",
+            "",
+            "",
+        )
+
     console.print(table)
 
 
 def display_monthly_stats(data: dict[str, Any]) -> None:
-    """Display monthly statistics."""
-    months = data.get("months", [])
+    """Display monthly statistics with a mileage trend bar, oldest month first."""
+    months = list(reversed(data.get("months", [])))
 
     table = Table(
         title=f"Monthly Stats ({data.get('count', len(months))} months)",
@@ -228,11 +303,14 @@ def display_monthly_stats(data: dict[str, Any]) -> None:
     table.add_column("Month", style="cyan")
     table.add_column("Runs", justify="right", style="green")
     table.add_column("Total", justify="right")
+    table.add_column("Trend", justify="left", style="magenta")
     table.add_column("Avg", justify="right")
     table.add_column("Pace", justify="right", style="yellow")
 
+    max_km = max((m.get("total_km") or 0 for m in months), default=0)
     for month in months:
-        total_miles = km_to_miles(month.get("total_km", 0))
+        total_km = month.get("total_km", 0)
+        total_miles = km_to_miles(total_km)
         avg_miles = km_to_miles(month.get("avg_km", 0))
         pace = format_pace(month.get("avg_pace_min_per_km", 0))
 
@@ -240,6 +318,7 @@ def display_monthly_stats(data: dict[str, Any]) -> None:
             month.get("month", "")[:7],
             str(month.get("run_count", 0)),
             f"{total_miles:.1f} mi",
+            _bar(total_km or 0, max_km, width=14),
             f"{avg_miles:.2f} mi",
             pace,
         )
@@ -315,17 +394,40 @@ def display_summary(data: dict[str, Any]) -> None:
     console.print(table)
 
 
-def _goal_row(table: Table, label: str, goal: dict[str, Any] | None) -> None:
+def _calendar_percent(period: str, today: date) -> float:
+    """How far through the period the calendar is, 0-100."""
+    if period == "year":
+        year_days = (date(today.year + 1, 1, 1) - date(today.year, 1, 1)).days
+        return today.timetuple().tm_yday / year_days * 100
+    # month
+    next_month = date(today.year + (today.month == 12), today.month % 12 + 1, 1)
+    month_days = (next_month - date(today.year, today.month, 1)).days
+    return today.day / month_days * 100
+
+
+def _vs_calendar(pct: float | None, period: str) -> str:
+    """▲/▼ marker: goal percent vs how far through the period the calendar is."""
+    if pct is None:
+        return ""
+    delta = pct - _calendar_percent(period, date.today())
+    if delta >= 0:
+        return f"[green]▲ +{delta:.0f}% vs calendar[/green]"
+    return f"[red]▼ {delta:.0f}% vs calendar[/red]"
+
+
+def _goal_row(table: Table, label: str, goal: dict[str, Any] | None, period: str) -> None:
     """Add one GoalProgress payload (already in miles) to a goals table."""
     if goal is None:
-        table.add_row(label, "-", "-", "[dim]no goal set[/dim]")
+        table.add_row(label, "-", "-", "", "-", "[dim]no goal set[/dim]")
         return
     pct = goal.get("percent")
     table.add_row(
         label,
         f"{goal.get('goal_mi', 0):.0f} mi",
         f"{goal.get('progress_mi', 0):.1f} mi",
+        _progress_bar(pct),
         f"{pct:.1f}%" if pct is not None else "-",
+        _vs_calendar(pct, period),
     )
 
 
@@ -335,10 +437,12 @@ def display_goals(data: dict[str, Any]) -> None:
     table.add_column("Period", style="cyan")
     table.add_column("Target", justify="right")
     table.add_column("Progress", justify="right", style="green")
+    table.add_column("", justify="left")
     table.add_column("%", justify="right", style="yellow")
+    table.add_column("Pace", justify="left")
 
-    _goal_row(table, "Year", data.get("yearly"))
-    _goal_row(table, "Month", data.get("monthly"))
+    _goal_row(table, "Year", data.get("yearly"), "year")
+    _goal_row(table, "Month", data.get("monthly"), "month")
     console.print(table)
 
 
@@ -365,6 +469,72 @@ def display_goal_history(data: list[dict[str, Any]]) -> None:
         )
 
     console.print(table)
+
+
+def display_dashboard(
+    streak_data: dict[str, Any],
+    goals_data: dict[str, Any] | None,
+    last_run: dict[str, Any] | None,
+    on_this_day_count: int | None,
+) -> None:
+    """One-screen morning glance: streak, goals, last run, on-this-day."""
+    current = streak_data.get("current_streak", 0)
+    streak_miles = km_to_miles(streak_data.get("current_streak_km", 0))
+    start = ""
+    for s in streak_data.get("top_streaks", []):
+        if s.get("is_current"):
+            start = s.get("start_date", "")
+            break
+
+    lines: list[str] = [
+        "",
+        f"        [bold red]🔥 DAY {current:,} 🔥[/bold red]",
+        f"   [dim]since {start} · {streak_miles:,.0f} mi[/dim]" if start else "",
+        "",
+    ]
+
+    def goal_line(label: str, goal: dict[str, Any] | None, period: str) -> str | None:
+        if goal is None:
+            return None
+        pct = goal.get("percent")
+        return (
+            f" {label:<6}{_progress_bar(pct)} "
+            f"{goal.get('progress_mi', 0):.0f}/{goal.get('goal_mi', 0):.0f} mi  "
+            f"{_vs_calendar(pct, period)}"
+        )
+
+    if goals_data:
+        today = date.today()
+        month_name = today.strftime("%B")
+        for line in (
+            goal_line(month_name, goals_data.get("monthly"), "month"),
+            goal_line(str(today.year), goals_data.get("yearly"), "year"),
+        ):
+            if line:
+                lines.append(line)
+        lines.append("")
+
+    if last_run:
+        mi = km_to_miles(last_run.get("distance_km", 0))
+        pace = format_pace(last_run.get("avg_pace_min_per_km") or 0)
+        temp_c = last_run.get("temperature_celsius")
+        weather = WEATHER_EMOJI.get(last_run.get("weather") or "", "")
+        temp = f" · {weather} {int(celsius_to_fahrenheit(temp_c))}°" if temp_c else ""
+        lines.append(
+            f" [bold]Last run[/bold]   {_friendly_date(last_run.get('date', ''))} · "
+            f"{mi:.2f} mi · {pace} /mi{temp}"
+        )
+
+    if on_this_day_count:
+        lines.append(
+            f" [bold]This day[/bold]   {on_this_day_count} year"
+            f"{'s' if on_this_day_count != 1 else ''} of runs on this date"
+        )
+
+    lines.append("")
+    console.print(
+        Panel("\n".join(line for line in lines if line is not None), border_style="cyan", width=64)
+    )
 
 
 def display_sync_progress(message: str, done: bool = False) -> None:

--- a/stk/src/cli/main.py
+++ b/stk/src/cli/main.py
@@ -5,7 +5,8 @@ stk - MyRunStreak CLI
 A terminal-native CLI for tracking your running streak.
 
 Usage:
-    stk                  # Show current streak
+    stk                  # Morning-glance dashboard (streak, goals, last run)
+    stk streak           # Streak + flame art
     stk stats            # Overall statistics
     stk recent           # Recent runs
     stk records          # Personal records
@@ -26,21 +27,66 @@ from cli.commands import athlete, auth, cache, invite, plan, runs, splits, stats
 # Create the main app
 app = typer.Typer(
     name="stk",
-    help="Track your running streak from the terminal.",
+    help="Track your running streak from the terminal. Run bare for the dashboard.",
+    epilog=(
+        "Examples: [cyan]stk[/cyan] (dashboard) · "
+        "[cyan]stk runs --on-this-day today[/cyan] · "
+        "[cyan]stk summary --weather rainy[/cyan] · "
+        "[cyan]stk runs --sort temperature --order desc -n 5[/cyan]"
+    ),
+    rich_markup_mode="rich",
     no_args_is_help=False,
     add_completion=True,
 )
 
+# Help-panel names (shared so the grouping reads as one system)
+_PANEL_STREAK = "Streak & Stats"
+_PANEL_RUNS = "Runs"
+_PANEL_PLANNING = "Planning & Goals"
+_PANEL_COACHING = "Coaching"
+_PANEL_SYSTEM = "System"
+
 # Add command groups
-app.add_typer(auth.app, name="auth", help="Authentication commands")
-app.add_typer(plan.plan_app, name="plan", help="Adaptive monthly plan")
-app.add_typer(plan.constraint_app, name="constraint", help="Plan constraints (travel, injury)")
-app.add_typer(plan.readiness_app, name="readiness", help="Daily readiness check-in")
-app.add_typer(splits.splits_app, name="splits", help="Per-mile splits")
-app.add_typer(workout.workout_app, name="workout", help="Athlete workout tracker")
-app.add_typer(invite.invite_app, name="invite", help="Invite-only onboarding (admin)")
-app.add_typer(athlete.athlete_app, name="athlete", help="Athletes you coach")
-app.add_typer(cache.cache_app, name="cache", help="Local response cache")
+app.add_typer(auth.app, name="auth", help="Authentication commands", rich_help_panel=_PANEL_SYSTEM)
+app.add_typer(
+    plan.plan_app, name="plan", help="Adaptive monthly plan", rich_help_panel=_PANEL_PLANNING
+)
+app.add_typer(
+    plan.constraint_app,
+    name="constraint",
+    help="Plan constraints (travel, injury)",
+    rich_help_panel=_PANEL_PLANNING,
+)
+app.add_typer(
+    plan.readiness_app,
+    name="readiness",
+    help="Daily readiness check-in",
+    rich_help_panel=_PANEL_PLANNING,
+)
+app.add_typer(
+    splits.splits_app, name="splits", help="Per-mile splits", rich_help_panel=_PANEL_STREAK
+)
+app.add_typer(
+    workout.workout_app,
+    name="workout",
+    help="Athlete workout tracker",
+    rich_help_panel=_PANEL_COACHING,
+)
+app.add_typer(
+    invite.invite_app,
+    name="invite",
+    help="Invite-only onboarding (admin)",
+    rich_help_panel=_PANEL_COACHING,
+)
+app.add_typer(
+    athlete.athlete_app,
+    name="athlete",
+    help="Athletes you coach",
+    rich_help_panel=_PANEL_COACHING,
+)
+app.add_typer(
+    cache.cache_app, name="cache", help="Local response cache", rich_help_panel=_PANEL_SYSTEM
+)
 
 # Console for output
 console = Console()
@@ -66,24 +112,24 @@ def main(
     """
     stk - Track your running streak from the terminal.
 
-    Run without arguments to see your current streak.
+    Run without arguments for the dashboard: streak, goals, last run.
     """
     cache_lib.set_no_cache(no_cache)
     if ctx.invoked_subcommand is None:
-        # Default action: show streak
-        stats.streak()
+        # Default action: the morning-glance dashboard
+        stats.dashboard()
 
 
 # Register commands directly on the app
-app.command(name="streak")(stats.streak)
-app.command(name="stats")(stats.overall)
-app.command(name="recent")(runs.recent)
-app.command(name="records")(stats.records)
-app.command(name="monthly")(stats.monthly)
-app.command(name="runs")(runs.list_runs)
-app.command(name="summary")(runs.summary)
-app.command(name="goals")(stats.goals)
-app.command(name="sync")(sync.sync_runs)
+app.command(name="streak", rich_help_panel=_PANEL_STREAK)(stats.streak)
+app.command(name="stats", rich_help_panel=_PANEL_STREAK)(stats.overall)
+app.command(name="records", rich_help_panel=_PANEL_STREAK)(stats.records)
+app.command(name="monthly", rich_help_panel=_PANEL_STREAK)(stats.monthly)
+app.command(name="recent", rich_help_panel=_PANEL_RUNS)(runs.recent)
+app.command(name="runs", rich_help_panel=_PANEL_RUNS)(runs.list_runs)
+app.command(name="summary", rich_help_panel=_PANEL_RUNS)(runs.summary)
+app.command(name="sync", rich_help_panel=_PANEL_RUNS)(sync.sync_runs)
+app.command(name="goals", rich_help_panel=_PANEL_PLANNING)(stats.goals)
 
 
 def cli() -> None:

--- a/stk/tests/test_runs_filters.py
+++ b/stk/tests/test_runs_filters.py
@@ -169,3 +169,122 @@ def test_goals_table_renders_no_goal(captured) -> None:  # type: ignore[no-untyp
     assert result.exit_code == 0
     assert "Distance Goals" in result.output
     assert "no goal set" in result.output
+
+
+# ---------------------------------------------------------------------------
+# UX helpers (SB-276)
+# ---------------------------------------------------------------------------
+
+
+def test_bar_scales_and_floors() -> None:
+    from cli import display
+
+    assert display._bar(0, 10) == ""
+    assert display._bar(10, 10, width=8) == "▉" * 8
+    assert display._bar(0.1, 10, width=8) == "▉"  # non-zero always shows
+
+
+def test_progress_bar_caps_at_full() -> None:
+    from cli import display
+
+    assert display._progress_bar(None, width=8) == "░" * 8
+    assert display._progress_bar(150.0, width=8) == "▓" * 8
+    half = display._progress_bar(50.0, width=8)
+    assert half.count("▓") == 4 and half.count("░") == 4
+
+
+def test_friendly_date_today_and_fallback() -> None:
+    from datetime import date
+
+    from cli import display
+
+    assert "today" in display._friendly_date(date.today().isoformat())
+    assert display._friendly_date("garbage") == "garbage"[:10]
+
+
+def test_recent_table_footer_and_weather(captured) -> None:  # type: ignore[no-untyped-def]
+    def fake_request(endpoint: str, params=None):  # type: ignore[no-untyped-def]
+        return {
+            "count": 2,
+            "runs": [
+                {
+                    "date": "2026-07-18T13:33:00+00:00",
+                    "distance_km": 3.0,
+                    "duration_minutes": 20.0,
+                    "avg_pace_min_per_km": 6.6,
+                    "weather": "cloudy",
+                    "temperature_celsius": 28.9,
+                },
+                {
+                    "date": "2026-07-17T14:09:00+00:00",
+                    "distance_km": 3.3,
+                    "duration_minutes": 18.8,
+                    "avg_pace_min_per_km": 5.7,
+                    "weather": "sunny",
+                    "temperature_celsius": None,
+                },
+            ],
+        }
+
+    import pytest as _pytest
+
+    monkeypatch = _pytest.MonkeyPatch()
+    monkeypatch.setattr("cli.commands.runs.api.request", fake_request)
+    try:
+        result = runner.invoke(app, ["recent"])
+    finally:
+        monkeypatch.undo()
+    assert result.exit_code == 0
+    assert "2 runs" in result.output  # totals footer
+    assert "☁" in result.output  # weather emoji
+
+
+def test_dashboard_renders_with_all_data(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    def fake_request(endpoint: str, params=None):  # type: ignore[no-untyped-def]
+        if endpoint == "stats/streaks":
+            return {
+                "current_streak": 4347,
+                "current_streak_km": 30698.5,
+                "top_streaks": [{"start_date": "2014-08-24", "is_current": True}],
+            }
+        if endpoint == "stats/goals":
+            return {
+                "yearly": {"goal_mi": 1200.0, "progress_mi": 750.0, "percent": 62.5},
+                "monthly": {"goal_mi": 125.0, "progress_mi": 64.0, "percent": 51.2},
+            }
+        if endpoint == "runs/recent":
+            return {
+                "runs": [
+                    {
+                        "date": "2026-07-18T13:33:00+00:00",
+                        "distance_km": 3.0,
+                        "avg_pace_min_per_km": 6.6,
+                        "weather": "cloudy",
+                        "temperature_celsius": 28.9,
+                    }
+                ]
+            }
+        if endpoint == "runs":
+            return {"total": 13, "runs": []}
+        raise AssertionError(f"unexpected endpoint {endpoint}")
+
+    monkeypatch.setattr("cli.commands.stats.api.request", fake_request)
+    result = runner.invoke(app, [])
+    assert result.exit_code == 0
+    assert "DAY 4,347" in result.output
+    assert "vs calendar" in result.output
+    assert "13 years" in result.output
+
+
+def test_dashboard_degrades_when_optional_reads_fail(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import sys as _sys
+
+    def fake_request(endpoint: str, params=None):  # type: ignore[no-untyped-def]
+        if endpoint == "stats/streaks":
+            return {"current_streak": 100, "current_streak_km": 500.0, "top_streaks": []}
+        _sys.exit(1)  # every optional read blows up like api.request would
+
+    monkeypatch.setattr("cli.commands.stats.api.request", fake_request)
+    result = runner.invoke(app, [])
+    assert result.exit_code == 0
+    assert "DAY 100" in result.output


### PR DESCRIPTION
## Summary
- Bare `stk` is now a one-screen dashboard: streak day + miles, goal progress bars with ▲/▼ vs-calendar markers, last run, on-this-day teaser. Degrades gracefully if optional reads fail; `stk streak` keeps the flame.
- `stk --help` grouped into panels (Streak & Stats / Runs / Planning & Goals / Coaching / System) with an examples epilog.
- `recent`/`runs` table: weekday + relative dates, weather emoji, inline distance bars, ⚡ fastest-pace highlight, totals footer.
- `stk goals`: ▓░ progress bars + vs-calendar marker. `stk monthly`: chronological + trend bars.
- Display layer only — no API/backend changes; all reads served by the version-gated cache.

## Test plan
- [x] `uv run pytest` — 60 pass (6 new: helpers, footer/weather render, dashboard full + degraded)
- [x] Live renders verified: `stk`, `stk --help`, `stk recent`, `stk goals`, `stk monthly -n 6`
- [x] ruff format + check clean

Fixes SB-276

🤖 Generated with [Claude Code](https://claude.com/claude-code)