### PR TITLE
feat: show activity id in the stk runs table (SB-306)

### DIFF
--- a/stk/src/cli/display.py
+++ b/stk/src/cli/display.py
@@ -230,6 +230,9 @@ def display_recent_runs(data: dict[str, Any]) -> None:
     table.add_column("Pace", justify="right", style="yellow")
     table.add_column("HR", justify="right", style="red")
     table.add_column("Temp", justify="right", style="blue")
+    # The id you pass to `stk route show <id>` / `stk audio <id> ...` — dim so it
+    # stays out of the way but is there to copy (SB-306).
+    table.add_column("ID", style="dim", no_wrap=True)
 
     max_km = max((r.get("distance_km") or 0 for r in runs), default=0)
     paces = [r["avg_pace_min_per_km"] for r in runs if r.get("avg_pace_min_per_km")]
@@ -272,6 +275,7 @@ def display_recent_runs(data: dict[str, Any]) -> None:
             pace,
             hr_str,
             temp_str,
+            str(run.get("activity_id", "")),
         )
 
     # Totals footer for the shown window (display-layer arithmetic only)
@@ -284,6 +288,7 @@ def display_recent_runs(data: dict[str, Any]) -> None:
             f"[bold]{km_to_miles(total_km):.1f} mi[/bold]",
             "",
             f"[bold]{hours}h {mins}m[/bold]" if hours else f"[bold]{mins}m[/bold]",
+            "",
             "",
             "",
             "",

--- a/stk/tests/test_runs_display.py
+++ b/stk/tests/test_runs_display.py
@@ -1,0 +1,48 @@
+"""SB-306: the runs table surfaces the activity id (for stk route show / audio)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cli import display
+from rich.console import Console
+
+
+def _render(data: dict[str, Any]) -> str:
+    # Render to a string buffer so we can assert on the visible table text.
+    console = Console(record=True, width=120)
+    original = display.console
+    display.console = console
+    try:
+        display.display_recent_runs(data)
+    finally:
+        display.console = original
+    return console.export_text()
+
+
+def _run(**over: Any) -> dict[str, Any]:
+    base = {
+        "date": "2026-07-22T09:16:00",
+        "distance_km": 6.88,
+        "duration_minutes": 34.5,
+        "avg_pace_min_per_km": 6.05,
+        "heart_rate_avg": 140,
+        "temperature_celsius": 24,
+        "weather": "cloudy",
+        "activity_id": "46444589",
+    }
+    base.update(over)
+    return base
+
+
+def test_runs_table_shows_activity_id() -> None:
+    out = _render({"count": 1, "runs": [_run()]})
+    assert "ID" in out  # column header
+    assert "46444589" in out  # the id you pass to `stk route show`
+
+
+def test_totals_row_column_count_matches() -> None:
+    # A totals row with the wrong cell count raises; rendering two runs exercises it.
+    out = _render({"count": 2, "runs": [_run(), _run(activity_id="46431098")]})
+    assert "46431098" in out
+    assert "2 runs" in out


### PR DESCRIPTION
Fixes SB-306. Closes a gap in the route/audio features.

## Problem
`stk route show <id>` and `stk audio <id> ...` need an activity id — but `stk runs` / `stk recent` showed Date/Distance/Time/Pace/HR/Temp and **no id**. The only way to get one was `stk runs --json | grep activity_id`. So the map/audio commands were effectively unreachable from the CLI itself.

## Fix
A dim `ID` column (rightmost, no-wrap) on the recent-runs table — there to copy, out of the visual hierarchy's way.

```
│ Wed 7/22 │  4.28 mi │ ▉▉▉▉▉▉▉▉ │  34m │ 9:44 ⚡ │ 140 │ ☁️ 75° │ 46444589 │
```

Now: `stk runs` → copy an id → `stk route show 46444589`.

## Testing
- Table renders the `ID` header + the id value.
- Totals footer row widened to match (a mismatched cell count would raise) — guarded by a test.
- ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)