### PR TITLE
feat(athlete): My Workouts view — athletes see coach-assigned workouts (SB-332)

### DIFF
--- a/backend/routes/athletes.py
+++ b/backend/routes/athletes.py
@@ -23,12 +23,14 @@ from src.shared.models import (
     AthleteProfileUpdate,
     CoachAthlete,
 )
+from src.shared.models.workout import WorkoutTemplate
 from src.shared.supabase_client import get_supabase_client
 from src.shared.supabase_ops import (
     AthletesRepository,
     CoachAthletesRepository,
     UserRolesRepository,
     UsersRepository,
+    WorkoutTemplatesRepository,
 )
 
 
@@ -88,6 +90,19 @@ def my_athlete(user_id: UUID = Depends(authenticate_request)) -> Athlete | None:
         return None
     # Linked-athlete view: coaching_notes redacted.
     return _athlete_with_profile(repo, row, coach_view=False)
+
+
+@me_router.get("/workouts", response_model=list[WorkoutTemplate])
+def my_workouts(user_id: UUID = Depends(authenticate_request)) -> list[WorkoutTemplate]:
+    """The workout templates assigned to the athlete this user IS (via
+    linked_user_id). Empty when the user isn't a linked athlete. Lets an athlete
+    see their coach-assigned workouts without the coach act-as header (SB-332)."""
+    sb = get_supabase_client()
+    athlete = AthletesRepository(sb).get_by_linked_user(user_id)
+    if athlete is None:
+        return []
+    rows = WorkoutTemplatesRepository(sb).list(user_id, athlete_id=UUID(athlete["id"]))
+    return [WorkoutTemplate(**r) for r in rows]
 
 
 @router.post("", response_model=Athlete, status_code=status.HTTP_201_CREATED)

