### PR TITLE
feat(workouts): created date + completion state on workout cards (SB-333, SB-334)

### DIFF
--- a/backend/tests/test_workout_repository.py
+++ b/backend/tests/test_workout_repository.py
@@ -177,6 +177,29 @@ def test_template_update_replaces_items_and_fields():
     assert upd["items"][0]["exercise_key"] == "plank"
 
 
+def test_list_attaches_completion_state():
+    """list() marks a template done when a session references it, keeping the
+    latest session_date; untouched templates report has_session False (SB-334)."""
+    supa = _FakeSupabase()
+    user = uuid4()
+    t1, t2 = str(uuid4()), str(uuid4())
+    supa.store["workout_templates"] = [
+        {"id": t1, "user_id": str(user), "name": "A", "type": "circuit", "rounds": 1},
+        {"id": t2, "user_id": str(user), "name": "B", "type": "circuit", "rounds": 1},
+    ]
+    supa.store["workout_sessions"] = [
+        {"template_id": t1, "session_date": "2026-07-21"},
+        {"template_id": t1, "session_date": "2026-07-23"},  # latest wins
+    ]
+    repo = WorkoutTemplatesRepository(supa)
+    by_id = {r["id"]: r for r in repo.list(user)}
+
+    assert by_id[t1]["has_session"] is True
+    assert by_id[t1]["last_session_date"] == "2026-07-23"
+    assert by_id[t2]["has_session"] is False
+    assert by_id[t2]["last_session_date"] is None
+
+
 def test_session_create_round_trips_with_sets():
     supa = _FakeSupabase()
     repo = WorkoutSessionsRepository(supa)

--- a/frontend/src/components/WorkoutTemplateCard.vue
+++ b/frontend/src/components/WorkoutTemplateCard.vue
@@ -11,8 +11,23 @@
           <span class="inline-flex items-center gap-1 rounded-full bg-brand-50 px-2 py-0.5 text-xs font-semibold text-brand-700 capitalize">
             <Repeat class="w-3 h-3" /> {{ template.type }} · {{ template.rounds }} {{ template.rounds === 1 ? 'round' : 'rounds' }}
           </span>
+          <span
+            v-if="template.has_session"
+            class="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-xs font-semibold text-green-700"
+          >
+            <Check class="w-3 h-3" /> Completed<template v-if="template.last_session_date"> · {{ formatDayMonth(template.last_session_date) }}</template>
+          </span>
+          <span
+            v-else
+            class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500"
+          >
+            Not logged
+          </span>
           <span v-if="template.source" class="text-xs text-gray-400">Coached by {{ template.source }}</span>
         </div>
+        <p v-if="template.created_at" class="mt-1 text-xs text-gray-400">
+          Added {{ formatRelativeTime(template.created_at) }}
+        </p>
       </div>
       <div v-if="!readonly" class="flex items-center gap-1 shrink-0 print:hidden">
         <button
@@ -83,9 +98,10 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { ClipboardCheck, Pencil, Printer, Repeat, Trash2 } from 'lucide-vue-next'
+import { Check, ClipboardCheck, Pencil, Printer, Repeat, Trash2 } from 'lucide-vue-next'
 import type { Exercise, TemplateItem, WorkoutSectionKey, WorkoutTemplate } from '@/types/workout'
 import { SECTIONS, fmtDuration, kgToLb, prettifyKey } from '@/utils/workoutPayload'
+import { formatDayMonth, formatRelativeTime } from '@/utils/format'
 
 const props = defineProps<{
   template: WorkoutTemplate

--- a/frontend/src/components/__tests__/WorkoutTemplateCard.test.ts
+++ b/frontend/src/components/__tests__/WorkoutTemplateCard.test.ts
@@ -95,4 +95,27 @@ describe('WorkoutTemplateCard', () => {
     // content still renders
     expect(w.text()).toContain('Monday - Circuit')
   })
+
+  it('shows the created date when present (SB-333)', () => {
+    const w = mount(WorkoutTemplateCard, {
+      props: { template: { ...template, created_at: '2026-07-20T12:00:00Z' } },
+    })
+    expect(w.text()).toContain('Added')
+  })
+
+  it('shows a completed badge with the last session date (SB-334)', () => {
+    const w = mount(WorkoutTemplateCard, {
+      props: { template: { ...template, has_session: true, last_session_date: '2026-07-23' } },
+    })
+    expect(w.text()).toContain('Completed')
+    expect(w.text()).toContain('Jul 23')
+    expect(w.text()).not.toContain('Not logged')
+  })
+
+  it('shows "Not logged" when no session exists (SB-334)', () => {
+    const w = mount(WorkoutTemplateCard, {
+      props: { template: { ...template, has_session: false } },
+    })
+    expect(w.text()).toContain('Not logged')
+  })
 })

--- a/frontend/src/types/workout.ts
+++ b/frontend/src/types/workout.ts
@@ -122,6 +122,9 @@ export interface WorkoutTemplate {
   notes: string | null
   items: TemplateItem[]
   created_at: string | null
+  // Completion (SB-334): a logged session references this template.
+  has_session?: boolean
+  last_session_date?: string | null
 }
 
 /** One row while building — loads are entered in lb (US coach), stored as kg. */

