### PR TITLE
ci: serialize deploys + rebase before tag commit (SB-300)

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -13,6 +13,13 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/silverbeer/myrunstreak-backend
 
+# Serialize deploys so two near-simultaneous merges don't race on the Helm
+# image-tag commit (non-fast-forward push). Queue, don't cancel — each image
+# builds and the later merge's tag wins (SB-300).
+concurrency:
+  group: backend-deploy
+  cancel-in-progress: false
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -22,6 +29,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so the pre-commit rebase can fast-forward onto main
+          # (also covers reruns whose base has drifted).
+          fetch-depth: 0
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -53,6 +64,12 @@ jobs:
         run: |
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
           sed -i "s|tag: \".*\" # backend-tag|tag: \"${SHORT_SHA}\" # backend-tag|" helm/myrunstreak/values.yaml
+
+      - name: Rebase onto latest main
+        # Belt-and-suspenders with the concurrency guard: pick up any commit that
+        # landed on main since checkout (e.g. a rerun with a drifted base) so the
+        # tag commit fast-forwards instead of getting rejected.
+        run: git pull --rebase --autostash origin main
 
       - name: Commit updated Helm values
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -12,6 +12,12 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/silverbeer/myrunstreak-frontend
 
+# Serialize deploys so two near-simultaneous merges don't race on the Helm
+# image-tag commit (non-fast-forward push). Queue, don't cancel (SB-300).
+concurrency:
+  group: frontend-deploy
+  cancel-in-progress: false
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -21,6 +27,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so the pre-commit rebase can fast-forward onto main.
+          fetch-depth: 0
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -53,6 +62,11 @@ jobs:
         run: |
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
           sed -i "s|tag: \".*\" # frontend-tag|tag: \"${SHORT_SHA}\" # frontend-tag|" helm/myrunstreak/values.yaml
+
+      - name: Rebase onto latest main
+        # Pick up any commit that landed on main since checkout so the tag
+        # commit fast-forwards instead of getting rejected (SB-300).
+        run: git pull --rebase --autostash origin main
 
       - name: Commit updated Helm values
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
Fixes SB-300.

## Problem
When two merges hit main close together (#173 and #174, ~10s apart), both backend deploys raced to commit the Helm image-tag bump. The loser failed with `! [rejected] main -> main (non-fast-forward)`. The Docker image builds + pushes fine — only the `values.yaml` commit fails — so ArgoCD never sees the new tag and **prod silently keeps the old image** behind a green-looking merge. Reruns made it worse (stale checkout base → always non-fast-forward).

## Fix (both backend + frontend deploy workflows)
1. **`concurrency: { group: <name>-deploy, cancel-in-progress: false }`** — serialize deploys. Queued (not cancelled), so the second deploy checks out *after* the first's tag commit lands → its push fast-forwards. Both images build; the latest merge's tag wins. (Mirrors the guard `supabase-migrations.yml` already has.)
2. **`fetch-depth: 0` + `git pull --rebase --autostash origin main`** before the commit — fast-forwards onto main even when the base drifted (covers reruns).

## Note
Merging this PR touches `.github/workflows/backend-deploy.yml`, so it triggers a backend deploy — a live self-test of the fix.

Recovery for the incident that surfaced this (prod on stale `39287fa`) was a manual `values.yaml` bump to `4ff5637`; backend is already live on the SB-297 + SB-298 code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)