### PR TITLE
fix: mile splits chart empty — derive split pace from cumulative deltas

### DIFF
--- a/backend/routes/runs.py
+++ b/backend/routes/runs.py
@@ -241,21 +241,35 @@ async def get_run_detail(
     if run is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Run not found")
 
-    splits = [
-        {
-            "split_number": s["split_number"],
-            "split_unit": s.get("split_unit"),
-            "cumulative_distance_km": _f(s.get("cumulative_distance_km")),
-            "cumulative_seconds": _f(s.get("cumulative_seconds")),
-            "pace_min_per_km": _f(s.get("pace_min_per_km")),
-            "heart_rate": s.get("heart_rate"),
-            "elevation_gain_m": _f(s.get("cumulative_elevation_gain_meters")),
-            "elevation_loss_m": _f(s.get("cumulative_elevation_loss_meters")),
-        }
-        for s in sorted(
-            repo.get_splits_for_run(UUID(run["id"])), key=lambda s: s["split_number"] or 0
+    splits: list[dict[str, Any]] = []
+    prev_km, prev_sec = 0.0, 0.0
+    for s in sorted(repo.get_splits_for_run(UUID(run["id"])), key=lambda s: s["split_number"] or 0):
+        cum_km = _f(s.get("cumulative_distance_km"))
+        cum_sec = _f(s.get("cumulative_seconds"))
+        # Splits store only cumulative metrics; per-split pace is derived from
+        # the deltas (the stored pace column is unpopulated by sync).
+        pace = _f(s.get("pace_min_per_km"))
+        if pace is None and cum_km is not None and cum_sec is not None:
+            delta_km = cum_km - prev_km
+            delta_sec = cum_sec - prev_sec
+            if delta_km > 0.001 and delta_sec > 0:
+                pace = round(delta_sec / 60 / delta_km, 2)
+        if cum_km is not None:
+            prev_km = cum_km
+        if cum_sec is not None:
+            prev_sec = cum_sec
+        splits.append(
+            {
+                "split_number": s["split_number"],
+                "split_unit": s.get("split_unit"),
+                "cumulative_distance_km": cum_km,
+                "cumulative_seconds": cum_sec,
+                "pace_min_per_km": pace,
+                "heart_rate": s.get("heart_rate"),
+                "elevation_gain_m": _f(s.get("cumulative_elevation_gain_meters")),
+                "elevation_loss_m": _f(s.get("cumulative_elevation_loss_meters")),
+            }
         )
-    ]
 
     return {
         "activity_id": run["source_activity_id"],

--- a/backend/tests/test_run_detail.py
+++ b/backend/tests/test_run_detail.py
@@ -91,6 +91,29 @@ def test_detail_shapes_weather_vitals_and_sorted_splits(monkeypatch: Any) -> Non
     assert out["splits"][1]["elevation_gain_m"] == 29.0
 
 
+def test_detail_derives_pace_from_cumulative_deltas(monkeypatch: Any) -> None:
+    # Real sync never populates pace_min_per_km — pace must come from deltas.
+    splits = [
+        {**_SPLITS[1], "pace_min_per_km": None},  # mile 1: 612s / 1.609km
+        {**_SPLITS[0], "pace_min_per_km": None},  # mile 2: 642s / 1.610km
+        {
+            "split_number": 3,
+            "split_unit": "mi",
+            "cumulative_distance_km": "3.219",  # zero-distance tail split
+            "cumulative_seconds": "1254",
+            "pace_min_per_km": None,
+            "heart_rate": None,
+            "cumulative_elevation_gain_meters": None,
+            "cumulative_elevation_loss_meters": None,
+        },
+    ]
+    out = _detail(_RUN, splits, monkeypatch)
+    paces = [s["pace_min_per_km"] for s in out["splits"]]
+    assert paces[0] == pytest.approx(612 / 60 / 1.609, abs=0.01)
+    assert paces[1] == pytest.approx((1254 - 612) / 60 / (3.219 - 1.609), abs=0.01)
+    assert paces[2] is None  # no distance covered -> no pace, not a divide-by-zero
+
+
 def test_detail_404_when_not_owned(monkeypatch: Any) -> None:
     with pytest.raises(HTTPException) as err:
         _detail(None, [], monkeypatch)


### PR DESCRIPTION
## Problem
Mile splits chart on run detail renders empty (axes only). `splits.pace_min_per_km` is never written by sync — `split_to_dict` stores only cumulative metrics — so `GET /runs/{activity_id}` returned `null` pace for every split and the frontend filtered them all out.

## Fix
Derive per-split pace at read time from cumulative distance/seconds deltas (`delta_sec / 60 / delta_km`). Stored column still wins if ever populated. Zero-distance tail splits return `null` (no divide-by-zero). Read-time derivation means all existing runs are fixed on deploy — no backfill.

## Testing
- New test: `test_detail_derives_pace_from_cumulative_deltas` (null stored pace → derived; zero-distance split → null)
- Full backend suite: 225 passed
- ruff check/format clean; mypy errors in file are pre-existing (untyped `@cached` decorator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)