--- a/backend/tests/test_my_workouts.py
+++ b/backend/tests/test_my_workouts.py
@@ -1,0 +1,70 @@
+"""SB-332: athlete-facing GET /me/workouts.
+
+An athlete (linked_user_id) sees the templates their coach assigned, scoped by
+the athlete's own athlete_id — no coach act-as header involved.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+
+def _template_row(athlete_id, coach_id) -> dict:
+    # A coach-created template: the row's user_id is the COACH, athlete_id the athlete.
+    return {
+        "id": str(uuid4()),
+        "user_id": str(coach_id),
+        "athlete_id": str(athlete_id),
+        "created_by": str(coach_id),
+        "name": "Monday At-Home",
+        "type": "circuit",
+        "rounds": 1,
+        "source": "Matthew",
+        "notes": None,
+        "items": [],
+        "created_at": "2026-07-20T00:00:00+00:00",
+    }
+
+
+def _patch(athletes_repo: MagicMock, templates_repo: MagicMock):
+    return (
+        patch("backend.routes.athletes.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.athletes.AthletesRepository", return_value=athletes_repo),
+        patch("backend.routes.athletes.WorkoutTemplatesRepository", return_value=templates_repo),
+    )
+
+
+def test_linked_athlete_sees_assigned_templates() -> None:
+    from backend.routes.athletes import my_workouts
+
+    athlete_user, athlete_id, coach_id = uuid4(), uuid4(), uuid4()
+    athletes_repo = MagicMock()
+    athletes_repo.get_by_linked_user.return_value = {"id": str(athlete_id)}
+    templates_repo = MagicMock()
+    templates_repo.list.return_value = [_template_row(athlete_id, coach_id)]
+
+    p1, p2, p3 = _patch(athletes_repo, templates_repo)
+    with p1, p2, p3:
+        out = my_workouts(user_id=athlete_user)
+
+    assert len(out) == 1
+    assert out[0].name == "Monday At-Home"
+    assert out[0].source == "Matthew"
+    # Scoped by the athlete's own athlete_id (coach-owned rows), not caller user_id.
+    templates_repo.list.assert_called_once_with(athlete_user, athlete_id=athlete_id)
+
+
+def test_non_athlete_gets_empty_list() -> None:
+    from backend.routes.athletes import my_workouts
+
+    athletes_repo = MagicMock()
+    athletes_repo.get_by_linked_user.return_value = None
+    templates_repo = MagicMock()
+
+    p1, p2, p3 = _patch(athletes_repo, templates_repo)
+    with p1, p2, p3:
+        out = my_workouts(user_id=uuid4())
+
+    assert out == []
+    templates_repo.list.assert_not_called()

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -85,6 +85,7 @@ const navLinks = computed(() => [
   ...(isCoach.value ? [{ name: 'Coach', path: '/coach' }] : []),
   ...(isCoach.value ? [{ name: 'Catalog', path: '/exercises' }] : []),
   ...(isAdmin.value ? [{ name: 'Admin', path: '/admin' }] : []),
+  ...(myAthlete.value ? [{ name: 'My Workouts', path: '/my/workouts' }] : []),
   ...(myAthlete.value ? [{ name: 'My Profile', path: '/profile' }] : []),
   { name: 'Settings', path: '/settings' },
 ])

--- a/frontend/src/components/WorkoutTemplateCard.vue
+++ b/frontend/src/components/WorkoutTemplateCard.vue
@@ -14,7 +14,7 @@
           <span v-if="template.source" class="text-xs text-gray-400">Coached by {{ template.source }}</span>
         </div>
       </div>
-      <div class="flex items-center gap-1 shrink-0 print:hidden">
+      <div v-if="!readonly" class="flex items-center gap-1 shrink-0 print:hidden">
         <button
           type="button"
           class="act hover:text-brand-600 hover:bg-brand-50"
@@ -90,6 +90,8 @@ import { SECTIONS, fmtDuration, kgToLb, prettifyKey } from '@/utils/workoutPaylo
 const props = defineProps<{
   template: WorkoutTemplate
   exercises?: Exercise[]
+  // Athlete-facing view (SB-332): hide the coach action buttons.
+  readonly?: boolean
 }>()
 
 defineEmits<{ (e: 'edit'): void; (e: 'delete'): void; (e: 'log'): void; (e: 'print'): void }>()

--- a/frontend/src/components/__tests__/WorkoutTemplateCard.test.ts
+++ b/frontend/src/components/__tests__/WorkoutTemplateCard.test.ts
@@ -87,4 +87,12 @@ describe('WorkoutTemplateCard', () => {
     expect(w.emitted('edit')).toHaveLength(1)
     expect(w.emitted('delete')).toHaveLength(1)
   })
+
+  it('hides the coach action buttons in readonly mode (SB-332)', () => {
+    const w = mount(WorkoutTemplateCard, { props: { template, readonly: true } })
+    expect(w.find('button[aria-label="Edit workout"]').exists()).toBe(false)
+    expect(w.find('button[aria-label="Delete workout"]').exists()).toBe(false)
+    // content still renders
+    expect(w.text()).toContain('Monday - Circuit')
+  })
 })

--- a/frontend/src/composables/useMyWorkouts.ts
+++ b/frontend/src/composables/useMyWorkouts.ts
@@ -1,0 +1,35 @@
+import { ref } from 'vue'
+import { apiCall } from '@/config/api'
+import type { Exercise, WorkoutTemplate } from '@/types/workout'
+
+/**
+ * The linked athlete's own coach-assigned workouts (SB-332). Reads
+ * GET /me/workouts — the backend resolves the athlete from the caller's
+ * linked_user_id, so no coach act-as header is involved. Exercises are fetched
+ * alongside so the card can show display names.
+ */
+export function useMyWorkouts() {
+  const templates = ref<WorkoutTemplate[]>([])
+  const exercises = ref<Exercise[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const load = async (): Promise<void> => {
+    loading.value = true
+    error.value = null
+    try {
+      const [t, ex] = await Promise.all([
+        apiCall<WorkoutTemplate[]>('/me/workouts'),
+        apiCall<Exercise[]>('/workouts/exercises'),
+      ])
+      templates.value = t
+      exercises.value = ex
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load workouts'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { templates, exercises, loading, error, load }
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -116,6 +116,12 @@ const router = createRouter({
       component: () => import('@/views/MyProfileView.vue'),
       meta: { requiresAuth: true },
     },
+    {
+      path: '/my/workouts',
+      name: 'my-workouts',
+      component: () => import('@/views/MyWorkoutsView.vue'),
+      meta: { requiresAuth: true },
+    },
   ],
   scrollBehavior(_to, _from, savedPosition) {
     return savedPosition ?? { top: 0 }

--- a/frontend/src/views/MyWorkoutsView.vue
+++ b/frontend/src/views/MyWorkoutsView.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="container-app py-8 max-w-2xl">
+    <h1 class="text-2xl font-bold text-gray-900 mb-1">My workouts</h1>
+    <p class="text-sm text-gray-500 mb-6">Workouts your coach has assigned to you.</p>
+
+    <div v-if="loading" class="space-y-3">
+      <div
+        v-for="i in 3"
+        :key="i"
+        class="h-28 bg-white rounded-2xl border border-gray-100 animate-pulse"
+      />
+    </div>
+
+    <div
+      v-else-if="error"
+      class="bg-red-50 border border-red-100 rounded-xl p-4 text-sm text-red-600"
+    >
+      {{ error }}
+    </div>
+
+    <div
+      v-else-if="templates.length === 0"
+      class="bg-white rounded-xl border border-gray-100 shadow-sm p-8 text-center text-gray-500"
+    >
+      <p>No workouts assigned yet.</p>
+    </div>
+
+    <div v-else class="space-y-4">
+      <WorkoutTemplateCard
+        v-for="t in templates"
+        :key="t.id"
+        :template="t"
+        :exercises="exercises"
+        readonly
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useMyAthlete } from '@/composables/useCoach'
+import { useMyWorkouts } from '@/composables/useMyWorkouts'
+import WorkoutTemplateCard from '@/components/WorkoutTemplateCard.vue'
+
+const router = useRouter()
+const { myAthlete, loadMyAthlete } = useMyAthlete()
+const { templates, exercises, loading, error, load } = useMyWorkouts()
+
+onMounted(async () => {
+  await loadMyAthlete(true)
+  // Not a linked athlete → no workouts to show here.
+  if (!myAthlete.value) {
+    router.replace('/dashboard')
+    return
+  }
+  await load()
+})
+</script>

--- a/frontend/src/views/__tests__/MyWorkoutsView.test.ts
+++ b/frontend/src/views/__tests__/MyWorkoutsView.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+const apiCallMock = vi.fn()
+vi.mock('@/config/api', () => ({ apiCall: (...a: unknown[]) => apiCallMock(...a) }))
+
+const myAthlete: { value: unknown } = { value: null }
+const loadMyAthlete = vi.fn(async () => {})
+vi.mock('@/composables/useCoach', () => ({
+  useMyAthlete: () => ({ myAthlete, loadMyAthlete }),
+}))
+
+const replaceMock = vi.fn()
+vi.mock('vue-router', () => ({ useRouter: () => ({ replace: replaceMock }) }))
+
+import MyWorkoutsView from '../MyWorkoutsView.vue'
+
+const template = {
+  id: 't1',
+  user_id: 'coach',
+  athlete_id: 'a1',
+  created_by: 'coach',
+  name: 'Monday At-Home',
+  type: 'circuit',
+  rounds: 1,
+  source: 'Matthew',
+  notes: null,
+  items: [],
+  created_at: '2026-07-20T00:00:00Z',
+}
+
+beforeEach(() => {
+  apiCallMock.mockReset()
+  loadMyAthlete.mockClear()
+  replaceMock.mockClear()
+  myAthlete.value = null
+})
+
+describe('MyWorkoutsView (SB-332)', () => {
+  it('redirects a non-athlete to the dashboard without fetching', async () => {
+    myAthlete.value = null
+    mount(MyWorkoutsView)
+    await flushPromises()
+    expect(replaceMock).toHaveBeenCalledWith('/dashboard')
+    expect(apiCallMock).not.toHaveBeenCalled()
+  })
+
+  it('renders assigned workouts for a linked athlete', async () => {
+    myAthlete.value = { id: 'a1', display_name: 'Gabe' }
+    apiCallMock.mockImplementation((path: string) => {
+      if (path === '/me/workouts') return Promise.resolve([template])
+      if (path === '/workouts/exercises') return Promise.resolve([])
+      return Promise.reject(new Error(`unexpected: ${path}`))
+    })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    expect(w.text()).toContain('Monday At-Home')
+    expect(w.text()).toContain('Coached by Matthew')
+    expect(replaceMock).not.toHaveBeenCalled()
+  })
+
+  it('shows the empty state when nothing is assigned', async () => {
+    myAthlete.value = { id: 'a1', display_name: 'Gabe' }
+    apiCallMock.mockImplementation((path: string) => {
+      if (path === '/me/workouts') return Promise.resolve([])
+      if (path === '/workouts/exercises') return Promise.resolve([])
+      return Promise.reject(new Error('unexpected'))
+    })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    expect(w.text()).toContain('No workouts assigned yet')
+  })
+})


### PR DESCRIPTION
Fixes SB-332.

## Problem
Every workout screen lived under `/coach/:athleteId/*` behind the coach act-as header. A **linked athlete had no page** to see the workouts their coach assigned — so Gabe ended up on `/coach` → "Coach privileges required." (SB-331 stopped the dead-end; this gives him the real destination.)

## Backend
- **`GET /me/workouts`** — resolves the athlete from the caller's `linked_user_id` and lists templates scoped to that `athlete_id`. Empty when the user isn't a linked athlete. No act-as header exposed to athlete-side code; the caller can only ever see their own athlete's workouts.

## Frontend
- New **`/my/workouts`** route + **`MyWorkoutsView`**, backed by `useMyWorkouts` (fetches templates + exercises for display names). Redirects a non-athlete to `/dashboard`.
- **`WorkoutTemplateCard`** gains a `readonly` prop that hides the coach action buttons; the athlete view renders read-only.
- **"My Workouts"** nav link, gated on being a linked athlete (same pattern as "My Profile").

## Tests
- Backend `test_my_workouts.py` — linked athlete sees assigned templates + correct scoping; non-athlete → empty, no list call.
- `MyWorkoutsView.test.ts` — redirect for non-athlete, renders assigned workouts, empty state.
- `WorkoutTemplateCard.test.ts` — readonly hides the action buttons.

Backend 21/21 pass; frontend new tests pass + no new regressions (the 2 failing `useSync`/`useUserPreferences` suites are the pre-existing `localStorage` env gap).

## Follow-ups (already ticketed)
- SB-333 created-date + SB-334 completed indicator will enrich these same cards.
- Landing (`useLanding`) still sends a linked athlete to `/dashboard`; nav link covers discovery. Could revisit if we want athletes to land on `/my/workouts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)