### PR TITLE
ci: Telegram alert when a deploy/build fails (SB-305)

### DIFF
--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -1,0 +1,51 @@
+name: Notify on failure
+
+# Central failure alarm: fires when any of the deploy / migration / image
+# workflows conclude with failure, and pings Telegram. Catches the silent case
+# where a post-merge deploy fails behind a green PR (SB-305).
+#
+# workflow_run only triggers from the copy of this file on the DEFAULT branch,
+# so it activates once merged to main. Needs two repo secrets:
+#   TELEGRAM_BOT_TOKEN  — from @BotFather
+#   TELEGRAM_CHAT_ID    — your chat id (see @userinfobot)
+
+on:
+  workflow_run:
+    workflows:
+      - Backend Deploy
+      - Frontend Deploy
+      - Supabase Migrations
+      - stk image
+    types:
+      - completed
+
+jobs:
+  telegram:
+    # Only when the watched run actually failed.
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Telegram
+        env:
+          TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          CHAT: ${{ secrets.TELEGRAM_CHAT_ID }}
+          WF: ${{ github.event.workflow_run.name }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          URL: ${{ github.event.workflow_run.html_url }}
+          TITLE: ${{ github.event.workflow_run.display_title }}
+        run: |
+          # Skip (with a visible warning) only when the alarm isn't wired up yet
+          # — never silently on a real send error below.
+          if [ -z "$TOKEN" ] || [ -z "$CHAT" ]; then
+            echo "::warning::TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID not set — cannot notify"
+            exit 0
+          fi
+          TEXT=$(printf '🔴 %s FAILED\n%s\nbranch: %s @ %s\n%s' \
+            "$WF" "$TITLE" "$BRANCH" "${SHA:0:7}" "$URL")
+          # --fail so a bad token / bad chat id turns THIS job red instead of
+          # failing quietly (the whole point is not to miss failures).
+          curl -sS --fail -X POST \
+            "https://api.telegram.org/bot${TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${CHAT}" \
+            --data-urlencode "text=${TEXT}"


### PR DESCRIPTION
Fixes SB-305. Stop failed deploys from being silent.

## Problem
A post-merge deploy that fails goes red — but nothing tells you, so it hides behind a green PR. Prod sat on a stale image twice this way (#178's deploy failure; the earlier Node-24 rerun). Checking email isn't a good signal for the owner.

## Fix
A central `workflow_run`-triggered workflow (`notify-failure.yml`) that pings **Telegram** whenever any of these conclude with `failure`:
- Backend Deploy · Frontend Deploy · Supabase Migrations · stk image

Message includes the workflow name, commit title, branch@sha, and a link to the run.

## Not-silent by design
- If the secrets aren't set yet → visible `::warning::` and skip (so it doesn't red-fail before setup).
- If a send genuinely fails (bad token / chat id) → `curl --fail` turns the notifier **red**, so a broken alarm is itself caught.

## Setup required (owner, one-time)
1. Telegram → **@BotFather** → `/newbot` → copy the bot token.
2. DM the new bot once, then get your chat id via **@userinfobot**.
3. Add repo secrets `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID`.

Activates once merged to main (`workflow_run` fires from the default-branch copy). Until the secrets exist it no-ops with a warning — safe to merge first.

## Related
- **#179** (SB-300 v2) fixes the deploy conflict that caused the silent failure. Merge both.
- Follow-up idea: a post-deploy check asserting the running image SHA == merged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)