### PR TITLE
ci: fix deploy tag commit — pull before sed (SB-300 v2)

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -61,15 +61,14 @@ jobs:
           platforms: linux/amd64
 
       - name: Update Helm values image tag
+        # Pull latest main FIRST (clean fast-forward — no local edits yet), THEN
+        # edit the tag. Order matters: sed-then-rebase conflicts when a prior
+        # deploy already changed this same line (SB-300 v2). Pull-then-sed never
+        # conflicts, so the auto-commit below always fast-forwards.
         run: |
+          git pull --ff-only origin main
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
           sed -i "s|tag: \".*\" # backend-tag|tag: \"${SHORT_SHA}\" # backend-tag|" helm/myrunstreak/values.yaml
-
-      - name: Rebase onto latest main
-        # Belt-and-suspenders with the concurrency guard: pick up any commit that
-        # landed on main since checkout (e.g. a rerun with a drifted base) so the
-        # tag commit fast-forwards instead of getting rejected.
-        run: git pull --rebase --autostash origin main
 
       - name: Commit updated Helm values
         uses: stefanzweifel/git-auto-commit-action@v7

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -59,14 +59,13 @@ jobs:
             VITE_API_BASE=${{ secrets.VITE_API_BASE }}
 
       - name: Update Helm values image tag
+        # Pull latest main FIRST (clean fast-forward — no local edits yet), THEN
+        # edit the tag, so the auto-commit below always fast-forwards even when a
+        # prior deploy changed this same line (SB-300 v2).
         run: |
+          git pull --ff-only origin main
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
           sed -i "s|tag: \".*\" # frontend-tag|tag: \"${SHORT_SHA}\" # frontend-tag|" helm/myrunstreak/values.yaml
-
-      - name: Rebase onto latest main
-        # Pick up any commit that landed on main since checkout so the tag
-        # commit fast-forwards instead of getting rejected (SB-300).
-        run: git pull --rebase --autostash origin main
 
       - name: Commit updated Helm values
         uses: stefanzweifel/git-auto-commit-action@v7


### PR DESCRIPTION
Follow-up to SB-300. The v1 fix stopped the parallel race but introduced a sequential conflict.

## What broke
When #177 and #178 merged back-to-back, the concurrency guard correctly serialized their deploys (no parallel race). But the v1 **rebase step** — `git pull --rebase --autostash` run *after* the `sed` tag edit — **conflicts**: #178's stashed tag change and #177's already-committed tag change touch the *same* `values.yaml` line, which can't auto-merge. The run died with `you need to resolve your current index first`, so #178's image built but never deployed (prod stuck on #177).

## Fix
Reorder: **pull latest main first** (clean fast-forward — nothing edited yet), **then** `sed` the tag, then commit. With no local change during the pull, there's nothing to conflict, and the auto-commit always fast-forwards. Keeps the v1 `concurrency` guard + `fetch-depth: 0`.

```diff
- sed -i "...tag..." values.yaml
- git pull --rebase --autostash origin main   # conflicts on the tag line
+ git pull --ff-only origin main              # clean, no local edits yet
+ sed -i "...tag..." values.yaml
```

## Note
Merging this touches the deploy workflow files → triggers a deploy → live self-test of the new order. Recovery for the incident (prod stuck on 43b4599) was a manual bump to 9e11dd7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes SB-300