### PR TITLE
fix(coach): gate /coach landing + routes behind coach role (SB-331)

### DIFF
--- a/frontend/src/composables/__tests__/useLanding.test.ts
+++ b/frontend/src/composables/__tests__/useLanding.test.ts
@@ -91,16 +91,34 @@ describe('resolveLanding (SB-265 heuristic)', () => {
 })
 
 describe('resolveLanding (SB-267 preference override)', () => {
-  it('an explicit preference beats the heuristic — no API calls needed', async () => {
+  it('an explicit preference beats the heuristic — skips the stats call', async () => {
     mockPreference('runs')
+    mockApi({ roles: [], is_admin: false }, 999)
     const { resolveLanding } = await freshModule()
     expect(await resolveLanding()).toBe('/runs')
-    expect(apiCallMock).not.toHaveBeenCalled()
+    // Roles are loaded (they gate a 'coach' preference), but the expensive
+    // heuristic stats call is still short-circuited.
+    expect(apiCallMock).not.toHaveBeenCalledWith('/stats/overall')
   })
 
   it('a coach preference sends even a running coach to Coach', async () => {
     mockPreference('coach')
     mockApi({ roles: ['coach'], is_admin: false }, 500)
+    const { resolveLanding } = await freshModule()
+    expect(await resolveLanding()).toBe('/coach')
+  })
+
+  it('a coach preference on a non-coach falls through to the heuristic (SB-331)', async () => {
+    // A stale default_view='coach' must NOT dead-end a plain runner on /coach.
+    mockPreference('coach')
+    mockApi({ roles: [], is_admin: false }, 10)
+    const { resolveLanding } = await freshModule()
+    expect(await resolveLanding()).toBe('/dashboard')
+  })
+
+  it('a coach preference on an admin is honored (SB-331)', async () => {
+    mockPreference('coach')
+    mockApi({ roles: [], is_admin: true }, 500)
     const { resolveLanding } = await freshModule()
     expect(await resolveLanding()).toBe('/coach')
   })

--- a/frontend/src/composables/useLanding.ts
+++ b/frontend/src/composables/useLanding.ts
@@ -26,11 +26,20 @@ const PREFERENCE_PATHS: Record<string, string> = {
 export async function resolveLanding(): Promise<string> {
   if (resolved) return resolved
 
-  // 1. Explicit preference wins (SB-267). 'auto' or absent falls through.
+  // Roles gate both the preference and the heuristic below. loadRoles() is
+  // module-cached and swallows its own errors (defaults to no roles).
+  const { roles, loadRoles } = useRoles()
+  await loadRoles()
+  const coachish = !!roles.value && (roles.value.roles.includes('coach') || roles.value.is_admin)
+
+  // 1. Explicit preference wins (SB-267). 'auto' or absent falls through. A
+  //    'coach' preference is honored ONLY for coaches/admins — otherwise a stale
+  //    preference dead-ends a non-coach on /coach ("Coach privileges required"),
+  //    so it falls through to the heuristic instead (SB-331).
   try {
     const { data } = await supabase.auth.getUser()
     const pref = data.user?.user_metadata?.default_view as string | undefined
-    if (pref && PREFERENCE_PATHS[pref]) {
+    if (pref && PREFERENCE_PATHS[pref] && (pref !== 'coach' || coachish)) {
       resolved = PREFERENCE_PATHS[pref]
       return resolved
     }
@@ -39,9 +48,6 @@ export async function resolveLanding(): Promise<string> {
   }
 
   // 2. Role heuristic (SB-265).
-  const { roles, loadRoles } = useRoles()
-  await loadRoles()
-  const coachish = !!roles.value && (roles.value.roles.includes('coach') || roles.value.is_admin)
   if (!coachish) {
     resolved = '/dashboard'
     return resolved

--- a/frontend/src/router/__tests__/index.test.ts
+++ b/frontend/src/router/__tests__/index.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
+
+// Navigating loads view components that pull useSync → window.localStorage,
+// which this test env doesn't provide. Shim it so navigation doesn't crash.
+beforeAll(() => {
+  if (!window.localStorage) {
+    const store: Record<string, string> = {}
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (k: string) => store[k] ?? null,
+        setItem: (k: string, v: string) => {
+          store[k] = String(v)
+        },
+        removeItem: (k: string) => {
+          delete store[k]
+        },
+        clear: () => {
+          for (const k of Object.keys(store)) delete store[k]
+        },
+      },
+    })
+  }
+})
+
+// Auth store: always authenticated with a session so the guard skips init.
+const authState = {
+  session: {},
+  loading: false,
+  isAuthenticated: true,
+  initialize: vi.fn(),
+}
+vi.mock('@/stores/auth', () => ({ useAuthStore: () => authState }))
+
+// Roles drive the requiresCoach guard. Tests set rolesRef.value per case.
+const rolesRef: { value: { roles: string[]; is_admin: boolean } | null } = { value: null }
+const loadRolesMock = vi.fn(async () => {})
+vi.mock('@/composables/useCoach', () => ({
+  useRoles: () => ({ roles: rolesRef, loadRoles: loadRolesMock }),
+}))
+
+// resolveLanding is where a redirected non-coach is sent.
+const resolveLandingMock = vi.fn(async () => '/dashboard')
+vi.mock('@/composables/useLanding', () => ({
+  resolveLanding: () => resolveLandingMock(),
+}))
+
+import router from '../index'
+
+beforeEach(async () => {
+  loadRolesMock.mockClear()
+  resolveLandingMock.mockClear()
+  rolesRef.value = null
+  await router.replace('/dashboard')
+  await router.isReady()
+})
+
+describe('router requiresCoach guard (SB-331)', () => {
+  it('redirects a non-coach away from /coach', async () => {
+    rolesRef.value = { roles: [], is_admin: false }
+    await router.push('/coach')
+    expect(resolveLandingMock).toHaveBeenCalled()
+    expect(router.currentRoute.value.path).toBe('/dashboard')
+  })
+
+  it('redirects a non-coach away from a coach sub-route', async () => {
+    rolesRef.value = { roles: [], is_admin: false }
+    await router.push('/coach/a1')
+    expect(router.currentRoute.value.path).toBe('/dashboard')
+  })
+
+  it('lets a coach reach /coach', async () => {
+    rolesRef.value = { roles: ['coach'], is_admin: false }
+    await router.push('/coach')
+    expect(resolveLandingMock).not.toHaveBeenCalled()
+    expect(router.currentRoute.value.path).toBe('/coach')
+  })
+
+  it('lets an admin reach /coach', async () => {
+    rolesRef.value = { roles: [], is_admin: true }
+    await router.push('/coach')
+    expect(router.currentRoute.value.path).toBe('/coach')
+  })
+})

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { resolveLanding } from '@/composables/useLanding'
+import { useRoles } from '@/composables/useCoach'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -59,7 +60,7 @@ const router = createRouter({
       path: '/coach',
       name: 'coach',
       component: () => import('@/views/CoachView.vue'),
-      meta: { requiresAuth: true },
+      meta: { requiresAuth: true, requiresCoach: true },
     },
     {
       path: '/admin',
@@ -71,37 +72,37 @@ const router = createRouter({
       path: '/coach/:athleteId',
       name: 'athlete-detail',
       component: () => import('@/views/AthleteDetailView.vue'),
-      meta: { requiresAuth: true },
+      meta: { requiresAuth: true, requiresCoach: true },
     },
     {
       path: '/coach/:athleteId/print/:templateId',
       name: 'workout-print',
       component: () => import('@/views/WorkoutPrintView.vue'),
-      meta: { requiresAuth: true },
+      meta: { requiresAuth: true, requiresCoach: true },
     },
     {
       path: '/coach/:athleteId/build',
       name: 'workout-builder',
       component: () => import('@/views/WorkoutBuilderView.vue'),
-      meta: { requiresAuth: true },
+      meta: { requiresAuth: true, requiresCoach: true },
     },
     {
       path: '/coach/:athleteId/build/:templateId',
       name: 'workout-editor',
       component: () => import('@/views/WorkoutBuilderView.vue'),
-      meta: { requiresAuth: true },
+      meta: { requiresAuth: true, requiresCoach: true },
     },
     {
       path: '/coach/:athleteId/log',
       name: 'workout-logger',
       component: () => import('@/views/WorkoutSessionLoggerView.vue'),
-      meta: { requiresAuth: true },
+      meta: { requiresAuth: true, requiresCoach: true },
     },
     {
       path: '/coach/:athleteId/log/:templateId',
       name: 'workout-logger-template',
       component: () => import('@/views/WorkoutSessionLoggerView.vue'),
-      meta: { requiresAuth: true },
+      meta: { requiresAuth: true, requiresCoach: true },
     },
     {
       path: '/exercises',
@@ -134,6 +135,17 @@ router.beforeEach(async (to) => {
 
   if (to.meta.requiresGuest && auth.isAuthenticated) {
     return resolveLanding()
+  }
+
+  // Coach-only surfaces: a non-coach hitting /coach* would only see the
+  // server's "Coach privileges required" error, a dead end. Send them to their
+  // real landing instead (SB-331). Server-side require_coach still enforces.
+  if (to.meta.requiresCoach && auth.isAuthenticated) {
+    const { roles, loadRoles } = useRoles()
+    await loadRoles()
+    const coachish =
+      !!roles.value && (roles.value.roles.includes('coach') || roles.value.is_admin)
+    if (!coachish) return await resolveLanding()
   }
 
   // '/' is the only implicit entry (its redirect targets the dashboard);


### PR DESCRIPTION
Fixes SB-331.

## Problem
An athlete (non-coach) could dead-end on `/coach` seeing **"Coach privileges required"** with no way forward — exactly what happened to Gabe. Two paths:
1. `resolveLanding` honored a stored `default_view='coach'` preference **without** checking role, sending a non-coach to `/coach`.
2. `/coach*` had no client-side coach guard, so a non-coach who navigated there only saw the server 403.

## Fix
- **`useLanding.ts`** — load roles up front; honor a `'coach'` preference **only** for coaches/admins, otherwise fall through to the heuristic (→ `/dashboard`).
- **`router/index.ts`** — mark `/coach` + the coach workout sub-routes `requiresCoach`; the nav guard redirects non-coaches to their real landing. Server-side `require_coach` still enforces (defense-in-depth).

## Tests
- `useLanding.test.ts` — coach preference on a non-coach falls through to `/dashboard`; on an admin it's honored; updated the "preference wins" case (roles now load, stats call still skipped).
- `router/__tests__/index.test.ts` (new) — non-coach redirected from `/coach` and a coach sub-route; coach/admin pass through. Includes a local `localStorage` shim for the happy-dom test env.

All 17 new/updated tests pass; typecheck clean. The 2 unrelated failing suites (`useSync`, `useUserPreferences`) fail on a **pre-existing** test-env `localStorage` gap — untouched here (candidate for a shared setup-file fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)