### PR TITLE
feat: store simplified GPS polylines (SB-309, north-star bridge)

### DIFF
--- a/backend/routes/runs.py
+++ b/backend/routes/runs.py
@@ -11,6 +11,7 @@ from backend.cache import cached, invalidate_user
 from backend.routes.sync import _resolve_access_token
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
+from src.shared.geo import simplify_and_encode
 from src.shared.smashrun import SmashRunAPIClient
 from src.shared.supabase_client import get_supabase_client
 from src.shared.supabase_ops import RunsRepository, TokenRepository
@@ -264,6 +265,23 @@ async def route_leaderboard(
     return await _routes(user_id, min_runs)
 
 
+@cached(ttl=300, key_prefix="runs:tracks")
+async def _tracks(user_id: UUID) -> dict[str, Any]:
+    repo = RunsRepository(get_supabase_client())
+    tracks = repo.get_all_track_polylines(user_id)
+    return {"count": len(tracks), "tracks": tracks}
+
+
+@router.get("/tracks")
+async def all_tracks(
+    user_id: UUID = Depends(authenticate_request),
+) -> dict[str, Any]:
+    """Every stored GPS polyline for the caller — the territory-heatmap data
+    source (SB-309). Populated by store-on-read + backfill; runs whose map has
+    never been opened won't appear until backfilled."""
+    return await _tracks(user_id)
+
+
 @cached(ttl=86400, key_prefix="runs:track")
 async def _track(user_id: UUID, activity_id: str) -> dict[str, Any]:
     supabase = get_supabase_client()
@@ -292,6 +310,17 @@ async def _track(user_id: UUID, activity_id: str) -> dict[str, Any]:
     dist_km = series("distance")
     clock_s = series("clock")
     pace = _per_point_pace(dist_km, clock_s)
+
+    # Persist the simplified polyline for the heatmap + route-matching (SB-309).
+    # Best-effort store-on-read: never fail the request over it; the batched
+    # backfill covers runs whose map is never opened.
+    if lat and lon:
+        try:
+            polyline, n_pts = simplify_and_encode(lat, lon)
+            if polyline:
+                RunsRepository(supabase).upsert_track(UUID(run["id"]), polyline, n_pts)
+        except Exception:  # noqa: BLE001 — storage is a side effect, not the response
+            pass
 
     # How many times this route has been run (count + rank), so the card can say
     # "run N times, #k of M" (SB-296). Needs the run's own start coords.

--- a/backend/tests/test_run_tracks_store.py
+++ b/backend/tests/test_run_tracks_store.py
@@ -1,0 +1,127 @@
+"""SB-309: /track stores the simplified polyline; /tracks serves them."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from uuid import uuid4
+
+from backend.routes import runs as runs_module
+
+USER = uuid4()
+
+_RUN = {
+    "id": str(uuid4()),
+    "start_date_time_local": "2026-07-21T08:32:00",
+    "distance_km": "6.88",
+    "duration_seconds": "2498",
+    "average_pace_min_per_km": "6.05",
+    "weather_type": "cloudy",
+    "temperature_celsius": "20.6",
+    "start_latitude": None,
+    "start_longitude": None,
+}
+
+
+class _Repo:
+    def __init__(self, run: dict[str, Any] | None) -> None:
+        self._run = run
+        self.stored: list[tuple[Any, str, int]] = []
+
+    def __call__(self, _sb: Any) -> _Repo:
+        return self
+
+    def get_run_by_activity_id(self, _uid: Any, _aid: str) -> dict[str, Any] | None:
+        return self._run
+
+    def get_route_for_run(self, *_a: Any, **_k: Any) -> None:
+        return None
+
+    def upsert_track(
+        self, run_id: Any, polyline: str, point_count: int, precision: int = 5
+    ) -> None:
+        self.stored.append((run_id, polyline, point_count))
+
+
+class _FakeApi:
+    def __init__(self, detail: dict[str, Any]) -> None:
+        self._detail = detail
+
+    def __call__(self, *, access_token: str) -> _FakeApi:
+        return self
+
+    def __enter__(self) -> _FakeApi:
+        return self
+
+    def __exit__(self, *_a: Any) -> bool:
+        return False
+
+    def get_activity_by_id(self, _aid: str) -> dict[str, Any]:
+        return self._detail
+
+
+def test_track_stores_simplified_polyline(monkeypatch: Any) -> None:
+    # A track with a redundant collinear middle point -> stored, simplified.
+    detail = {
+        "recordingKeys": ["latitude", "longitude"],
+        "recordingValues": [[42.0, 42.1, 42.2], [-71.0, -71.0, -71.0]],
+    }
+    repo = _Repo(_RUN)
+    monkeypatch.setattr(runs_module, "get_supabase_client", lambda: object())
+    monkeypatch.setattr(runs_module, "RunsRepository", repo)
+    monkeypatch.setattr(runs_module, "TokenRepository", lambda _sb: object())
+    monkeypatch.setattr(runs_module, "_resolve_access_token", lambda _uid, _repo: "tok")
+    monkeypatch.setattr(runs_module, "SmashRunAPIClient", _FakeApi(detail))
+
+    out = asyncio.run(runs_module.get_run_track("act-1", user_id=USER))
+
+    assert out["has_track"] is True
+    assert len(repo.stored) == 1
+    run_id, polyline, n_pts = repo.stored[0]
+    assert polyline  # non-empty encoded string
+    assert n_pts == 2  # collinear middle point dropped
+
+
+def test_track_store_failure_never_breaks_response(monkeypatch: Any) -> None:
+    detail = {
+        "recordingKeys": ["latitude", "longitude"],
+        "recordingValues": [[42.0, 42.1], [-71.0, -71.1]],
+    }
+
+    class _BoomRepo(_Repo):
+        def upsert_track(self, *_a: Any, **_k: Any) -> None:
+            raise RuntimeError("db down")
+
+    monkeypatch.setattr(runs_module, "get_supabase_client", lambda: object())
+    monkeypatch.setattr(runs_module, "RunsRepository", _BoomRepo(_RUN))
+    monkeypatch.setattr(runs_module, "TokenRepository", lambda _sb: object())
+    monkeypatch.setattr(runs_module, "_resolve_access_token", lambda _uid, _repo: "tok")
+    monkeypatch.setattr(runs_module, "SmashRunAPIClient", _FakeApi(detail))
+
+    # Storage blew up, but the track response still comes back.
+    out = asyncio.run(runs_module.get_run_track("act-1", user_id=USER))
+    assert out["has_track"] is True
+    assert out["lat"] == [42.0, 42.1]
+
+
+class _TracksRepo:
+    def __init__(self, tracks: list[dict[str, Any]]) -> None:
+        self._tracks = tracks
+
+    def __call__(self, _sb: Any) -> _TracksRepo:
+        return self
+
+    def get_all_track_polylines(self, user_id: Any) -> list[dict[str, Any]]:
+        assert user_id == USER
+        return self._tracks
+
+
+def test_tracks_endpoint_shape(monkeypatch: Any) -> None:
+    monkeypatch.setattr(runs_module, "get_supabase_client", lambda: object())
+    monkeypatch.setattr(
+        runs_module,
+        "RunsRepository",
+        _TracksRepo([{"polyline": "abc", "encoded_precision": 5}]),
+    )
+    out = asyncio.run(runs_module.all_tracks(user_id=USER))
+    assert out == {"count": 1, "tracks": [{"polyline": "abc", "encoded_precision": 5}]}

--- a/src/shared/geo.py
+++ b/src/shared/geo.py
@@ -1,0 +1,127 @@
+"""Polyline simplification + encoding for stored GPS tracks (SB-309).
+
+Turns a run's raw lat/lon arrays into a compact, storable string:
+Douglas-Peucker simplification (drop points that don't change the line's shape)
+then Google's Encoded Polyline Algorithm Format. ~578 raw points -> ~1-2 KB.
+"""
+
+from __future__ import annotations
+
+import math
+
+# One degree of latitude is ~111 km; used to turn a metre tolerance into the
+# degree-space epsilon Douglas-Peucker works in.
+_DEG_PER_M_LAT = 1.0 / 111_320.0
+
+
+def _perp_distance(p: tuple[float, float], a: tuple[float, float], b: tuple[float, float]) -> float:
+    """Perpendicular distance from point p to segment a-b, in degree units,
+    aspect-corrected so longitude and latitude are comparable at this latitude."""
+    k = math.cos(math.radians(a[0])) or 1e-9
+    ax, ay = a[1] * k, a[0]
+    bx, by = b[1] * k, b[0]
+    px, py = p[1] * k, p[0]
+    dx, dy = bx - ax, by - ay
+    seg2 = dx * dx + dy * dy
+    if seg2 == 0:
+        return math.hypot(px - ax, py - ay)
+    t = ((px - ax) * dx + (py - ay) * dy) / seg2
+    t = max(0.0, min(1.0, t))
+    cx, cy = ax + t * dx, ay + t * dy
+    return math.hypot(px - cx, py - cy)
+
+
+def douglas_peucker(
+    points: list[tuple[float, float]], tolerance_m: float = 6.0
+) -> list[tuple[float, float]]:
+    """Simplify a (lat, lon) path, keeping points that matter to its shape.
+
+    tolerance_m is the max deviation allowed (metres) — ~6 m is imperceptible on
+    a route map and typically drops 50-70% of running-GPS points.
+    """
+    if len(points) < 3:
+        return list(points)
+    eps = tolerance_m * _DEG_PER_M_LAT
+
+    # Iterative stack to avoid recursion limits on long tracks.
+    keep = [False] * len(points)
+    keep[0] = keep[-1] = True
+    stack = [(0, len(points) - 1)]
+    while stack:
+        start, end = stack.pop()
+        dmax, idx = 0.0, start
+        for i in range(start + 1, end):
+            d = _perp_distance(points[i], points[start], points[end])
+            if d > dmax:
+                dmax, idx = d, i
+        if dmax > eps and idx != start:
+            keep[idx] = True
+            stack.append((start, idx))
+            stack.append((idx, end))
+    return [p for p, k in zip(points, keep, strict=True) if k]
+
+
+def _encode_signed(value: int) -> str:
+    """Google polyline: zigzag + 5-bit-chunk base64-ish encoding of one number."""
+    value = ~(value << 1) if value < 0 else (value << 1)
+    out = []
+    while value >= 0x20:
+        out.append(chr((0x20 | (value & 0x1F)) + 63))
+        value >>= 5
+    out.append(chr(value + 63))
+    return "".join(out)
+
+
+def encode_polyline(points: list[tuple[float, float]], precision: int = 5) -> str:
+    """Encode (lat, lon) points as a Google Encoded Polyline string.
+
+    precision=5 -> ~1.1 m resolution, plenty for a running route.
+    """
+    factor = 10**precision
+    out: list[str] = []
+    prev_lat = prev_lon = 0
+    for lat, lon in points:
+        ilat = round(lat * factor)
+        ilon = round(lon * factor)
+        out.append(_encode_signed(ilat - prev_lat))
+        out.append(_encode_signed(ilon - prev_lon))
+        prev_lat, prev_lon = ilat, ilon
+    return "".join(out)
+
+
+def decode_polyline(encoded: str, precision: int = 5) -> list[tuple[float, float]]:
+    """Inverse of encode_polyline — for tests and client-side rendering."""
+    factor = 10**precision
+    points: list[tuple[float, float]] = []
+    i = lat = lon = 0
+    while i < len(encoded):
+        for is_lon in (False, True):
+            shift = result = 0
+            while True:
+                b = ord(encoded[i]) - 63
+                i += 1
+                result |= (b & 0x1F) << shift
+                shift += 5
+                if b < 0x20:
+                    break
+            delta = ~(result >> 1) if result & 1 else (result >> 1)
+            if is_lon:
+                lon += delta
+            else:
+                lat += delta
+        points.append((lat / factor, lon / factor))
+    return points
+
+
+def simplify_and_encode(
+    lat: list[float], lon: list[float], tolerance_m: float = 6.0
+) -> tuple[str, int]:
+    """Raw lat/lon arrays -> (encoded simplified polyline, kept point count).
+
+    Returns ("", 0) when there's nothing to store (no / degenerate track).
+    """
+    if not lat or len(lat) != len(lon) or len(lat) < 2:
+        return "", 0
+    pts = list(zip(lat, lon, strict=True))
+    simplified = douglas_peucker(pts, tolerance_m)
+    return encode_polyline(simplified), len(simplified)

--- a/src/shared/supabase_ops/runs_repository.py
+++ b/src/shared/supabase_ops/runs_repository.py
@@ -95,6 +95,56 @@ class RunsRepository:
         data_list = cast(list[dict[str, Any]], result.data)
         return data_list[0] if data_list else None
 
+    def get_track_polyline(self, run_id: UUID) -> dict[str, Any] | None:
+        """A run's stored simplified polyline, or None if not backfilled (SB-309)."""
+        result = (
+            self.supabase.table("run_tracks")
+            .select("polyline, point_count, encoded_precision")
+            .eq("run_id", str(run_id))
+            .limit(1)
+            .execute()
+        )
+        data = cast(list[dict[str, Any]], result.data)
+        return data[0] if data else None
+
+    def upsert_track(
+        self, run_id: UUID, polyline: str, point_count: int, precision: int = 5
+    ) -> None:
+        """Store/refresh a run's simplified encoded polyline (SB-309)."""
+        self.supabase.table("run_tracks").upsert(
+            {
+                "run_id": str(run_id),
+                "polyline": polyline,
+                "point_count": point_count,
+                "encoded_precision": precision,
+            },
+            on_conflict="run_id",
+        ).execute()
+
+    def get_all_track_polylines(self, user_id: UUID) -> list[dict[str, Any]]:
+        """Every stored polyline for a user's runs — the territory-heatmap data
+        source (SB-309). Joins run_tracks to runs so it's user-scoped."""
+        result = (
+            self.supabase.table("run_tracks")
+            .select("polyline, encoded_precision, runs!inner(user_id)")
+            .eq("runs.user_id", str(user_id))
+            .execute()
+        )
+        rows = cast(list[dict[str, Any]], result.data)
+        return [
+            {"polyline": r["polyline"], "encoded_precision": r["encoded_precision"]} for r in rows
+        ]
+
+    def count_tracks(self, user_id: UUID) -> int:
+        """How many of a user's runs have a stored polyline (backfill progress)."""
+        result = (
+            self.supabase.table("run_tracks")
+            .select("run_id, runs!inner(user_id)", count="exact")
+            .eq("runs.user_id", str(user_id))
+            .execute()
+        )
+        return cast(int, result.count or 0)
+
     def set_run_audio(
         self,
         user_id: UUID,

--- a/supabase/migrations/20260724000000_run_tracks.sql
+++ b/supabase/migrations/20260724000000_run_tracks.sql
@@ -1,0 +1,34 @@
+-- =====================================================
+-- Stored GPS polylines (SB-309): the north-star bridge
+-- =====================================================
+-- Persist each GPS run's track as a simplified, encoded polyline so route maps
+-- stop re-fetching from SmashRun on every view, and so shape-based route
+-- matching + the territory heatmap have data to work with.
+--
+-- Kept in its own table (not a column on runs) so the ~1-2 KB blob never bloats
+-- the hot runs table that every list / leaderboard scans; loaded only when a
+-- map or the heatmap needs it.
+
+CREATE TABLE IF NOT EXISTS run_tracks (
+    run_id UUID PRIMARY KEY REFERENCES runs(id) ON DELETE CASCADE,
+    -- Google Encoded Polyline Algorithm Format, Douglas-Peucker simplified.
+    polyline TEXT NOT NULL,
+    point_count INTEGER NOT NULL,
+    encoded_precision SMALLINT NOT NULL DEFAULT 5,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE run_tracks IS 'Simplified encoded GPS polyline per run (SB-309)';
+COMMENT ON COLUMN run_tracks.polyline IS 'Google encoded polyline, Douglas-Peucker simplified';
+
+ALTER TABLE run_tracks ENABLE ROW LEVEL SECURITY;
+
+-- Owner-scoped: a track is visible/writable only to the user who owns its run.
+-- Backend uses the service role (bypasses RLS); this guards any anon/auth path.
+CREATE POLICY run_tracks_owner ON run_tracks
+    USING (
+        EXISTS (
+            SELECT 1 FROM runs r
+            WHERE r.id = run_tracks.run_id AND r.user_id = auth.uid()
+        )
+    );

--- a/tests/test_geo_polyline.py
+++ b/tests/test_geo_polyline.py
@@ -1,0 +1,69 @@
+"""SB-309: polyline simplify + encode round-trips and stays accurate."""
+
+from __future__ import annotations
+
+import math
+
+from src.shared.geo import (
+    decode_polyline,
+    douglas_peucker,
+    encode_polyline,
+    simplify_and_encode,
+)
+
+
+def test_encode_decode_roundtrip_within_precision() -> None:
+    pts = [(42.24431, -71.65018), (42.25011, -71.64998), (42.24399, -71.65044)]
+    back = decode_polyline(encode_polyline(pts))
+    assert len(back) == len(pts)
+    for (la, lo), (ba, bo) in zip(pts, back, strict=True):
+        assert abs(la - ba) < 1e-5
+        assert abs(lo - bo) < 1e-5
+
+
+def test_encode_matches_google_reference() -> None:
+    # The canonical example from Google's polyline algorithm docs.
+    pts = [(38.5, -120.2), (40.7, -120.95), (43.252, -126.453)]
+    assert encode_polyline(pts) == "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
+
+
+def test_douglas_peucker_drops_collinear_points() -> None:
+    # A straight line of 5 points collapses to its 2 endpoints.
+    line = [(42.0, -71.0), (42.1, -71.0), (42.2, -71.0), (42.3, -71.0), (42.4, -71.0)]
+    simplified = douglas_peucker(line, tolerance_m=6.0)
+    assert simplified == [(42.0, -71.0), (42.4, -71.0)]
+
+
+def test_douglas_peucker_keeps_a_real_corner() -> None:
+    # An L-shape must keep the corner point.
+    path = [(42.0, -71.0), (42.0, -71.01), (42.0, -71.02), (42.01, -71.02), (42.02, -71.02)]
+    simplified = douglas_peucker(path, tolerance_m=6.0)
+    assert (42.0, -71.02) in simplified  # the corner survives
+    assert len(simplified) < len(path)
+
+
+def test_simplify_reduces_a_noisy_track_but_stays_faithful() -> None:
+    # A realistic ~1 km circular loop sampled densely (points along a smooth
+    # arc) — simplification should shrink it while keeping the endpoints.
+    r = 0.0045  # ~500 m radius in degrees
+    lat = [42.0 + r * math.sin(2 * math.pi * i / 120) for i in range(120)]
+    lon = [-71.0 + r * math.cos(2 * math.pi * i / 120) for i in range(120)]
+    encoded, n = simplify_and_encode(lat, lon, tolerance_m=6.0)
+    assert 2 <= n < len(lat)  # actually reduced
+    decoded = decode_polyline(encoded)
+    assert len(decoded) == n
+    # Endpoints preserved exactly (to precision).
+    assert abs(decoded[0][0] - lat[0]) < 1e-4
+    assert abs(decoded[-1][0] - lat[-1]) < 1e-4
+
+
+def test_simplify_and_encode_handles_empty_and_degenerate() -> None:
+    assert simplify_and_encode([], []) == ("", 0)
+    assert simplify_and_encode([42.0], [-71.0]) == ("", 0)
+    assert simplify_and_encode([42.0, 42.1], [-71.0]) == ("", 0)  # mismatched
+
+
+def test_two_point_track_encodes_without_simplifying() -> None:
+    encoded, n = simplify_and_encode([42.0, 42.1], [-71.0, -71.1])
+    assert n == 2
+    assert math.isclose(decode_polyline(encoded)[1][0], 42.1, abs_tol=1e-4)


### PR DESCRIPTION
Fixes SB-309. The single bridge from today's start+distance route heuristic to the whole north-star tier (shape-based route matching, **territory heatmap**, ghost-race, mile markers).

## What
Persist each GPS run's track as a **Douglas–Peucker simplified, Google-encoded polyline** — ~578 raw points → ~1–2 KB.

- **`src/shared/geo.py`** — `douglas_peucker` + `encode_polyline`/`decode_polyline` + `simplify_and_encode`. The encoder is verified against Google's published reference vector (`_p~iF~ps|U…`).
- **Migration** — `run_tracks(run_id, polyline, point_count, encoded_precision)`, RLS owner-scoped. **Its own table**, not a column on `runs`, so the blob never bloats the hot runs table that every list/leaderboard scans.
- **Store-on-read** — `/track` stores the simplified polyline as a best-effort side effect (a storage failure never breaks the response). `upsert_track` / `get_track_polyline`.
- **`GET /runs/tracks`** — every stored polyline for the caller: the heatmap's data source (`get_all_track_polylines`, user-scoped join). `count_tracks` for backfill progress.

## Storage (the free-tier question)
~4,200 GPS runs × ~1–2 KB = **~5–10 MB total**, **~1–2% of the 500 MB free-tier** database — in MyRunStreak's project only, zero impact on the MT project (each free project has its own 500 MB).

## Testing
- Polyline round-trip within precision; **matches Google's reference encoding**; simplification drops collinear points, keeps corners, stays faithful on a real loop.
- Store-on-read stores the simplified polyline; a store failure still returns the track; `/tracks` shape.
- Backend suite 251 passed, root suite 63 passed, ruff clean.

## Backfill (post-deploy, manual)
Same pattern as the coords backfill: hit `/track` per GPS run → store-on-read populates `run_tracks`. Then the heatmap has full history. I'll drive it once this deploys.

## Next
This unblocks the **territory heatmap** (`stk map` + web) — the immediate follow-up PR, which reads `/runs/tracks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)