### PR TITLE
feat: stk route show — braille GPS route-card (SB-295)

### DIFF
--- a/backend/routes/runs.py
+++ b/backend/routes/runs.py
@@ -8,9 +8,11 @@ from uuid import UUID
 
 from backend.auth import authenticate_request
 from backend.cache import cached
+from backend.routes.sync import _resolve_access_token
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from src.shared.smashrun import SmashRunAPIClient
 from src.shared.supabase_client import get_supabase_client
-from src.shared.supabase_ops import RunsRepository
+from src.shared.supabase_ops import RunsRepository, TokenRepository
 
 router = APIRouter(prefix="/runs", tags=["runs"])
 
@@ -244,6 +246,54 @@ async def route_leaderboard(
     distance bucket, sorted by run count. Answers "how many times have I run
     this route". Treadmill / no-GPS runs are excluded."""
     return await _routes(user_id, min_runs)
+
+
+@cached(ttl=86400, key_prefix="runs:track")
+async def _track(user_id: UUID, activity_id: str) -> dict[str, Any]:
+    supabase = get_supabase_client()
+    run = RunsRepository(supabase).get_run_by_activity_id(user_id, activity_id)
+    if run is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Run not found")
+
+    # The GPS track lives only in SmashRun's per-activity detail (recordingValues),
+    # not our DB — fetch it on demand with the user's token.
+    token = _resolve_access_token(user_id, TokenRepository(supabase))
+    with SmashRunAPIClient(access_token=token) as api:
+        detail = api.get_activity_by_id(activity_id)
+
+    keys = detail.get("recordingKeys") or []
+    values = detail.get("recordingValues") or []
+    lat: list[float] = []
+    lon: list[float] = []
+    if "latitude" in keys and "longitude" in keys and values:
+        lat = [float(v) for v in values[keys.index("latitude")]]
+        lon = [float(v) for v in values[keys.index("longitude")]]
+
+    return {
+        "activity_id": activity_id,
+        "has_track": bool(lat),
+        "lat": lat,
+        "lon": lon,
+        "city": detail.get("city"),
+        "state": detail.get("state"),
+        "date": run["start_date_time_local"],
+        "distance_km": _f(run.get("distance_km")),
+        "duration_seconds": _f(run.get("duration_seconds")),
+        "avg_pace_min_per_km": _f(run.get("average_pace_min_per_km")),
+        "weather_type": run.get("weather_type"),
+        "temperature_celsius": _f(run.get("temperature_celsius")),
+    }
+
+
+@router.get("/{activity_id}/track")
+async def get_run_track(
+    activity_id: str,
+    user_id: UUID = Depends(authenticate_request),
+) -> dict[str, Any]:
+    """GPS track (lat/lon arrays) + place/stats for one run (SB-293), for the
+    `stk route show` braille map. Track is fetched on demand from SmashRun's
+    detail payload (not stored). 404 if the run isn't the caller's."""
+    return await _track(user_id, activity_id)
 
 
 # NOTE: registered after /recent, /head, /routes, and "" so the static paths keep priority.

--- a/backend/tests/test_run_track.py
+++ b/backend/tests/test_run_track.py
@@ -1,0 +1,97 @@
+"""SB-293: GET /runs/{activity_id}/track — GPS track for the route-card map."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from backend.routes import runs as runs_module
+from fastapi import HTTPException
+
+USER = uuid4()
+
+_RUN = {
+    "id": str(uuid4()),
+    "start_date_time_local": "2026-07-21T08:32:00",
+    "distance_km": "6.88",
+    "duration_seconds": "2498",
+    "average_pace_min_per_km": "6.05",
+    "weather_type": "cloudy",
+    "temperature_celsius": "20.6",
+}
+
+
+class _Repo:
+    def __init__(self, run: dict[str, Any] | None) -> None:
+        self._run = run
+
+    def __call__(self, _sb: Any) -> _Repo:
+        return self
+
+    def get_run_by_activity_id(self, _uid: Any, _aid: str) -> dict[str, Any] | None:
+        return self._run
+
+
+class _FakeApi:
+    def __init__(self, detail: dict[str, Any]) -> None:
+        self._detail = detail
+
+    def __call__(self, *, access_token: str) -> _FakeApi:
+        return self
+
+    def __enter__(self) -> _FakeApi:
+        return self
+
+    def __exit__(self, *_a: Any) -> bool:
+        return False
+
+    def get_activity_by_id(self, _aid: str) -> dict[str, Any]:
+        return self._detail
+
+
+def _track(run: dict[str, Any] | None, detail: dict[str, Any], monkeypatch: Any) -> Any:
+    monkeypatch.setattr(runs_module, "get_supabase_client", lambda: object())
+    monkeypatch.setattr(runs_module, "RunsRepository", _Repo(run))
+    monkeypatch.setattr(runs_module, "TokenRepository", lambda _sb: object())
+    monkeypatch.setattr(runs_module, "_resolve_access_token", lambda _uid, _repo: "tok")
+    monkeypatch.setattr(runs_module, "SmashRunAPIClient", _FakeApi(detail))
+    return asyncio.run(runs_module.get_run_track("act-1", user_id=USER))
+
+
+def test_track_returns_lat_lon_and_place(monkeypatch: Any) -> None:
+    detail = {
+        "recordingKeys": ["distance", "latitude", "longitude", "elevation"],
+        "recordingValues": [
+            [0, 1, 2],
+            [42.24, 42.25, 42.26],
+            [-71.65, -71.66, -71.67],
+            [10, 11, 12],
+        ],
+        "city": "Worcester County",
+        "state": "Massachusetts",
+    }
+    out = _track(_RUN, detail, monkeypatch)
+    assert out["has_track"] is True
+    assert out["lat"] == [42.24, 42.25, 42.26]
+    assert out["lon"] == [-71.65, -71.66, -71.67]
+    assert out["city"] == "Worcester County"
+    assert out["state"] == "Massachusetts"
+    # Stats come from our DB row (canonical), coerced to float.
+    assert out["distance_km"] == 6.88
+    assert out["avg_pace_min_per_km"] == 6.05
+
+
+def test_track_empty_when_no_gps(monkeypatch: Any) -> None:
+    detail = {"recordingKeys": ["distance", "clock"], "recordingValues": [[0, 1], [0, 5]]}
+    out = _track(_RUN, detail, monkeypatch)
+    assert out["has_track"] is False
+    assert out["lat"] == []
+    assert out["lon"] == []
+
+
+def test_track_404_when_not_owned(monkeypatch: Any) -> None:
+    with pytest.raises(HTTPException) as err:
+        _track(None, {}, monkeypatch)
+    assert err.value.status_code == 404

--- a/stk/src/cli/commands/runs.py
+++ b/stk/src/cli/commands/runs.py
@@ -100,6 +100,25 @@ def list_runs(
         display.display_recent_runs(data)
 
 
+route_app = typer.Typer(help="Examine a single route + its GPS map")
+
+
+@route_app.command("show")
+def route_show(
+    activity_id: str = typer.Argument(..., help="Run's activity id (from stk runs / route URL)"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
+) -> None:
+    """Show a run's GPS route as a braille map + stats."""
+    data = api.request(f"runs/{activity_id}/track")
+
+    if json_output:
+        import json
+
+        print(json.dumps(data, indent=2))
+    else:
+        display.display_route_card(data)
+
+
 def routes(
     min_runs: int = typer.Option(2, "--min-runs", help="Only routes run at least this many times"),
     limit: int = typer.Option(15, "--limit", "-n", help="Max routes to show"),

--- a/stk/src/cli/display.py
+++ b/stk/src/cli/display.py
@@ -3,9 +3,10 @@
 from datetime import date, datetime
 from typing import Any
 
-from rich.console import Console
+from rich.console import Console, Group
 from rich.panel import Panel
 from rich.table import Table
+from rich.text import Text
 
 console = Console()
 
@@ -612,3 +613,99 @@ def display_route_leaderboard(data: dict[str, Any], limit: int = 15) -> None:
         )
 
     console.print(table)
+
+
+# --- braille route map (SB-293) ---
+
+# Braille dot bit layout within a 2-wide x 4-tall cell (U+2800 base).
+_BRAILLE_DOTS = [[0x01, 0x08], [0x02, 0x10], [0x04, 0x20], [0x40, 0x80]]
+
+
+class _BrailleCanvas:
+    """Tiny drawille-style canvas. w/h are in character cells (each = 2x4 dots)."""
+
+    def __init__(self, w: int, h: int) -> None:
+        self.dots_x, self.dots_y = w * 2, h * 4
+        self.grid = [[0] * w for _ in range(h)]
+
+    def _set(self, x: int, y: int) -> None:
+        if 0 <= x < self.dots_x and 0 <= y < self.dots_y:
+            self.grid[y // 4][x // 2] |= _BRAILLE_DOTS[y % 4][x % 2]
+
+    def line(self, x0: int, y0: int, x1: int, y1: int) -> None:
+        # Bresenham — connect consecutive GPS points into a continuous trace.
+        dx, dy = abs(x1 - x0), -abs(y1 - y0)
+        sx, sy = (1 if x0 < x1 else -1), (1 if y0 < y1 else -1)
+        err = dx + dy
+        while True:
+            self._set(x0, y0)
+            if x0 == x1 and y0 == y1:
+                break
+            e2 = 2 * err
+            if e2 >= dy:
+                err += dy
+                x0 += sx
+            if e2 <= dx:
+                err += dx
+                y0 += sy
+
+    def rows(self) -> list[str]:
+        return ["".join(chr(0x2800 + c) for c in row) for row in self.grid]
+
+
+def _render_track(lat: list[float], lon: list[float], w: int = 40, h: int = 16) -> list[str]:
+    """Trace a lat/lon polyline into braille rows (aspect-corrected, north up)."""
+    import math
+
+    mean_lat = sum(lat) / len(lat)
+    # Equalize distance scaling: 1 deg lon is cos(lat)x shorter than 1 deg lat.
+    xs = [lo * math.cos(math.radians(mean_lat)) for lo in lon]
+    ys = list(lat)
+    minx, maxx, miny, maxy = min(xs), max(xs), min(ys), max(ys)
+    spanx, spany = (maxx - minx) or 1e-9, (maxy - miny) or 1e-9
+
+    cv = _BrailleCanvas(w, h)
+    pad = 1
+    px = [int((x - minx) / spanx * (cv.dots_x - 1 - 2 * pad)) + pad for x in xs]
+    # Invert y so higher latitude (north) is higher on screen.
+    py = [(cv.dots_y - 1 - pad) - int((y - miny) / spany * (cv.dots_y - 1 - 2 * pad)) for y in ys]
+    for i in range(len(px) - 1):
+        cv.line(px[i], py[i], px[i + 1], py[i + 1])
+    return cv.rows()
+
+
+def display_route_card(data: dict[str, Any]) -> None:
+    """Braille GPS map + stats for one run (SB-293)."""
+    aid = data.get("activity_id", "")
+    lat, lon = data.get("lat") or [], data.get("lon") or []
+    if not data.get("has_track") or len(lat) < 2:
+        console.print(f"[dim]No GPS track for run {aid} (indoor/treadmill or GPS off).[/dim]")
+        return
+
+    rows = _render_track(lat, lon)
+    miles = km_to_miles(data.get("distance_km") or 0)
+    dur_s = int(data.get("duration_seconds") or 0)
+    pace = data.get("avg_pace_min_per_km")
+    temp_c = data.get("temperature_celsius")
+    place = ", ".join(p for p in (data.get("city"), data.get("state")) if p)
+    date = (data.get("date") or "")[:10]
+
+    stats = Text()
+    stats.append(f"\n📍 {place}\n" if place else "\n", style="bold cyan")
+    stats.append(f"📅 {date}   ", style="white")
+    if temp_c is not None:
+        weather = data.get("weather_type") or ""
+        stats.append(f"{weather} · {round(celsius_to_fahrenheit(temp_c))}°F", style="dim")
+    stats.append(f"\n🏃 {miles:.2f} mi   ⏱ {dur_s // 60}:{dur_s % 60:02d}", style="bold white")
+    if pace:
+        stats.append(f"   ⚡ {format_pace(pace)}/mi", style="bold white")
+
+    console.print(
+        Panel(
+            Group(Text("\n".join(rows), style="bright_green"), stats),
+            title=f"[bold]Route[/]  ·  {miles:.1f} mi",
+            subtitle=f"[dim]activity {aid}[/]",
+            border_style="green",
+            width=54,
+        )
+    )

--- a/stk/src/cli/main.py
+++ b/stk/src/cli/main.py
@@ -85,6 +85,12 @@ app.add_typer(
     rich_help_panel=_PANEL_COACHING,
 )
 app.add_typer(
+    runs.route_app,
+    name="route",
+    help="Examine a single route + its GPS map",
+    rich_help_panel=_PANEL_RUNS,
+)
+app.add_typer(
     cache.cache_app, name="cache", help="Local response cache", rich_help_panel=_PANEL_SYSTEM
 )
 


### PR DESCRIPTION
Step 3 of SB-289. Fixes SB-295. The "examine a route and see the map" ask.

## What
`stk route show <activity_id>` renders a run's GPS route as a **braille map + stats** in the terminal.

```
╭───────────────── Route  ·  4.3 mi ─────────────────╮
│ ⠀⠀⠀⢀⠤⠤⠦⣄⠀⠀⠀ … (real 578-pt GPS trace, north-up) │
│                                                    │
│ 📍 Worcester County, Massachusetts                 │
│ 📅 2026-07-21   partlycloudy · 69°F                │
│ 🏃 4.28 mi   ⏱ 41:38   ⚡ 9:44/mi                  │
╰──────────────── activity 46431098 ─────────────────╯
```

## Changes
- **`GET /runs/{activity_id}/track`**: fetches the GPS track on demand from SmashRun's detail payload (`recordingValues` lat/lon) — **not stored, no schema change**. Ownership-checked (404 if not the caller's), cached 24h (track is immutable). Stats come from our DB row (canonical); city/state from the SmashRun detail.
- **`stk route show <id>`**: braille canvas (2×4 dots/cell → 8 "pixels"/char), aspect-corrected (`cos(lat)` on longitude), north-up, Bresenham-connected trace, in a Rich panel.
- Non-GPS / treadmill runs → graceful "no track" message.

## Testing
- Backend (3): lat/lon extraction from `recordingKeys/Values`; empty when no GPS; 404 when not owned. Full suite 234 passed.
- CLI: `route show` registered; card + empty-state render verified against a real cached 578-point track. ruff clean both sides.
- Live endpoint verification pending deploy (needs `/runs/{id}/track` in prod).

## Notes / follow-ups
- Fetch-on-demand ships first; **stored polylines** (SB-289 north-star) come with the territory heatmap and would avoid a per-view SmashRun call.
- Route context ("run #N / 3rd-fastest") can layer on later via the SB-291 grouping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)