--- a/frontend/src/utils/__tests__/format.test.ts
+++ b/frontend/src/utils/__tests__/format.test.ts
@@ -5,6 +5,7 @@ import {
   formatPace,
   formatDuration,
   formatDate,
+  formatDayMonth,
   formatMonthLabel,
   formatRelativeTime,
   distanceLabel,
@@ -153,5 +154,22 @@ describe('formatMonthLabel', () => {
 
   it('falls back to the raw string when unparseable', () => {
     expect(formatMonthLabel('garbage')).toBe('garbage')
+  })
+})
+
+describe('formatDayMonth', () => {
+  it('formats a date-only string as day + month', () => {
+    expect(formatDayMonth('2026-07-20')).toBe('Jul 20')
+    expect(formatDayMonth('2026-01-01')).toBe('Jan 1')
+    expect(formatDayMonth('2026-12-31')).toBe('Dec 31')
+  })
+
+  it('does not shift a day in negative-offset zones (timezone-safe)', () => {
+    // new Date('2026-07-01') would be UTC midnight → Jun 30 locally in the US.
+    expect(formatDayMonth('2026-07-01')).toBe('Jul 1')
+  })
+
+  it('falls back to the raw string when unparseable', () => {
+    expect(formatDayMonth('nope')).toBe('nope')
   })
 })

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -55,6 +55,19 @@ export const formatMonthLabel = (month: string): string => {
   return `${name} ${String(year).slice(-2)}`
 }
 
+/**
+ * Format a date-only string ('YYYY-MM-DD') as 'Jul 20'. Parses the parts
+ * directly rather than via `new Date()`, which treats date-only ISO as UTC
+ * midnight and shifts a day in negative-offset zones (same trap as
+ * [[format-month-label]] / the SB monthly-distance fix).
+ */
+export const formatDayMonth = (dateOnly: string): string => {
+  const [, month, day] = dateOnly.split('-').map(Number)
+  const name = MONTHS[month - 1]
+  if (!name || Number.isNaN(day)) return dateOnly
+  return `${name} ${day}`
+}
+
 export const formatDate = (iso: string): string => {
   const d = new Date(iso)
   if (Number.isNaN(d.getTime())) return iso

--- a/src/shared/models/workout.py
+++ b/src/shared/models/workout.py
@@ -203,6 +203,10 @@ class WorkoutTemplate(BaseModel):
     notes: str | None = None
     items: list[TemplateItem] = Field(default_factory=list)
     created_at: datetime | None = None
+    # Completion (SB-334), populated by the list query: a template is "done"
+    # when a logged session references it. False/None on single-template reads.
+    has_session: bool = False
+    last_session_date: date | None = None
 
 
 # --------------------------------------------------------------------------- #

--- a/src/shared/supabase_ops/workout_repository.py
+++ b/src/shared/supabase_ops/workout_repository.py
@@ -221,6 +221,25 @@ class WorkoutTemplatesRepository:
             by_template.setdefault(it["template_id"], []).append(it)
         for t in templates:
             t["items"] = by_template.get(t["id"], [])
+
+        # Attach completion state (SB-334): a template is "done" when a logged
+        # session references it. One batched query; keep the latest session_date
+        # per template (session_date is 'YYYY-MM-DD', so string max = latest).
+        sessions = (
+            self.supabase.table("workout_sessions")
+            .select("template_id, session_date")
+            .in_("template_id", ids)
+            .execute()
+        )
+        last_by_template: dict[str, str] = {}
+        for s in cast(list[dict[str, Any]], sessions.data):
+            tid, d = s.get("template_id"), s.get("session_date")
+            if tid and d and (tid not in last_by_template or d > last_by_template[tid]):
+                last_by_template[tid] = d
+        for t in templates:
+            last = last_by_template.get(t["id"])
+            t["has_session"] = last is not None
+            t["last_session_date"] = last
         return templates
 
     def list_for_athletes(self, athlete_ids: Sequence[UUID]) -> list[dict[str, Any]]:


### PR DESCRIPTION
Fixes SB-333. Fixes SB-334.

Two card enhancements shipped together (they share `WorkoutTemplateCard` + `types/workout.ts`).

## SB-334 — per-workout completed indicator
- `WorkoutTemplate` gains `has_session` + `last_session_date`, populated by the templates `list()` via **one batched `workout_sessions` query** (latest `session_date` per template; string max on `YYYY-MM-DD`). A template is "done" when a logged session references it.
- Both the coach athlete-detail view **and** the athlete `/me/workouts` view (SB-332) get this for free — same `list()`. Single-template reads default to not-logged.
- Card shows a green **"Completed · \<date\>"** badge, else **"Not logged"**.

## SB-333 — created date
- Card renders **"Added \<relative time\>"** from `created_at` (already in the payload; display-only).

## Timezone-safe date
`last_session_date` is date-only (`YYYY-MM-DD`). Formatting it with `new Date()` would shift a day in US zones — the exact trap fixed in the monthly-distance PR. Added `formatDayMonth` that parses the parts directly.

## Tests
- Backend `test_workout_repository.py` — `list()` attaches completion state (latest session wins; untouched template → `has_session` false).
- `format.test.ts` — `formatDayMonth` incl. the timezone case.
- `WorkoutTemplateCard.test.ts` — created-date line + completed/not-logged badges.

Backend 260/260 pass; frontend new tests pass, no new regressions (the 2 failing `useSync`/`useUserPreferences` suites are the pre-existing `localStorage` gap — now ticketed as SB-345).

🤖 Generated with [Claude Code](https://claude.com/claude-code)