### PR TITLE
feat: interactive route map on run detail (web) — SB-299

### DIFF
--- a/backend/routes/runs.py
+++ b/backend/routes/runs.py
@@ -263,17 +263,29 @@ async def _track(user_id: UUID, activity_id: str) -> dict[str, Any]:
 
     keys = detail.get("recordingKeys") or []
     values = detail.get("recordingValues") or []
-    lat: list[float] = []
-    lon: list[float] = []
-    if "latitude" in keys and "longitude" in keys and values:
-        lat = [float(v) for v in values[keys.index("latitude")]]
-        lon = [float(v) for v in values[keys.index("longitude")]]
+
+    def series(name: str) -> list[float]:
+        return [float(v) for v in values[keys.index(name)]] if name in keys and values else []
+
+    lat = series("latitude")
+    lon = series("longitude")
+    elevation = series("elevation")
+    heart_rate = series("heartRate")
+    # Per-point pace (min/km) smoothed over a short window of the cumulative
+    # distance/clock series — SmashRun gives cumulative km + seconds, not pace.
+    dist_km = series("distance")
+    clock_s = series("clock")
+    pace = _per_point_pace(dist_km, clock_s)
 
     return {
         "activity_id": activity_id,
         "has_track": bool(lat),
         "lat": lat,
         "lon": lon,
+        "elevation_m": elevation,
+        "heart_rate": heart_rate,
+        "pace_min_per_km": pace,
+        "dist_km": dist_km,
         "city": detail.get("city"),
         "state": detail.get("state"),
         "date": run["start_date_time_local"],
@@ -283,6 +295,26 @@ async def _track(user_id: UUID, activity_id: str) -> dict[str, Any]:
         "weather_type": run.get("weather_type"),
         "temperature_celsius": _f(run.get("temperature_celsius")),
     }
+
+
+def _per_point_pace(dist_km: list[float], clock_s: list[float], window: int = 5) -> list[float]:
+    """Windowed pace (min/km) per sample from cumulative distance + clock.
+
+    A lookback window smooths out GPS jitter (a single noisy sample would spike
+    an instantaneous pace). Returns [] if the series aren't both present/aligned.
+    """
+    n = len(dist_km)
+    if n == 0 or len(clock_s) != n:
+        return []
+    out: list[float] = []
+    for i in range(n):
+        j = max(0, i - window)
+        dd = dist_km[i] - dist_km[j]
+        dt = clock_s[i] - clock_s[j]
+        out.append(round(dt / 60 / dd, 2) if dd > 0.005 and dt > 0 else 0.0)
+    # Seed the first samples (no lookback) with the first real pace.
+    first = next((p for p in out if p > 0), 0.0)
+    return [p if p > 0 else first for p in out]
 
 
 @router.get("/{activity_id}/track")

--- a/backend/tests/test_run_track.py
+++ b/backend/tests/test_run_track.py
@@ -60,14 +60,16 @@ def _track(run: dict[str, Any] | None, detail: dict[str, Any], monkeypatch: Any)
     return asyncio.run(runs_module.get_run_track("act-1", user_id=USER))
 
 
