### PR TITLE
fix: paginate past PostgREST 1000-row cap in track queries (SB-311)

### DIFF
--- a/backend/tests/test_track_pagination.py
+++ b/backend/tests/test_track_pagination.py
@@ -1,0 +1,84 @@
+"""SB-310/311: repo paginates past PostgREST's 1000-row cap.
+
+The bug the backfill verification caught: .limit(10000) is silently capped at
+1000 rows per response, so a multi-thousand-run history truncated. These prove
+the range-based pagination returns everything.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from src.shared.supabase_ops.runs_repository import RunsRepository
+
+USER = uuid4()
+PAGE = 1000
+
+
+class _RangeCappedTable:
+    """Fake PostgREST table that honours .range() and caps a page at 1000 rows,
+    exactly like Supabase — so a single query can't see more than 1000."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+        self._lo = 0
+        self._hi = PAGE - 1
+
+    def select(self, *_a: Any, **_k: Any) -> _RangeCappedTable:
+        return self
+
+    def eq(self, *_a: Any, **_k: Any) -> _RangeCappedTable:
+        return self
+
+    @property
+    def not_(self) -> _RangeCappedTable:  # for .not_.is_(...)
+        return self
+
+    def is_(self, *_a: Any, **_k: Any) -> _RangeCappedTable:
+        return self
+
+    def order(self, *_a: Any, **_k: Any) -> _RangeCappedTable:
+        return self
+
+    def range(self, lo: int, hi: int) -> _RangeCappedTable:
+        self._lo, self._hi = lo, min(hi, lo + PAGE - 1)  # server caps span at 1000
+        return self
+
+    def execute(self) -> Any:
+        class _R:
+            data = self._rows[self._lo : self._hi + 1]
+
+        return _R()
+
+
+class _Supabase:
+    def __init__(self, by_table: dict[str, list[dict[str, Any]]]) -> None:
+        self._by_table = by_table
+
+    def table(self, name: str) -> _RangeCappedTable:
+        return _RangeCappedTable(self._by_table.get(name, []))
+
+
+def test_get_all_track_polylines_returns_more_than_one_page() -> None:
+    tracks = [{"polyline": f"p{i}", "encoded_precision": 5} for i in range(2500)]
+    repo = RunsRepository(_Supabase({"run_tracks": tracks}))  # type: ignore[arg-type]
+    out = repo.get_all_track_polylines(USER)
+    assert len(out) == 2500  # not truncated to 1000
+    assert out[0]["polyline"] == "p0"
+    assert out[-1]["polyline"] == "p2499"
+
+
+def test_missing_tracks_count_spans_full_history() -> None:
+    gps = [
+        {"id": f"r{i}", "source_activity_id": f"a{i}", "start_date": "2020-01-01"}
+        for i in range(4203)
+    ]
+    stored = [{"run_id": f"r{i}"} for i in range(100)]  # only 100 backfilled so far
+    repo = RunsRepository(_Supabase({"runs": gps, "run_tracks": stored}))  # type: ignore[arg-type]
+    # The real remaining is 4103, not the capped 900 the bug reported.
+    assert repo.count_runs_missing_tracks(USER) == 4103
+    # A bounded batch still returns just `limit` runs, oldest first.
+    batch = repo.get_runs_missing_tracks(USER, limit=100)
+    assert len(batch) == 100
+    assert batch[0]["id"] == "r100"  # first un-stored run

--- a/src/shared/supabase_ops/runs_repository.py
+++ b/src/shared/supabase_ops/runs_repository.py
@@ -1,6 +1,7 @@
 """Repository for runs/activities data operations in Supabase."""
 
 import logging
+from collections.abc import Callable
 from datetime import date
 from statistics import median
 from typing import Any, cast
@@ -121,16 +122,42 @@ class RunsRepository:
             on_conflict="run_id",
         ).execute()
 
