### PR TITLE
ci: bump actions to Node 24 runtimes (SB-301)

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -28,14 +28,14 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Full history so the pre-commit rebase can fast-forward onto main
           # (also covers reruns whose base has drifted).
           fetch-depth: 0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -43,14 +43,14 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
             type=sha,prefix=,format=short
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: backend/Dockerfile
@@ -72,7 +72,7 @@ jobs:
         run: git pull --rebase --autostash origin main
 
       - name: Commit updated Helm values
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "ci: update myrunstreak-backend image tag to ${{ github.sha }} [skip ci]"
           file_pattern: helm/myrunstreak/values.yaml

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -26,13 +26,13 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Full history so the pre-commit rebase can fast-forward onto main.
           fetch-depth: 0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -40,14 +40,14 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
             type=sha,prefix=,format=short
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./frontend
           push: true
@@ -69,7 +69,7 @@ jobs:
         run: git pull --rebase --autostash origin main
 
       - name: Commit updated Helm values
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "ci: update myrunstreak-frontend image tag to ${{ github.sha }} [skip ci]"
           file_pattern: helm/myrunstreak/values.yaml

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -19,9 +19,9 @@ jobs:
         working-directory: ./frontend
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/stk-image.yml
+++ b/.github/workflows/stk-image.yml
@@ -20,9 +20,9 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -33,14 +33,14 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest
             type=sha,prefix=,format=short
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: stk
           file: stk/Dockerfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ jobs:
     name: Root suite (src/shared, cli, planning)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           version: latest
       - name: Set up Python
@@ -51,9 +51,9 @@ jobs:
     name: Backend suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           version: latest
       - name: Set up Python
@@ -89,9 +89,9 @@ jobs:
     name: stk CLI (lint + install)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           version: latest
       - name: Set up Python


### PR DESCRIPTION
Fixes SB-301. Addresses the `Node.js 20 is deprecated` warning on every job.

## What
Bump each action to its **lowest Node 24 major** — verified against each `action.yml`'s `runs.using`, not guessed:

| action | v→ | why not lower |
|---|---|---|
| actions/checkout | v4→**v5** | |
| actions/setup-node | v4→**v5** | |
| astral-sh/setup-uv | v3→**v7** | v6 still `node20` |
| docker/login-action | v3→**v4** | |
| docker/metadata-action | v5→**v6** | |
| docker/build-push-action | v5→**v7** | v6 still `node20` |
| stefanzweifel/git-auto-commit-action | v5→**v7** | v6 still `node20` |

Workflows: backend-deploy, frontend-deploy, stk-image, frontend-test, test.

## Deferred (deliberately)
`supabase-migrations.yml` (checkout@v4 + setup-cli@v1) — `setup-cli` v3 is a **composite** rewrite, and editing that file triggers a **prod migration-apply** on merge. It gets its own PR with a dry-run, not a mechanical bump.

## Verification
- `frontend-test` + `test` exercise checkout / setup-node / setup-uv on this PR's own CI.
- Deploy + stk-image bumps run on merge — merging this (it touches the deploy workflow files) self-tests build-push@v7 / git-auto-commit@v7 via a live deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)