### PR TITLE
feat: capture run start coords + fix has_gps_data (SB-290)

### DIFF
--- a/src/shared/models/activity.py
+++ b/src/shared/models/activity.py
@@ -62,6 +62,32 @@ class Activity(BaseModel):
         alias="externalDeviceType",
     )
 
+    # Location & GPS (SB-290) — present in the list payload, no detail call
+    start_latitude: float | None = Field(
+        default=None,
+        description="Latitude at the start of the run",
+        alias="startLatitude",
+        ge=-90,
+        le=90,
+    )
+    start_longitude: float | None = Field(
+        default=None,
+        description="Longitude at the start of the run",
+        alias="startLongitude",
+        ge=-180,
+        le=180,
+    )
+    has_details_gps: bool = Field(
+        default=False,
+        description="Whether SmashRun has a GPS track for this activity",
+        alias="hasDetailsGPS",
+    )
+    is_treadmill: bool = Field(
+        default=False,
+        description="Indoor/treadmill run (no outdoor route)",
+        alias="isTreadmill",
+    )
+
     # Performance Metrics - Cadence
     cadence_average: float | None = Field(
         default=None,

--- a/src/shared/supabase_ops/mappers.py
+++ b/src/shared/supabase_ops/mappers.py
@@ -102,10 +102,15 @@ def activity_to_run_dict(activity: Activity, user_id: UUID, source_id: UUID) -> 
             activity.external_device_type.value if activity.external_device_type else None
         ),
         "app_version": activity.external_app_version,
+        # Location & GPS (SB-290) — all from the list payload, no detail call
+        "start_latitude": activity.start_latitude,
+        "start_longitude": activity.start_longitude,
+        "is_treadmill": activity.is_treadmill,
         # Data availability flags
-        "has_gps_data": (
-            activity.recording_keys is not None and "latitude" in (activity.recording_keys or [])
-        ),
+        # has_gps_data now sourced from SmashRun's hasDetailsGPS. The old
+        # derivation from recording_keys was always false in list-based sync
+        # (the list omits recordingKeys), so it never reflected reality.
+        "has_gps_data": activity.has_details_gps,
         "has_heart_rate_data": activity.heart_rate_average is not None,
         "has_cadence_data": activity.cadence_average is not None,
         "has_splits": False,  # Will be updated when splits are added

--- a/supabase/migrations/20260721000000_run_start_location.sql
+++ b/supabase/migrations/20260721000000_run_start_location.sql
@@ -1,0 +1,23 @@
+-- =====================================================
+-- Run start location + GPS flag (SB-290, step 1 of SB-289)
+-- =====================================================
+-- SmashRun's /my/activities/search (list) payload already carries
+-- startLatitude / startLongitude / hasDetailsGPS / isTreadmill — free on every
+-- sync, no per-activity detail call. Capturing the start point unlocks the
+-- near-free route-frequency MVP (group by rounded start cell + distance).
+--
+-- Backfill: none needed here. The sync mapper now emits these columns and
+-- upsert_run overwrites on conflict, so `stk sync --full` repopulates every
+-- existing run from the list endpoint (~48 pages, no detail calls).
+--
+-- Also fixes has_gps_data: it was derived from recordingKeys, which the list
+-- endpoint never returns, so it was never set true by the search-based sync
+-- (a bogus ~444/4774 in prod). The mapper now sources it from hasDetailsGPS.
+
+ALTER TABLE runs ADD COLUMN IF NOT EXISTS start_latitude NUMERIC(9, 6);
+ALTER TABLE runs ADD COLUMN IF NOT EXISTS start_longitude NUMERIC(9, 6);
+ALTER TABLE runs ADD COLUMN IF NOT EXISTS is_treadmill BOOLEAN DEFAULT FALSE;
+
+COMMENT ON COLUMN runs.start_latitude IS 'Run start latitude from SmashRun startLatitude (SB-290)';
+COMMENT ON COLUMN runs.start_longitude IS 'Run start longitude from SmashRun startLongitude (SB-290)';
+COMMENT ON COLUMN runs.is_treadmill IS 'Indoor/treadmill run from SmashRun isTreadmill (SB-290)';

