### PR TITLE
feat: goal catch-up pace — mi/day to finish when behind

### DIFF
--- a/frontend/src/components/GoalsCard.vue
+++ b/frontend/src/components/GoalsCard.vue
@@ -51,6 +51,12 @@
           {{ formatMilesDelta(monthlyMilesDelta) }}
         </span>
       </div>
+      <p
+        v-if="monthlyCatchUp"
+        class="mt-1 text-xs font-medium text-amber-600 inline-flex items-center gap-1"
+      >
+        <Zap class="w-3.5 h-3.5 inline" /> {{ monthlyCatchUp }}
+      </p>
     </div>
 
     <!-- Yearly goal -->
@@ -89,13 +95,19 @@
           {{ formatMilesDelta(yearlyMilesDelta) }}
         </span>
       </div>
+      <p
+        v-if="yearlyCatchUp"
+        class="mt-1 text-xs font-medium text-amber-600 inline-flex items-center gap-1"
+      >
+        <Zap class="w-3.5 h-3.5 inline" /> {{ yearlyCatchUp }}
+      </p>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { Calendar, PartyPopper, Target } from 'lucide-vue-next'
+import { Calendar, PartyPopper, Target, Zap } from 'lucide-vue-next'
 import type { GoalProgress } from '@/types/runs'
 
 const props = defineProps<{
@@ -153,6 +165,46 @@ const yearlyMilesDelta = computed((): number | null => {
   if (delta === null || !props.yearly) return null
   return (delta / 100) * props.yearly.goal_mi
 })
+
+// Catch-up coaching: when behind, the deficit alone scolds — the actionable
+// number is "what to run per day to still finish". Today's run is assumed
+// banked into progress_mi, so days left excludes today (guarded against the
+// final-day divide-by-zero).
+const monthlyDaysLeft = computed((): number => {
+  const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate()
+  return daysInMonth - now.getDate()
+})
+
+const yearlyDaysLeft = computed((): number => {
+  const start = new Date(now.getFullYear(), 0, 0)
+  const dayOfYear = Math.floor((now.getTime() - start.getTime()) / 86400000)
+  const isLeap =
+    (now.getFullYear() % 4 === 0 && now.getFullYear() % 100 !== 0) ||
+    now.getFullYear() % 400 === 0
+  return (isLeap ? 366 : 365) - dayOfYear
+})
+
+const catchUpText = (
+  goal: GoalProgress | null,
+  delta: number | null,
+  daysLeft: number,
+): string | null => {
+  // Only when meaningfully behind (amber/red) and the goal is still reachable-by-running.
+  if (!goal || delta === null || delta > -0.5) return null
+  const remaining = goal.goal_mi - goal.progress_mi
+  if (remaining <= 0 || daysLeft <= 0) return null
+  const perDay = remaining / daysLeft
+  const dayWord = daysLeft === 1 ? 'day' : 'days'
+  return `${daysLeft} ${dayWord} left · ${perDay.toFixed(1)} mi/day to finish`
+}
+
+const monthlyCatchUp = computed((): string | null =>
+  catchUpText(props.monthly, monthlyPaceDelta.value, monthlyDaysLeft.value),
+)
+
+const yearlyCatchUp = computed((): string | null =>
+  catchUpText(props.yearly, yearlyPaceDelta.value, yearlyDaysLeft.value),
+)
 
 const formatMilesDelta = (milesDelta: number | null): string => {
   if (milesDelta === null) return ''

--- a/frontend/src/components/__tests__/GoalsCard.test.ts
+++ b/frontend/src/components/__tests__/GoalsCard.test.ts
@@ -84,6 +84,24 @@ describe('GoalsCard', () => {
     expect(w.text()).not.toMatch(/ahead of pace/)
   })
 
+  it('shows a catch-up line with days left and mi/day when behind', () => {
+    // May 9, 31-day month → 22 days left; (125 - 13.5) / 22 ≈ 5.07 mi/day.
+    const w = mount(GoalsCard, { props: { yearly: null, monthly: monthlyBehind } })
+    expect(w.text()).toContain('22 days left')
+    expect(w.text()).toContain('5.1 mi/day to finish')
+  })
+
+  it('omits the catch-up line when on/ahead of pace', () => {
+    // yearlyOnPace is exactly on pace → no catch-up coaching.
+    const w = mount(GoalsCard, { props: { yearly: yearlyOnPace, monthly: null } })
+    expect(w.text()).not.toContain('to finish')
+  })
+
+  it('omits the catch-up line when the goal is already complete', () => {
+    const w = mount(GoalsCard, { props: { yearly: null, monthly: monthlyComplete } })
+    expect(w.text()).not.toContain('to finish')
+  })
+
   it('uses the current month name in the monthly header', () => {
     // FIXED_NOW is 2026-05-09 → "May"
     const w = mount(GoalsCard, { props: { yearly: null, monthly: monthlyBehind } })


### PR DESCRIPTION
## Problem
When behind on a distance goal, the Goals card shows the deficit ("8.0 mi behind pace") but not the actionable number: **what to run per day to still finish**. Deficit alone scolds; it doesn't coach.

## Fix
Add a catch-up line under any behind-pace goal (monthly + yearly):

```
July            76.7 / 125 mi
████████████░░░░░░  61.4%          8.0 mi behind pace
⚡ 10 days left · 4.8 mi/day to finish   ← new (amber)
```

- Shown **only** when meaningfully behind (amber/red delta) and the goal is still reachable-by-running (`remaining > 0`, `daysLeft > 0`).
- `perDay = (goal_mi − progress_mi) / daysLeft`.
- Today's run is assumed banked into `progress_mi`, so days-left **excludes today**; guarded against the final-day divide-by-zero.
- Fully client-side from data already on the card — **no API change**.

The existing red "behind pace" text stays (honest gap); the new amber line is the forward-looking fix.

## Testing
- 3 new tests: catch-up line present when behind (`22 days left` / `5.1 mi/day to finish`), absent when on/ahead of pace, absent when complete.
- GoalsCard suite: 12 passed. Type-check + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)