### PR TITLE
feat: route count on route-card + coarser cell precision (SB-297)

### DIFF
--- a/backend/routes/runs.py
+++ b/backend/routes/runs.py
@@ -269,6 +269,19 @@ async def _track(user_id: UUID, activity_id: str) -> dict[str, Any]:
         lat = [float(v) for v in values[keys.index("latitude")]]
         lon = [float(v) for v in values[keys.index("longitude")]]
 
+    # How many times this route has been run (count + rank), so the card can say
+    # "run N times, #k of M" (SB-296). Needs the run's own start coords.
+    route = None
+    run_lat, run_lon, run_dist = (
+        run.get("start_latitude"),
+        run.get("start_longitude"),
+        run.get("distance_km"),
+    )
+    if run_lat is not None and run_lon is not None and run_dist is not None:
+        route = RunsRepository(supabase).get_route_for_run(
+            user_id, float(run_lat), float(run_lon), float(run_dist)
+        )
+
     return {
         "activity_id": activity_id,
         "has_track": bool(lat),
@@ -282,6 +295,7 @@ async def _track(user_id: UUID, activity_id: str) -> dict[str, Any]:
         "avg_pace_min_per_km": _f(run.get("average_pace_min_per_km")),
         "weather_type": run.get("weather_type"),
         "temperature_celsius": _f(run.get("temperature_celsius")),
+        "route": route,
     }
 
 

--- a/backend/tests/test_route_leaderboard.py
+++ b/backend/tests/test_route_leaderboard.py
@@ -89,6 +89,28 @@ def test_distance_separates_routes_from_same_start() -> None:
     assert {round(r["distance_km"], 1) for r in routes} == {4.0, 8.0}
 
 
+def test_get_route_for_run_returns_count_and_rank() -> None:
+    # Two routes; the queried run belongs to the busier one.
+    rows = [
+        _run(42.244, -71.651, 4.0, 6.0, "2026-01-01"),
+        _run(42.244, -71.650, 4.0, 5.9, "2026-02-01"),  # precision=2 folds these together
+        _run(42.244, -71.651, 4.0, 6.1, "2026-03-01"),
+        _run(41.893, -87.624, 5.0, 5.5, "2026-01-01"),
+        _run(41.893, -87.624, 5.0, 5.6, "2026-02-01"),
+    ]
+    got = _repo(rows).get_route_for_run(USER, 42.2441, -71.6509, 4.05)
+    assert got is not None
+    assert got["run_count"] == 3  # all three home runs, split cells folded by precision=2
+    assert got["rank"] == 1  # busiest route
+    assert got["total_routes"] == 2
+    assert got["best_pace_min_per_km"] == 5.9
+
+
+def test_get_route_for_run_none_for_unseen_start() -> None:
+    rows = [_run(42.244, -71.651, 4.0, 6.0, "2026-01-01")]
+    assert _repo(rows).get_route_for_run(USER, 10.0, 10.0, 4.0) is None
+
+
 # ---- endpoint wiring ----
 
 