-def test_track_returns_lat_lon_and_place(monkeypatch: Any) -> None:
+def test_track_returns_lat_lon_place_and_series(monkeypatch: Any) -> None:
     detail = {
-        "recordingKeys": ["distance", "latitude", "longitude", "elevation"],
+        "recordingKeys": ["distance", "latitude", "longitude", "elevation", "heartRate", "clock"],
         "recordingValues": [
-            [0, 1, 2],
+            [0.0, 0.1, 0.2],  # cumulative km
             [42.24, 42.25, 42.26],
             [-71.65, -71.66, -71.67],
-            [10, 11, 12],
+            [10, 12, 11],  # elevation m
+            [140, 150, 155],  # heart rate
+            [0, 36, 74],  # clock seconds
         ],
         "city": "Worcester County",
         "state": "Massachusetts",
@@ -76,8 +78,13 @@ def test_track_returns_lat_lon_and_place(monkeypatch: Any) -> None:
     assert out["has_track"] is True
     assert out["lat"] == [42.24, 42.25, 42.26]
     assert out["lon"] == [-71.65, -71.66, -71.67]
+    assert out["elevation_m"] == [10, 12, 11]
+    assert out["heart_rate"] == [140, 150, 155]
+    assert out["dist_km"] == [0.0, 0.1, 0.2]
+    # Pace derived from distance+clock: last window 74s / 0.2km = 6.17 min/km.
+    assert len(out["pace_min_per_km"]) == 3
+    assert out["pace_min_per_km"][-1] == pytest.approx(74 / 60 / 0.2, abs=0.01)
     assert out["city"] == "Worcester County"
-    assert out["state"] == "Massachusetts"
     # Stats come from our DB row (canonical), coerced to float.
     assert out["distance_km"] == 6.88
     assert out["avg_pace_min_per_km"] == 6.05

--- a/frontend/src/components/RouteMap.vue
+++ b/frontend/src/components/RouteMap.vue
@@ -1,0 +1,316 @@
+<template>
+  <div class="bg-white rounded-xl border border-gray-100 shadow-sm p-6 mt-4">
+    <div class="flex items-start justify-between flex-wrap gap-3 mb-3">
+      <div>
+        <h2 class="font-semibold text-gray-900">Route</h2>
+        <p v-if="place" class="text-xs text-gray-400 mt-0.5">📍 {{ place }}</p>
+      </div>
+      <div class="flex items-center gap-1.5 flex-wrap">
+        <button
+          v-for="m in availableModes"
+          :key="m.key"
+          type="button"
+          class="text-xs px-2.5 py-1 rounded-full border transition-colors"
+          :class="mode === m.key
+            ? 'border-brand-500 bg-brand-50 text-brand-700 font-medium'
+            : 'border-gray-200 text-gray-500 hover:border-gray-300'"
+          @click="mode = m.key"
+        >
+          {{ m.label }}
+        </button>
+        <button
+          type="button"
+          class="text-xs px-2.5 py-1 rounded-full border border-gray-200 text-gray-500 hover:border-gray-300"
+          @click="replay"
+        >
+          ↻ Replay
+        </button>
+      </div>
+    </div>
+
+    <div
+      class="relative w-full rounded-lg overflow-hidden"
+      :style="{ aspectRatio: `${vb.W} / ${vb.H}`, background: 'radial-gradient(120% 90% at 50% 0%, #fff7ec, #fdfbf7)' }"
+      @pointermove="onHover"
+      @pointerleave="hoverIdx = null"
+    >
+      <svg :viewBox="`0 0 ${vb.W} ${vb.H}`" preserveAspectRatio="xMidYMid meet" class="block w-full h-full">
+        <defs>
+          <filter id="rm-glow" x="-20%" y="-20%" width="140%" height="140%">
+            <feGaussianBlur stdDeviation="0.5" result="b" />
+            <feMerge><feMergeNode in="b" /><feMergeNode in="SourceGraphic" /></feMerge>
+          </filter>
+        </defs>
+
+        <!-- ghost full route -->
+        <path :d="pathD" fill="none" stroke="#f1930f" stroke-opacity="0.12"
+              stroke-width="1.1" stroke-linecap="round" stroke-linejoin="round" />
+
+        <!-- colored segments, revealed progressively -->
+        <g filter="url(#rm-glow)">
+          <line
+            v-for="(s, i) in segments"
+            :key="i"
+            :x1="s.x1" :y1="s.y1" :x2="s.x2" :y2="s.y2"
+            :stroke="s.color"
+            stroke-width="1.2"
+            stroke-linecap="round"
+            :style="{ opacity: i < shown ? 1 : 0 }"
+          />
+        </g>
+
+        <!-- start marker -->
+        <circle :cx="pts[0].x" :cy="pts[0].y" r="1.4" fill="#ffffff"
+                stroke="#16a34a" stroke-width="0.8" />
+
+        <!-- runner dot while drawing -->
+        <circle v-if="running" :cx="runnerPt.x" :cy="runnerPt.y" r="1.4"
+                fill="#fff" filter="url(#rm-glow)" />
+
+        <!-- hover marker -->
+        <circle v-if="hoverIdx !== null" :cx="pts[hoverIdx].x" :cy="pts[hoverIdx].y"
+                r="1.6" fill="#f1930f" stroke="#fff" stroke-width="0.7" />
+      </svg>
+
+      <!-- hover tooltip -->
+      <div
+        v-if="hoverIdx !== null"
+        class="absolute pointer-events-none bg-gray-900/90 text-white text-[11px] rounded-md px-2 py-1.5 shadow-lg whitespace-nowrap -translate-x-1/2"
+        :style="{
+          left: `${(pts[hoverIdx].x / vb.W) * 100}%`,
+          top: `calc(${(pts[hoverIdx].y / vb.H) * 100}% - 8px)`,
+          transform: 'translate(-50%, -100%)',
+        }"
+      >
+        <div class="font-semibold">{{ hoverDistance }}</div>
+        <div v-if="hoverPace" class="text-gray-300">{{ hoverPace }}</div>
+        <div v-if="hoverHr" class="text-gray-300">{{ hoverHr }} bpm</div>
+        <div v-if="hoverElev" class="text-gray-300">↑ {{ hoverElev }}</div>
+      </div>
+    </div>
+
+    <!-- legend for the active metric -->
+    <div class="flex items-center justify-between mt-3 text-xs text-gray-400">
+      <span>{{ activeMode.legendLow }}</span>
+      <div class="h-1.5 flex-1 mx-3 rounded-full" :style="{ background: legendGradient }" />
+      <span>{{ activeMode.legendHigh }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import type { RunTrack, Unit } from '@/types/runs'
+import { formatPace, distanceLabel } from '@/utils/format'
+
+const props = defineProps<{ track: RunTrack; unit: Unit }>()
+
+const KM_PER_MI = 1.609344
+const toMi = (km: number) => km / KM_PER_MI
+const toFt = (m: number) => m * 3.28084
+
+type ModeKey = 'pace' | 'elevation' | 'hr'
+type Stop = [number, number, number]
+
+// Each metric: how to read its series, the colour ramp (low→high value), and
+// how to phrase the legend ends. Pace ramps gold(fast)→red(slow); elevation
+// low→high blue; HR easy→max green→red.
+const MODE_DEFS: Record<
+  ModeKey,
+  { key: ModeKey; label: string; series: () => number[]; stops: Stop[]; legend: (lo: number, hi: number) => [string, string] }
+> = {
+  pace: {
+    key: 'pace',
+    label: 'Pace',
+    series: () => props.track.pace_min_per_km,
+    stops: [[255, 210, 74], [241, 147, 15], [224, 87, 31]],
+    legend: (lo, hi) => [`${formatPace(lo, props.unit)}/${distanceLabel(props.unit)}`, `${formatPace(hi, props.unit)}/${distanceLabel(props.unit)}`],
+  },
+  elevation: {
+    key: 'elevation',
+    label: 'Elevation',
+    series: () => props.track.elevation_m,
+    stops: [[147, 197, 253], [59, 130, 246], [30, 58, 138]],
+    legend: (lo, hi) => [elevLabel(lo), elevLabel(hi)],
+  },
+  hr: {
+    key: 'hr',
+    label: 'Heart rate',
+    series: () => props.track.heart_rate,
+    stops: [[52, 211, 153], [245, 158, 11], [239, 68, 68]],
+    legend: (lo, hi) => [`${Math.round(lo)} bpm`, `${Math.round(hi)} bpm`],
+  },
+}
+
+const elevLabel = (m: number) =>
+  props.unit === 'mi' ? `${Math.round(toFt(m))} ft` : `${Math.round(m)} m`
+
+const n = computed(() => props.track.lat.length)
+
+const availableModes = computed(() =>
+  (Object.values(MODE_DEFS) as (typeof MODE_DEFS)[ModeKey][]).filter((m) => {
+    const s = m.series()
+    return s.length === n.value && Math.max(...s) > Math.min(...s)
+  }),
+)
+
+const mode = ref<ModeKey>('pace')
+watch(availableModes, (modes) => {
+  if (!modes.some((m) => m.key === mode.value) && modes.length) mode.value = modes[0].key
+}, { immediate: true })
+
+const activeDef = computed(() => MODE_DEFS[mode.value])
+
+// --- projection (equirectangular, cos(lat)-corrected, north up) ---
+const vb = computed(() => {
+  const { lat, lon } = props.track
+  const meanLat = lat.reduce((a, b) => a + b, 0) / lat.length
+  const k = Math.cos((meanLat * Math.PI) / 180)
+  const xs = lon.map((v) => v * k)
+  const minx = Math.min(...xs)
+  const maxx = Math.max(...xs)
+  const miny = Math.min(...lat)
+  const maxy = Math.max(...lat)
+  const spanx = maxx - minx || 1e-9
+  const spany = maxy - miny || 1e-9
+  const W = 100
+  const pad = 6
+  // Fit both spans to one scale so the shape isn't distorted; height follows.
+  const s = Math.max(spanx / (W - 2 * pad), spany / 60)
+  const usedW = spanx / s
+  const usedH = spany / s
+  const H = usedH + 2 * pad
+  const offx = (W - usedW) / 2
+  const pts = lat.map((la, i) => ({
+    x: offx + (xs[i] - minx) / s,
+    y: H - (pad + (la - miny) / s),
+  }))
+  return { W, H, pts, xs, minx, s }
+})
+
+const pts = computed(() => vb.value.pts)
+const pathD = computed(() => 'M' + pts.value.map((p) => `${p.x.toFixed(2)} ${p.y.toFixed(2)}`).join(' L'))
+
+// --- colour ramp for the active metric ---
+function ramp(values: number[], stops: Stop[]) {
+  const sorted = [...values].sort((a, b) => a - b)
+  const lo = sorted[Math.floor(sorted.length * 0.05)]
+  const hi = sorted[Math.floor(sorted.length * 0.95)] || lo + 1
+  const color = (v: number) => {
+    let t = (v - lo) / (hi - lo || 1)
+    t = Math.max(0, Math.min(1, t))
+    const seg = t * (stops.length - 1)
+    const i = Math.min(stops.length - 2, Math.floor(seg))
+    const f = seg - i
+    const a = stops[i]
+    const b = stops[i + 1]
+    return `rgb(${Math.round(a[0] + (b[0] - a[0]) * f)},${Math.round(a[1] + (b[1] - a[1]) * f)},${Math.round(a[2] + (b[2] - a[2]) * f)})`
+  }
+  return { color, lo, hi }
+}
+
+const segments = computed(() => {
+  const s = activeDef.value.series()
+  const { color } = ramp(s, activeDef.value.stops)
+  const p = pts.value
+  const out: { x1: number; y1: number; x2: number; y2: number; color: string }[] = []
+  for (let i = 1; i < p.length; i++) {
+    out.push({ x1: p[i - 1].x, y1: p[i - 1].y, x2: p[i].x, y2: p[i].y, color: color(s[i]) })
+  }
+  return out
+})
+
+const activeMode = computed(() => {
+  const s = activeDef.value.series()
+  const { lo, hi } = ramp(s, activeDef.value.stops)
+  const [legendLow, legendHigh] = activeDef.value.legend(lo, hi)
+  return { legendLow, legendHigh }
+})
+
+const legendGradient = computed(() => {
+  const st = activeDef.value.stops
+  const css = st.map((c, i) => `rgb(${c[0]},${c[1]},${c[2]}) ${(i / (st.length - 1)) * 100}%`)
+  return `linear-gradient(90deg, ${css.join(', ')})`
+})
+
+// --- draw-on animation ---
+const shown = ref(0)
+const running = ref(false)
+const runnerPt = computed(() => pts.value[Math.max(0, Math.min(pts.value.length - 1, shown.value))])
+let rafId = 0
+
+function replay() {
+  cancelAnimationFrame(rafId)
+  const total = segments.value.length
+  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  if (prefersReduced) {
+    shown.value = total
+    running.value = false
+    return
+  }
+  const dur = 3400
+  const t0 = performance.now()
+  running.value = true
+  const step = (now: number) => {
+    const p = Math.min(1, (now - t0) / dur)
+    const e = 1 - Math.pow(1 - p, 3)
+    shown.value = Math.round(total * e)
+    if (p < 1) {
+      rafId = requestAnimationFrame(step)
+    } else {
+      running.value = false
+    }
+  }
+  rafId = requestAnimationFrame(step)
+}
+
+onMounted(replay)
+onBeforeUnmount(() => cancelAnimationFrame(rafId))
+
+// --- hover scrubbing ---
+const hoverIdx = ref<number | null>(null)
+function onHover(e: PointerEvent) {
+  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+  const vx = ((e.clientX - rect.left) / rect.width) * vb.value.W
+  const vy = ((e.clientY - rect.top) / rect.height) * vb.value.H
+  let best = -1
+  let bestD = Infinity
+  const p = pts.value
+  for (let i = 0; i < p.length; i++) {
+    const dx = p[i].x - vx
+    const dy = p[i].y - vy
+    const d = dx * dx + dy * dy
+    if (d < bestD) {
+      bestD = d
+      best = i
+    }
+  }
+  hoverIdx.value = best
+}
+
+const hoverDistance = computed(() => {
+  if (hoverIdx.value === null) return ''
+  const km = props.track.dist_km[hoverIdx.value] ?? 0
+  return props.unit === 'mi' ? `${toMi(km).toFixed(2)} mi` : `${km.toFixed(2)} km`
+})
+const hoverPace = computed(() => {
+  const i = hoverIdx.value
+  if (i === null) return ''
+  const p = props.track.pace_min_per_km[i]
+  return p ? `${formatPace(p, props.unit)}/${distanceLabel(props.unit)}` : ''
+})
+const hoverHr = computed(() => {
+  const i = hoverIdx.value
+  if (i === null) return 0
+  return props.track.heart_rate[i] ? Math.round(props.track.heart_rate[i]) : 0
+})
+const hoverElev = computed(() => {
+  const i = hoverIdx.value
+  if (i === null || !props.track.elevation_m.length) return ''
+  return elevLabel(props.track.elevation_m[i])
+})
+
+const place = computed(() =>
+  [props.track.city, props.track.state].filter(Boolean).join(', '),
+)
+</script>

--- a/frontend/src/components/__tests__/RouteMap.test.ts
+++ b/frontend/src/components/__tests__/RouteMap.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import RouteMap from '../RouteMap.vue'
+import type { RunTrack } from '@/types/runs'
+
+// jsdom has no matchMedia; force prefers-reduced-motion so the draw-on
+// animation resolves to "show everything" synchronously.
+beforeEach(() => {
+  vi.stubGlobal('matchMedia', () => ({ matches: true, addEventListener() {}, removeEventListener() {} }))
+})
+
+const track: RunTrack = {
+  activity_id: 'act-1',
+  has_track: true,
+  lat: [42.0, 42.001, 42.002, 42.003],
+  lon: [-71.0, -71.001, -71.002, -71.001],
+  elevation_m: [10, 12, 14, 11],
+  heart_rate: [140, 150, 160, 150],
+  pace_min_per_km: [6.0, 6.0, 5.0, 7.0],
+  dist_km: [0, 0.1, 0.2, 0.3],
+  city: 'Worcester County',
+  state: 'Massachusetts',
+  date: '2026-07-21T08:32:00',
+  distance_km: 6.88,
+  duration_seconds: 2498,
+  avg_pace_min_per_km: 6.05,
+  weather_type: 'cloudy',
+  temperature_celsius: 20.3,
+}
+
+describe('RouteMap', () => {
+  it('renders one segment per pair of points', () => {
+    const w = mount(RouteMap, { props: { track, unit: 'mi' } })
+    // 4 points -> 3 connecting segments.
+    expect(w.findAll('line').length).toBe(3)
+  })
+
+  it('offers a mode toggle for each metric with variation', () => {
+    const w = mount(RouteMap, { props: { track, unit: 'mi' } })
+    const labels = w.findAll('button').map((b) => b.text())
+    expect(labels).toContain('Pace')
+    expect(labels).toContain('Elevation')
+    expect(labels).toContain('Heart rate')
+  })
+
+  it('hides a metric mode when its series is flat', () => {
+    const flat = { ...track, heart_rate: [150, 150, 150, 150] }
+    const w = mount(RouteMap, { props: { track: flat, unit: 'mi' } })
+    const labels = w.findAll('button').map((b) => b.text())
+    expect(labels).not.toContain('Heart rate')
+  })
+
+  it('shows the place name', () => {
+    const w = mount(RouteMap, { props: { track, unit: 'mi' } })
+    expect(w.text()).toContain('Worcester County, Massachusetts')
+  })
+
+  it('switches the coloured segments when the mode changes', async () => {
+    const w = mount(RouteMap, { props: { track, unit: 'mi' } })
+    const paceColors = w.findAll('line').map((l) => l.attributes('stroke'))
+    const elevBtn = w.findAll('button').find((b) => b.text() === 'Elevation')!
+    await elevBtn.trigger('click')
+    const elevColors = w.findAll('line').map((l) => l.attributes('stroke'))
+    expect(elevColors).not.toEqual(paceColors)
+  })
+})

--- a/frontend/src/composables/useRunTrack.ts
+++ b/frontend/src/composables/useRunTrack.ts
@@ -1,0 +1,25 @@
+import { ref } from 'vue'
+import { apiCall } from '@/config/api'
+import type { RunTrack } from '@/types/runs'
+
+/** One run's GPS track + aligned metric series for the route map (SB-298).
+ * Fetched lazily and separately from the run detail (it hits SmashRun). */
+export function useRunTrack(activityId: string) {
+  const track = ref<RunTrack | null>(null)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const load = async (): Promise<void> => {
+    loading.value = true
+    error.value = null
+    try {
+      track.value = await apiCall<RunTrack>(`/runs/${encodeURIComponent(activityId)}/track`)
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load route'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { track, loading, error, load }
+}

--- a/frontend/src/types/runs.ts
+++ b/frontend/src/types/runs.ts
@@ -166,3 +166,23 @@ export interface RunDetail {
   notes: string | null
   splits: RunSplit[]
 }
+
+/** Per-point GPS track + aligned metric series for the route map (SB-298). */
+export interface RunTrack {
+  activity_id: string
+  has_track: boolean
+  lat: number[]
+  lon: number[]
+  elevation_m: number[]
+  heart_rate: number[]
+  pace_min_per_km: number[]
+  dist_km: number[]
+  city: string | null
+  state: string | null
+  date: string
+  distance_km: number | null
+  duration_seconds: number | null
+  avg_pace_min_per_km: number | null
+  weather_type: string | null
+  temperature_celsius: number | null
+}

--- a/frontend/src/views/RunDetailView.vue
+++ b/frontend/src/views/RunDetailView.vue
@@ -59,6 +59,8 @@
         </div>
       </div>
 
+      <RouteMap v-if="track && track.has_track" :track="track" :unit="unit" />
+
       <div v-if="run.splits.length > 0" class="bg-white rounded-xl border border-gray-100 shadow-sm p-6 mt-4">
         <h2 class="font-semibold text-gray-900 mb-1">{{ splitNoun }} splits</h2>
         <p class="text-xs text-gray-400 mb-3">fastest split highlighted</p>
@@ -106,14 +108,17 @@ import {
   Cloud, CloudDrizzle, CloudRain, CloudSnow, Snowflake, Sun, SunDim, Wind, Zap, Home, Thermometer,
 } from 'lucide-vue-next'
 import { useRunDetail } from '@/composables/useRunDetail'
+import { useRunTrack } from '@/composables/useRunTrack'
 import { useUserPreferences } from '@/composables/useUserPreferences'
 import { formatDate, formatDistance, formatDuration, formatPace, distanceLabel } from '@/utils/format'
+import RouteMap from '@/components/RouteMap.vue'
 
 const KM_PER_MI = 1.609344
 
 const route = useRoute()
 const { unit } = useUserPreferences()
 const { run, loading, error, load } = useRunDetail(String(route.params.activityId))
+const { track, load: loadTrack } = useRunTrack(String(route.params.activityId))
 
 // Start time (browser-local, matching formatDate) + early-bird nod (SB-270).
 const startTime = computed(() => {
@@ -254,5 +259,10 @@ const elevOptions = computed(() => ({
   tooltip: { y: { formatter: (v: number) => `${Math.round(v)} ${elevUnit.value}` } },
 }))
 
-onMounted(load)
+onMounted(() => {
+  load()
+  // The track hits SmashRun on the backend — load it lazily, never block the
+  // page, and let RouteMap render only if a GPS track came back.
+  loadTrack()
+})
 </script>


### PR DESCRIPTION
The web version of `stk route show` — an animated, interactive GPS route on the run detail page. Ships the preview mockup for real. Part of the SB-289 route-viz arc.

## Backend
`GET /runs/{id}/track` now returns per-point series aligned with lat/lon: `elevation_m`, `heart_rate`, `pace_min_per_km` (windowed from cumulative distance + clock), `dist_km` — so the map colors by the **real** metric, not a proxy.

## Frontend — `RouteMap.vue`
- SVG route, cos(lat)-corrected + north-up
- **Draw-on animation** with a leading runner dot (respects `prefers-reduced-motion`)
- **Per-segment coloring, toggleable**: Pace (gold→red), Elevation (blue ramp), Heart rate (green→red). A mode hides when its series is flat or absent.
- **Hover scrubbing**: pace / HR / elevation at any point on the route, plus a metric legend
- Loaded lazily via `useRunTrack` (never blocks the page); renders above the splits chart when a GPS track exists
- Navy UI chrome + warm route colors, matching the existing splits/elevation charts

## Testing
- 5 component tests: one segment per point-pair, a toggle per metric, mode-switch recolors, flat series hides its mode, place name shown
- Backend: series extraction + windowed pace derivation
- Frontend type-check + build clean; backend suite 234 passed; no new frontend test failures

## Notes
- `/track` is also touched by SB-297 (route count on the card). Trivial additive merge if that lands first — both just add keys to the same response.
- Live browser verification lands post-deploy: `/track` hits SmashRun, and the same endpoint is already proven live via `stk route show`.

## Follow-ups
Mile markers on the path · stored polylines (avoid the per-view SmashRun call, unlock the territory heatmap + multi-run ghost-race) · optional Leaflet map-tile underlay (with the privacy tradeoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes SB-299