### PR TITLE
fix: keep Monthly distance labels on their own month

### DIFF
--- a/frontend/src/components/MonthlyDistanceChart.vue
+++ b/frontend/src/components/MonthlyDistanceChart.vue
@@ -18,7 +18,7 @@
 import { computed } from 'vue'
 import ApexChart from 'vue3-apexcharts'
 import type { MonthlyStats, Unit } from '@/types/runs'
-import { distanceLabel } from '@/utils/format'
+import { distanceLabel, formatMonthLabel } from '@/utils/format'
 
 const KM_PER_MI = 1.609344
 
@@ -36,12 +36,7 @@ const series = computed(() => [
   },
 ])
 
-const monthLabels = computed(() =>
-  props.months.map((m) => {
-    const d = new Date(m.month)
-    return d.toLocaleDateString('en-US', { month: 'short', year: '2-digit' })
-  }),
-)
+const monthLabels = computed(() => props.months.map((m) => formatMonthLabel(m.month)))
 
 const chartOptions = computed(() => ({
   chart: {

--- a/frontend/src/utils/__tests__/format.test.ts
+++ b/frontend/src/utils/__tests__/format.test.ts
@@ -5,6 +5,7 @@ import {
   formatPace,
   formatDuration,
   formatDate,
+  formatMonthLabel,
   formatRelativeTime,
   distanceLabel,
 } from '../format'
@@ -128,5 +129,29 @@ describe('formatRelativeTime', () => {
   })
   it('falls back to absolute date past a week', () => {
     expect(formatRelativeTime('2026-04-20T12:00:00Z')).toMatch(/\w{3} Apr 20/)
+  })
+})
+
+describe('formatMonthLabel', () => {
+  it('labels a month on its own month, not the previous one', () => {
+    // Regression: date-only strings were parsed as UTC midnight and rendered in
+    // the local zone, rolling back a day in negative-offset zones so July's bar
+    // showed as "Jun 26". The label must stay on the month it represents.
+    expect(formatMonthLabel('2026-07-01')).toBe('Jul 26')
+  })
+
+  it('formats each month correctly', () => {
+    expect(formatMonthLabel('2025-09-01')).toBe('Sep 25')
+    expect(formatMonthLabel('2025-12-01')).toBe('Dec 25')
+    expect(formatMonthLabel('2026-01-01')).toBe('Jan 26')
+    expect(formatMonthLabel('2026-06-01')).toBe('Jun 26')
+  })
+
+  it('does not shift January back into the prior December', () => {
+    expect(formatMonthLabel('2026-01-01')).not.toBe('Dec 25')
+  })
+
+  it('falls back to the raw string when unparseable', () => {
+    expect(formatMonthLabel('garbage')).toBe('garbage')
   })
 })

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -37,6 +37,24 @@ const MONTHS = [
   'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
 ]
 
+/**
+ * Format a monthly-summary month string (date-only, e.g. "2026-07-01") as a
+ * short label like "Jul 26".
+ *
+ * Parses the year/month straight from the string rather than via `new Date()`.
+ * `new Date("2026-07-01")` treats date-only ISO as UTC midnight, and formatting
+ * it then renders in the browser's local zone — in any negative-offset zone
+ * (e.g. US) that rolls back to the previous day, shifting every label a month
+ * early (July's bar labeled "Jun 26"). String parsing keeps each label on its
+ * own month in every timezone.
+ */
+export const formatMonthLabel = (month: string): string => {
+  const [year, monthNum] = month.split('-').map(Number)
+  const name = MONTHS[monthNum - 1]
+  if (!name || Number.isNaN(year)) return month
+  return `${name} ${String(year).slice(-2)}`
+}
+
 export const formatDate = (iso: string): string => {
   const d = new Date(iso)
   if (Number.isNaN(d.getTime())) return iso


### PR DESCRIPTION
## Problem

On the dashboard's **Monthly distance** chart, the current month appeared **missing** and the prior bar looked **low**.

Root cause: labels were built with `new Date(m.month)` on a **date-only** string like `"2026-07-01"`. JS parses date-only ISO as **UTC midnight**, then `toLocaleDateString` renders in the browser's **local** zone. In any negative-offset zone (e.g. US, UTC−4/−5) that rolls back to the previous day, shifting **every label one month early**:

- July's data got labeled **"Jun 26"** → no bar labeled July → looked missing.
- That mislabeled bar is the **partial current month** (fewer days) → looked low.

Every other bar was likewise one month behind its data.

## Fix

- New `formatMonthLabel(month)` util parses year/month **straight from the string** — no `Date`, so it's timezone-independent.
- `MonthlyDistanceChart.vue` uses it instead of `new Date(...).toLocaleDateString(...)`.

## Tests

Added regression cases in `format.test.ts` (run under `TZ=America/New_York`):
- `2026-07-01` → `Jul 26` (the reported bug)
- Jan boundary does **not** roll back to prior Dec
- unparseable input falls back to the raw string

All `formatMonthLabel` + existing format tests pass. Two unrelated suites (`useSync`, `useUserPreferences`) fail on this machine due to a pre-existing jsdom `localStorage` env issue — untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)