--- a/backend/tests/test_run_track.py
+++ b/backend/tests/test_run_track.py
@@ -24,14 +24,18 @@ _RUN = {
 
 
 class _Repo:
-    def __init__(self, run: dict[str, Any] | None) -> None:
+    def __init__(self, run: dict[str, Any] | None, route: dict[str, Any] | None = None) -> None:
         self._run = run
+        self._route = route
 
     def __call__(self, _sb: Any) -> _Repo:
         return self
 
     def get_run_by_activity_id(self, _uid: Any, _aid: str) -> dict[str, Any] | None:
         return self._run
+
+    def get_route_for_run(self, *_a: Any, **_k: Any) -> dict[str, Any] | None:
+        return self._route
 
 
 class _FakeApi:
@@ -51,9 +55,14 @@ class _FakeApi:
         return self._detail
 
 
-def _track(run: dict[str, Any] | None, detail: dict[str, Any], monkeypatch: Any) -> Any:
+def _track(
+    run: dict[str, Any] | None,
+    detail: dict[str, Any],
+    monkeypatch: Any,
+    route: dict[str, Any] | None = None,
+) -> Any:
     monkeypatch.setattr(runs_module, "get_supabase_client", lambda: object())
-    monkeypatch.setattr(runs_module, "RunsRepository", _Repo(run))
+    monkeypatch.setattr(runs_module, "RunsRepository", _Repo(run, route))
     monkeypatch.setattr(runs_module, "TokenRepository", lambda _sb: object())
     monkeypatch.setattr(runs_module, "_resolve_access_token", lambda _uid, _repo: "tok")
     monkeypatch.setattr(runs_module, "SmashRunAPIClient", _FakeApi(detail))
@@ -89,6 +98,24 @@ def test_track_empty_when_no_gps(monkeypatch: Any) -> None:
     assert out["has_track"] is False
     assert out["lat"] == []
     assert out["lon"] == []
+
+
+def test_track_includes_route_count_when_run_has_coords(monkeypatch: Any) -> None:
+    run = {**_RUN, "start_latitude": "42.244", "start_longitude": "-71.651"}
+    detail = {
+        "recordingKeys": ["latitude", "longitude"],
+        "recordingValues": [[42.24, 42.25], [-71.65, -71.66]],
+    }
+    route = {"run_count": 38, "rank": 3, "total_routes": 27, "best_pace_min_per_km": 5.21}
+    out = _track(run, detail, monkeypatch, route=route)
+    assert out["route"] == route
+
+
+def test_track_route_none_without_coords(monkeypatch: Any) -> None:
+    # _RUN has no start_latitude -> the route lookup is skipped.
+    detail = {"recordingKeys": ["latitude", "longitude"], "recordingValues": [[42.2], [-71.6]]}
+    out = _track(_RUN, detail, monkeypatch, route={"run_count": 99})
+    assert out["route"] is None
 
 
 def test_track_404_when_not_owned(monkeypatch: Any) -> None:

--- a/src/shared/supabase_ops/runs_repository.py
+++ b/src/shared/supabase_ops/runs_repository.py
@@ -364,7 +364,7 @@ class RunsRepository:
         self,
         user_id: UUID,
         min_runs: int = 2,
-        precision: int = 3,
+        precision: int = 2,
         dist_bucket_km: float = 0.5,
     ) -> list[dict[str, Any]]:
         """Group a user's GPS runs into repeated routes (SB-291).
@@ -374,10 +374,16 @@ class RunsRepository:
         without any polyline. Treadmill / no-GPS runs are excluded (they have
         no start coordinates).
 
+        precision=2 (~1.1 km cell) instead of 3: at 3 decimals the same physical
+        route split across a rounding boundary into two rows (SB-289 — e.g. one
+        home route counted as 20 + 18). A home-based runner starts most routes
+        from one spot, so the distance bucket does the real separating; the
+        coarser cell folds the boundary jitter back together.
+
         Args:
             user_id: User UUID
             min_runs: Only return routes run at least this many times
-            precision: Decimal places to round start lat/lon (3 ≈ 110 m cell)
+            precision: Decimal places to round start lat/lon (2 ≈ 1.1 km cell)
             dist_bucket_km: Distance bucket width in km
 
         Returns:
@@ -433,6 +439,38 @@ class RunsRepository:
 
         routes.sort(key=lambda x: x["run_count"], reverse=True)
         return routes
+
+    def get_route_for_run(
+        self,
+        user_id: UUID,
+        start_latitude: float,
+        start_longitude: float,
+        distance_km: float,
+        precision: int = 2,
+        dist_bucket_km: float = 0.5,
+    ) -> dict[str, Any] | None:
+        """The route a given run belongs to, with its count + rank (SB-296).
+
+        Reuses the leaderboard grouping so the route-card can show "run N times,
+        #k of M" for a single activity. Returns None if the run has no GPS start
+        (nothing to group on).
+        """
+        board = self.get_route_leaderboard(
+            user_id, min_runs=1, precision=precision, dist_bucket_km=dist_bucket_km
+        )
+        lat = round(float(start_latitude), precision)
+        lon = round(float(start_longitude), precision)
+        bucket = round(round(float(distance_km) / dist_bucket_km) * dist_bucket_km, 3)
+        key = f"{lat},{lon},{bucket}"
+        for rank, route in enumerate(board, start=1):
+            if route["route_key"] == key:
+                return {
+                    "run_count": route["run_count"],
+                    "rank": rank,
+                    "total_routes": len(board),
+                    "best_pace_min_per_km": route["best_pace_min_per_km"],
+                }
+        return None
 
     def get_monthly_stats(self, user_id: UUID, limit: int = 12) -> list[dict[str, Any]]:
         """

--- a/stk/src/cli/display.py
+++ b/stk/src/cli/display.py
@@ -700,6 +700,16 @@ def display_route_card(data: dict[str, Any]) -> None:
     if pace:
         stats.append(f"   ⚡ {format_pace(pace)}/mi", style="bold white")
 
+    route = data.get("route")
+    if route and route.get("run_count"):
+        line = f"\n🔁 {route['run_count']}× on this route"
+        if route.get("rank") and route.get("total_routes"):
+            line += f"  ·  #{route['rank']}/{route['total_routes']}"
+        best = route.get("best_pace_min_per_km")
+        if best:
+            line += f"  ·  best {format_pace(best)}/mi"
+        stats.append(line, style="yellow")
+
     console.print(
         Panel(
             Group(Text("\n".join(rows), style="bright_green"), stats),


### PR DESCRIPTION
Follow-up on SB-291 / SB-295. Makes `stk route show` answer "how many times have I run this route" directly, and fixes the split-route artifact from SB-289.

## 1. Count on the route-card
`stk route show` drew the map but not the count — you had to eyeball `stk routes` and mentally merge split rows. Now:
```
🔁 38× on this route  ·  #3/27  ·  best 8:23/mi
```
- New `RunsRepository.get_route_for_run` returns the route a run belongs to (count, rank, best pace), reusing the leaderboard grouping.
- `GET /runs/{id}/track` returns a `route` block (None when the run has no GPS start).

## 2. Split-route precision fix (SB-289 note)
Route-cell rounding was 3 decimals (~110 m), so one physical route split across a boundary into two rows — a home route counted as **20 + 18** (really the same ~38). Default `precision` **3 → 2** (~1.1 km). A home-based runner starts most routes from one spot; the distance bucket does the real separating, so the coarser cell folds the boundary jitter together.

## Testing
- `get_route_for_run`: count + rank (split cells folded by precision=2); None for unseen start.
- Track endpoint: `route` block present when the run has coords, None otherwise.
- Existing leaderboard tests still green under precision=2. Backend suite 238 passed; ruff clean; card renders on one line.

## Out of scope
End-point / polyline route identity (SB-289 north-star) — the exact fix that also handles reverse/partial overlaps; start+distance is the interim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes SB-297