+    @staticmethod
+    def _paginate(
+        fetch_page: Callable[[int, int], list[dict[str, Any]]], page_size: int = 1000
+    ) -> list[dict[str, Any]]:
+        """Fetch every row across PostgREST's 1000-row response cap.
+
+        Supabase caps a single response at ~1000 rows regardless of .limit(), so
+        anything scanning a user's full history (thousands of runs) must page or
+        it silently truncates. fetch_page(offset, size) runs one .range() query.
+        """
+        out: list[dict[str, Any]] = []
+        offset = 0
+        while True:
+            batch = fetch_page(offset, page_size)
+            out.extend(batch)
+            if len(batch) < page_size:
+                return out
+            offset += page_size
+
     def get_all_track_polylines(self, user_id: UUID) -> list[dict[str, Any]]:
         """Every stored polyline for a user's runs — the territory-heatmap data
-        source (SB-309). Joins run_tracks to runs so it's user-scoped."""
-        result = (
-            self.supabase.table("run_tracks")
-            .select("polyline, encoded_precision, runs!inner(user_id)")
-            .eq("runs.user_id", str(user_id))
-            .execute()
-        )
-        rows = cast(list[dict[str, Any]], result.data)
+        source (SB-309). Joins run_tracks to runs so it's user-scoped. Paged so
+        it returns all of a multi-thousand-run history, not just the first 1000."""
+
+        def page(off: int, size: int) -> list[dict[str, Any]]:
+            return cast(
+                list[dict[str, Any]],
+                self.supabase.table("run_tracks")
+                .select("polyline, encoded_precision, runs!inner(user_id)")
+                .eq("runs.user_id", str(user_id))
+                .range(off, off + size - 1)
+                .execute()
+                .data,
+            )
+
+        rows = self._paginate(page)
         return [
             {"polyline": r["polyline"], "encoded_precision": r["encoded_precision"]} for r in rows
         ]
@@ -756,20 +783,34 @@ class RunsRepository:
         thousand ids — and PostgREST has no clean anti-join). Returns id +
         source_activity_id for a bounded batch.
         """
-        gps = (
-            self.supabase.table("runs")
-            .select("id, source_activity_id, start_date")
-            .eq("user_id", str(user_id))
-            .eq("has_gps_data", True)
-            .not_.is_("start_latitude", "null")
-            .order("start_date", desc=False)  # oldest first — fill history from the start
-            .limit(10000)
-            .execute()
-        )
-        gps_runs = cast(list[dict[str, Any]], gps.data)
 
-        have = self.supabase.table("run_tracks").select("run_id").limit(10000).execute()
-        have_ids = {r["run_id"] for r in cast(list[dict[str, Any]], have.data)}
+        def gps_page(off: int, size: int) -> list[dict[str, Any]]:
+            return cast(
+                list[dict[str, Any]],
+                self.supabase.table("runs")
+                .select("id, source_activity_id, start_date")
+                .eq("user_id", str(user_id))
+                .eq("has_gps_data", True)
+                .not_.is_("start_latitude", "null")
+                .order("start_date", desc=False)  # oldest first — fill history from the start
+                .range(off, off + size - 1)
+                .execute()
+                .data,
+            )
+
+        def tracks_page(off: int, size: int) -> list[dict[str, Any]]:
+            return cast(
+                list[dict[str, Any]],
+                self.supabase.table("run_tracks")
+                .select("run_id, runs!inner(user_id)")
+                .eq("runs.user_id", str(user_id))
+                .range(off, off + size - 1)
+                .execute()
+                .data,
+            )
+
+        gps_runs = self._paginate(gps_page)
+        have_ids = {r["run_id"] for r in self._paginate(tracks_page)}
 
         pending = [r for r in gps_runs if r["id"] not in have_ids]
         return pending[:limit]


### PR DESCRIPTION
Fixes SB-311. Caught by the SB-310 backfill verification batch.

## The bug
Supabase/PostgREST caps a single response at ~1000 rows **regardless of `.limit()`**. So `get_all_track_polylines` (the heatmap's data source) and `get_runs_missing_tracks` (the backfill) silently truncated a multi-thousand-run history to the first 1000 rows.

**Real-world impact:** the deployed track-backfill cron would have processed the oldest ~1000 runs, then falsely reported "0 remaining" and stopped — leaving ~3,200 runs un-backfilled forever. The verification batch is what exposed it: it reported **"900 remaining"** when the truth was **4,103** (100 stored, 4,203 GPS runs).

## Fix
- `RunsRepository._paginate(fetch_page)` — `range()` through 1000-row pages until a short page.
- `get_all_track_polylines` + `get_runs_missing_tracks` page **both** the GPS-run scan and the run_tracks scan.

## Tests
- A >2,500-row fetch is not truncated to 1000.
- Missing-tracks count spans the full history (4,103, not the capped 900), and a bounded batch still returns `limit` oldest-first.
- Backend suite 257 passed.

## Note
Other repo methods use `.limit(10000)` too (route leaderboard, conditions penalty) — same latent cap, so they're approximate for a >1000-run user. Out of scope here; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)