--- a/tests/test_run_location_mapper.py
+++ b/tests/test_run_location_mapper.py
@@ -1,0 +1,61 @@
+"""SB-290: activity_to_run_dict captures start location + a correct GPS flag."""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from src.shared.models import Activity
+from src.shared.supabase_ops.mappers import activity_to_run_dict
+
+USER = uuid4()
+SOURCE = uuid4()
+
+
+def _run_dict(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "activityId": "act-loc-1",
+        "startDateTimeLocal": datetime(2026, 7, 21, 8, 32, 0, tzinfo=UTC),
+        "distance": 6.88,
+        "duration": 2498,
+    }
+    payload.update(overrides)
+    return activity_to_run_dict(Activity(**payload), USER, SOURCE)
+
+
+def test_outdoor_run_captures_start_coords_and_gps_flag() -> None:
+    out = _run_dict(
+        startLatitude=42.2626,
+        startLongitude=-71.8023,
+        hasDetailsGPS=True,
+        isTreadmill=False,
+    )
+    assert out["start_latitude"] == 42.2626
+    assert out["start_longitude"] == -71.8023
+    assert out["is_treadmill"] is False
+    # has_gps_data now tracks SmashRun's hasDetailsGPS, not recording_keys.
+    assert out["has_gps_data"] is True
+
+
+def test_treadmill_run_has_no_coords_and_no_gps() -> None:
+    out = _run_dict(hasDetailsGPS=False, isTreadmill=True)
+    assert out["start_latitude"] is None
+    assert out["start_longitude"] is None
+    assert out["is_treadmill"] is True
+    assert out["has_gps_data"] is False
+
+
+def test_gps_flag_ignores_recording_keys() -> None:
+    # Regression: the old derivation set has_gps_data from recording_keys, which
+    # the list payload never carries. It must follow hasDetailsGPS instead.
+    out = _run_dict(hasDetailsGPS=True, recordingKeys=None)
+    assert out["has_gps_data"] is True
+
+    out2 = _run_dict(hasDetailsGPS=False, recordingKeys=["latitude", "longitude"])
+    assert out2["has_gps_data"] is False
+
+
+def test_fields_default_when_absent() -> None:
+    out = _run_dict()  # no location fields in payload
+    assert out["start_latitude"] is None
+    assert out["start_longitude"] is None
+    assert out["is_treadmill"] is False
+    assert out["has_gps_data"] is False


### PR DESCRIPTION
Step 1 of SB-289 (route-frequency tracker). Fixes SB-290.

## What
SmashRun's `/my/activities/search` (list) payload already carries `startLatitude`, `startLongitude`, `hasDetailsGPS`, and `isTreadmill` — **free on every sync, no per-activity detail call** (proven by the SB-289 spike). This captures the start point (the near-free unlock for route-frequency) and fixes the dead `has_gps_data` flag.

## Changes
- **Migration** `20260721000000_run_start_location.sql`: add `start_latitude`, `start_longitude`, `is_treadmill` to `runs`.
- **Activity model**: `startLatitude` / `startLongitude` / `hasDetailsGPS` / `isTreadmill` fields.
- **Mapper**: emit the new columns; source `has_gps_data` from `hasDetailsGPS`.

## `has_gps_data` was broken
It was derived from `recordingKeys`, which the **list payload never returns**, so the search-based sync could never set it true — a bogus **444/4774** in prod. It now follows `hasDetailsGPS`. Column has zero readers, so repurposing is safe.

## Backfill: no job needed
`upsert_run` overwrites on conflict, and the mapper now emits these columns, so **`stk sync --full` repopulates every existing run** from the list endpoint (~48 pages, no detail calls). One-time, cheap.

## Verification
- Unit: mapper captures coords + correct GPS flag; treadmill → null/false; regression that GPS flag ignores `recordingKeys`.
- **Live**: ran the real SmashRun payload through parse → mapper. Outdoor runs captured coords (incl. Chicago travel days), `has_gps_data=true`; the treadmill run stayed null/false. 7/8 recent runs have GPS — real coverage ~85%, confirming the old flag was the bug.
- Root suite 56 passed, backend 225 passed, ruff clean, no new mypy errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)