### PR TITLE
fix: stk sync watermark must not regress on backfill (SB-308)

### DIFF
--- a/stk/src/cli/commands/sync.py
+++ b/stk/src/cli/commands/sync.py
@@ -36,12 +36,28 @@ def get_last_sync_date() -> date:
 
 
 def update_sync_state(sync_date: date, runs_synced: int) -> None:
-    """Update sync state file."""
+    """Advance the incremental-sync watermark — never regress it (SB-308).
+
+    ``last_sync_date`` is the point a bare ``stk sync`` picks up from. A
+    targeted/historical sync (``--year 2022``, ``--since 2019-…``) covers an
+    *older* window, so writing its ``until`` here would drag the watermark
+    backward and make the next bare sync re-pull years of runs. Only ever move
+    it forward.
+    """
     from datetime import UTC, datetime
+
+    watermark = sync_date
+    if SYNC_STATE_FILE.exists():
+        try:
+            with open(SYNC_STATE_FILE) as f:
+                prev = date.fromisoformat(json.load(f).get("last_sync_date", ""))
+            watermark = max(watermark, prev)
+        except (ValueError, json.JSONDecodeError, KeyError, OSError):
+            pass  # unreadable/legacy state -> just use this sync's date
 
     ensure_config_dir()
     state = {
-        "last_sync_date": sync_date.isoformat(),
+        "last_sync_date": watermark.isoformat(),
         "last_sync_timestamp": datetime.now(UTC).isoformat(),
         "runs_synced": runs_synced,
     }

--- a/stk/tests/test_sync_state.py
+++ b/stk/tests/test_sync_state.py
@@ -1,0 +1,54 @@
+"""SB-308: the incremental-sync watermark only moves forward, never back."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import pytest
+from cli.commands import sync as sync_mod
+
+
+@pytest.fixture(autouse=True)
+def _tmp_state(monkeypatch: Any, tmp_path: Path) -> Path:
+    state = tmp_path / "sync_state.json"
+    monkeypatch.setattr(sync_mod, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(sync_mod, "SYNC_STATE_FILE", state)
+    return state
+
+
+def _written(state: Path) -> str:
+    return json.loads(state.read_text())["last_sync_date"]
+
+
+def test_first_sync_writes_the_date(_tmp_state: Path) -> None:
+    sync_mod.update_sync_state(date(2026, 7, 24), 5)
+    assert _written(_tmp_state) == "2026-07-24"
+
+
+def test_forward_sync_advances_watermark(_tmp_state: Path) -> None:
+    sync_mod.update_sync_state(date(2026, 6, 1), 3)
+    sync_mod.update_sync_state(date(2026, 7, 24), 3)
+    assert _written(_tmp_state) == "2026-07-24"
+
+
+def test_historical_backfill_does_not_regress_watermark(_tmp_state: Path) -> None:
+    # Bare sync gets us current...
+    sync_mod.update_sync_state(date(2026, 7, 24), 3)
+    # ...then a `--year 2022` backfill (until = 2022-12-31) must NOT drag it back.
+    sync_mod.update_sync_state(date(2022, 12, 31), 370)
+    assert _written(_tmp_state) == "2026-07-24"
+
+
+def test_get_last_sync_defaults_to_30_days_ago_without_file(_tmp_state: Path) -> None:
+    assert not _tmp_state.exists()
+    got = sync_mod.get_last_sync_date()
+    assert (date.today() - got).days == 30
+
+
+def test_corrupt_state_is_ignored(_tmp_state: Path) -> None:
+    _tmp_state.write_text("{ not json")
+    sync_mod.update_sync_state(date(2026, 7, 24), 1)
+    assert _written(_tmp_state) == "2026-07-24"


### PR DESCRIPTION
Fixes SB-308.

## Symptom
`stk sync` (bare, meant for *recent* runs) went way back:
```
ℹ Syncing since 2022-12-31
✓ Synced 1312 runs
```

## Cause
Bare `stk sync` picks up from `last_sync_date` in `~/.config/stk/sync_state.json`. But **every** sync wrote that file with its window's `until` date — including targeted ones. A `stk sync --year 2022` sets `until = 2022-12-31`, so it **dragged the watermark ~3.5 years backward**. The next bare sync then re-pulled everything from 2022 forward.

The batched backfill run earlier in this project (`--year 2014 … --year 2022`, to populate route start-coords) is exactly what clobbered it — the last `--year 2022` left the watermark at 2022-12-31.

## Fix
`update_sync_state` now only ever **advances** the watermark — `max(existing, new)`. A historical/targeted sync covering an older window can't move it back; a bare sync (`until = today`) still advances normally. Unreadable/legacy state is tolerated.

## Testing
- 5 tests: first write, forward advance, **backfill does not regress** (the bug), default `-30d` with no file, corrupt state ignored.
- ruff clean.

## Note
The state file already self-corrected to today after the user's last sync, so their next bare sync is fine — this prevents recurrence the next time any `--year`/`--since` backfill runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)