### PR TITLE
feat: quantify the steamy pace penalty from history (SB-304)

### DIFF
--- a/backend/routes/runs.py
+++ b/backend/routes/runs.py
@@ -213,6 +213,21 @@ async def runs_summary(
     )
 
 
+@cached(ttl=300, key_prefix="runs:conditions-penalty")
+async def _conditions_penalty(user_id: UUID) -> dict[str, Any]:
+    penalty = RunsRepository(get_supabase_client()).get_conditions_penalty(user_id)
+    return {"available": penalty is not None, **(penalty or {})}
+
+
+@router.get("/conditions-penalty")
+async def conditions_penalty(
+    user_id: UUID = Depends(authenticate_request),
+) -> dict[str, Any]:
+    """How much slower the caller runs in hot + humid conditions, from their own
+    history (SB-304). Powers the quantified steamy flag on the run detail."""
+    return await _conditions_penalty(user_id)
+
+
 @cached(ttl=60, key_prefix="runs:head")
 async def _head(user_id: UUID) -> dict[str, Any]:
     return RunsRepository(get_supabase_client()).get_runs_head(user_id)

--- a/backend/tests/test_conditions_penalty.py
+++ b/backend/tests/test_conditions_penalty.py
@@ -1,0 +1,100 @@
+"""SB-304: hot+humid pace penalty from history — repo + endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from uuid import uuid4
+
+from backend.routes import runs as runs_module
+from src.shared.supabase_ops.runs_repository import RunsRepository
+
+USER = uuid4()
+
+
+class _FakeQuery:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def __getattr__(self, _name: str) -> Any:
+        return self
+
+    def __call__(self, *_a: Any, **_k: Any) -> _FakeQuery:
+        return self
+
+    def execute(self) -> Any:
+        return SimpleNamespace(data=self._rows)
+
+
+def _repo(rows: list[dict[str, Any]]) -> RunsRepository:
+    return RunsRepository(_FakeQuery(rows))  # type: ignore[arg-type]
+
+
+def _run(pace: float, temp: float | None, humidity: float | None) -> dict[str, Any]:
+    return {
+        "average_pace_min_per_km": pace,
+        "temperature_celsius": temp,
+        "humidity_percent": humidity,
+    }
+
+
+def test_penalty_is_steamy_minus_baseline_median() -> None:
+    rows = (
+        # steamy (>=24C & >=70%): median pace 6.5 min/km
+        [_run(6.4, 26, 80), _run(6.5, 27, 85), _run(6.6, 25, 72)]
+        # baseline: median pace 6.0
+        + [_run(5.9, 15, 50), _run(6.0, 18, 60), _run(6.1, 20, 65)]
+    )
+    out = _repo(rows).get_conditions_penalty(USER, min_steamy=3)
+    assert out is not None
+    assert out["steamy_run_count"] == 3
+    assert out["baseline_run_count"] == 3
+    # (6.5 - 6.0) min/km -> sec/mi
+    assert out["penalty_sec_per_mi"] == round(0.5 * 1.609344 * 60)
+
+
+def test_none_when_too_few_steamy_runs() -> None:
+    rows = [_run(6.4, 26, 80)] + [_run(6.0, 15, 50) for _ in range(10)]
+    assert _repo(rows).get_conditions_penalty(USER, min_steamy=5) is None
+
+
+def test_runs_missing_weather_count_as_baseline() -> None:
+    # A run with null temp/humidity can't be steamy -> baseline side.
+    rows = [
+        _run(6.5, 26, 80),
+        _run(6.5, 26, 80),
+        _run(6.5, 26, 80),
+        _run(6.5, 26, 80),
+        _run(6.5, 26, 80),
+        _run(6.0, None, None),
+    ]
+    out = _repo(rows).get_conditions_penalty(USER, min_steamy=5)
+    assert out is not None
+    assert out["steamy_run_count"] == 5
+    assert out["baseline_run_count"] == 1
+
+
+class _EndpointRepo:
+    def __init__(self, penalty: dict[str, Any] | None) -> None:
+        self._penalty = penalty
+
+    def __call__(self, _sb: Any) -> _EndpointRepo:
+        return self
+
+    def get_conditions_penalty(self, _uid: Any) -> dict[str, Any] | None:
+        return self._penalty
+
+
+def test_endpoint_available_true_when_penalty(monkeypatch: Any) -> None:
+    monkeypatch.setattr(runs_module, "get_supabase_client", lambda: object())
+    monkeypatch.setattr(runs_module, "RunsRepository", _EndpointRepo({"penalty_sec_per_mi": 25}))
+    out = asyncio.run(runs_module.conditions_penalty(user_id=USER))
+    assert out == {"available": True, "penalty_sec_per_mi": 25}
+
+
+def test_endpoint_available_false_when_none(monkeypatch: Any) -> None:
+    monkeypatch.setattr(runs_module, "get_supabase_client", lambda: object())
+    monkeypatch.setattr(runs_module, "RunsRepository", _EndpointRepo(None))
+    out = asyncio.run(runs_module.conditions_penalty(user_id=USER))
+    assert out == {"available": False}

--- a/frontend/src/composables/useConditionsPenalty.ts
+++ b/frontend/src/composables/useConditionsPenalty.ts
@@ -1,0 +1,19 @@
+import { ref } from 'vue'
+import { apiCall } from '@/config/api'
+import type { ConditionsPenalty } from '@/types/runs'
+
+/** The user's hot+humid pace penalty from history (SB-304). Best-effort — a
+ * failure just leaves the steamy flag showing its generic message. */
+export function useConditionsPenalty() {
+  const penalty = ref<ConditionsPenalty | null>(null)
+
+  const load = async (): Promise<void> => {
+    try {
+      penalty.value = await apiCall<ConditionsPenalty>('/runs/conditions-penalty')
+    } catch {
+      penalty.value = null
+    }
+  }
+
+  return { penalty, load }
+}

--- a/frontend/src/types/runs.ts
+++ b/frontend/src/types/runs.ts
@@ -186,3 +186,11 @@ export interface RunTrack {
   weather_type: string | null
   temperature_celsius: number | null
 }
+
+/** Hot+humid pace penalty from the user's own history (SB-304). */
+export interface ConditionsPenalty {
+  available: boolean
+  penalty_sec_per_mi?: number
+  steamy_run_count?: number
+  baseline_run_count?: number
+}

--- a/frontend/src/views/RunDetailView.vue
+++ b/frontend/src/views/RunDetailView.vue
@@ -33,7 +33,9 @@
         </div>
 
         <p v-if="isSteamy" class="text-xs text-amber-700 mt-3">
-          Hot + humid — expect pace to run slower than the effort feels.
+          Hot + humid — expect pace to run slower than the effort feels.<template v-if="heatPenalty">
+            Your history runs about <strong>{{ heatPenalty }}s/mi</strong> slower in these
+            conditions.</template>
         </p>
 
         <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mt-5">
@@ -109,6 +111,7 @@ import {
 } from 'lucide-vue-next'
 import { useRunDetail } from '@/composables/useRunDetail'
 import { useRunTrack } from '@/composables/useRunTrack'
+import { useConditionsPenalty } from '@/composables/useConditionsPenalty'
 import { useUserPreferences } from '@/composables/useUserPreferences'
 import { formatDate, formatDistance, formatDuration, formatPace, distanceLabel } from '@/utils/format'
 import RouteMap from '@/components/RouteMap.vue'
@@ -119,6 +122,14 @@ const route = useRoute()
 const { unit } = useUserPreferences()
 const { run, loading, error, load } = useRunDetail(String(route.params.activityId))
 const { track, load: loadTrack } = useRunTrack(String(route.params.activityId))
+const { penalty, load: loadPenalty } = useConditionsPenalty()
+
+// Quantified steamy penalty (SB-304): the user's own hot+humid pace hit, shown
+// only when meaningful (positive) — otherwise the flag keeps its generic line.
+const heatPenalty = computed(() => {
+  const p = penalty.value
+  return p?.available && (p.penalty_sec_per_mi ?? 0) > 0 ? p.penalty_sec_per_mi : null
+})
 
 // Start time (browser-local, matching formatDate) + early-bird nod (SB-270).
 const startTime = computed(() => {
@@ -264,5 +275,7 @@ onMounted(() => {
   // The track hits SmashRun on the backend — load it lazily, never block the
   // page, and let RouteMap render only if a GPS track came back.
   loadTrack()
+  // Cached history stat; only surfaced when the run is steamy (SB-304).
+  loadPenalty()
 })
 </script>

--- a/src/shared/supabase_ops/runs_repository.py
+++ b/src/shared/supabase_ops/runs_repository.py
@@ -2,6 +2,7 @@
 
 import logging
 from datetime import date
+from statistics import median
 from typing import Any, cast
 from uuid import UUID
 from zoneinfo import ZoneInfo
@@ -471,6 +472,66 @@ class RunsRepository:
                     "best_pace_min_per_km": route["best_pace_min_per_km"],
                 }
         return None
+
+    def get_conditions_penalty(
+        self,
+        user_id: UUID,
+        temp_c: float = 24.0,
+        humidity_pct: float = 70.0,
+        min_steamy: int = 5,
+    ) -> dict[str, Any] | None:
+        """How much slower the user runs in hot + humid conditions (SB-304).
+
+        Compares median pace on "steamy" runs (temp ≥ temp_c AND humidity ≥
+        humidity_pct — the SB-269 flag's zone) against every other run. The
+        spike found this is the only condition that meaningfully moves this
+        runner's pace, so it's reported per-user rather than modeled.
+
+        Returns the penalty in seconds/mile plus the run counts, or None if
+        there aren't enough steamy runs to be meaningful.
+        """
+        result = (
+            self.supabase.table("runs")
+            .select("average_pace_min_per_km, temperature_celsius, humidity_percent")
+            .eq("user_id", str(user_id))
+            .not_.is_("average_pace_min_per_km", "null")
+            .limit(10000)
+            .execute()
+        )
+        rows = cast(list[dict[str, Any]], result.data)
+
+        steamy: list[float] = []
+        baseline: list[float] = []
+        for r in rows:
+            pace = r.get("average_pace_min_per_km")
+            if pace is None:
+                continue
+            pace = float(pace)
+            temp = r.get("temperature_celsius")
+            humidity = r.get("humidity_percent")
+            is_steamy = (
+                temp is not None
+                and humidity is not None
+                and float(temp) >= temp_c
+                and float(humidity) >= humidity_pct
+            )
+            (steamy if is_steamy else baseline).append(pace)
+
+        if len(steamy) < min_steamy or not baseline:
+            return None
+
+        steamy_med = median(steamy)
+        baseline_med = median(baseline)
+        penalty_min_per_km = steamy_med - baseline_med
+        return {
+            "steamy_run_count": len(steamy),
+            "baseline_run_count": len(baseline),
+            "penalty_sec_per_mi": round(penalty_min_per_km * 1.609344 * 60),
+            "steamy_median_pace_min_per_km": round(steamy_med, 3),
+            "baseline_median_pace_min_per_km": round(baseline_med, 3),
+            "temp_c": temp_c,
+            "humidity_pct": humidity_pct,
+        }
 
     def get_monthly_stats(self, user_id: UUID, limit: int = 12) -> list[dict[str, Any]]:
         """


### PR DESCRIPTION
Fixes SB-304. Turns the spike finding into a small, honest feature.

## The spike said (n=4,194 outdoor runs)
A general expected-pace model from temp/humidity **doesn't work** for this runner — regression R²≈0.05, median pace flat ~8:50–9:11/mi across nearly every temp×humidity cell. A streak runner runs by feel at consistent effort, so pace barely tracks weather. (HR didn't hide the effect either — also R²≈0.05.)

**The one real effect:** hot AND humid *together* — the existing "steamy" zone (≥24°C & ≥70%, SB-269) — is ~15–30 s/mi slower. So rather than a full model, put the user's own number on the flag they already have.

## What
- `RunsRepository.get_conditions_penalty`: median pace on steamy runs vs everything else → penalty in s/mi + counts; `None` when there aren't enough steamy runs.
- `GET /runs/conditions-penalty` — version-cached. **No schema change** (reuses existing temp/humidity columns).
- Run detail steamy flag now appends *"your history runs about N s/mi slower in these conditions"* when meaningful; keeps the generic line otherwise.
- Computed **per-user** (the app is heading multi-user) — not a hardcoded spike constant.

## Testing
- Backend (5): penalty = steamy-minus-baseline median; min-steamy guard → None; null-weather runs fall to baseline; endpoint `available` true/false.
- Backend suite 243 passed; frontend type-check + build clean; no new frontend failures.

## Notes
- Deliberately did **not** build the general pace model — the spike showed it would be a flat, useless band. This is the narrow, data-backed slice.
- Spike script + full findings on SB-304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)