### PR TITLE
feat(workouts): optional scheduled_for date on workout templates (SB-335)

### DIFF
--- a/backend/tests/test_workout_repository.py
+++ b/backend/tests/test_workout_repository.py
@@ -177,6 +177,17 @@ def test_template_update_replaces_items_and_fields():
     assert upd["items"][0]["exercise_key"] == "plank"
 
 
+def test_template_create_round_trips_scheduled_for():
+    """An optional scheduled_for date survives create -> read (SB-335)."""
+    supa = _FakeSupabase()
+    repo = WorkoutTemplatesRepository(supa)
+    out = repo.create(
+        uuid4(),
+        {"name": "Monday", "type": "circuit", "rounds": 1, "scheduled_for": "2026-07-28"},
+    )
+    assert out["scheduled_for"] == "2026-07-28"
+
+
 def test_list_attaches_completion_state():
     """list() marks a template done when a session references it, keeping the
     latest session_date; untouched templates report has_session False (SB-334)."""

--- a/frontend/src/components/WorkoutTemplateCard.vue
+++ b/frontend/src/components/WorkoutTemplateCard.vue
@@ -12,6 +12,12 @@
             <Repeat class="w-3 h-3" /> {{ template.type }} · {{ template.rounds }} {{ template.rounds === 1 ? 'round' : 'rounds' }}
           </span>
           <span
+            v-if="template.scheduled_for"
+            class="inline-flex items-center gap-1 rounded-full bg-sky-50 px-2 py-0.5 text-xs font-semibold text-sky-700"
+          >
+            <Calendar class="w-3 h-3" /> {{ formatDayMonth(template.scheduled_for) }}
+          </span>
+          <span
             v-if="template.has_session"
             class="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-xs font-semibold text-green-700"
           >
@@ -98,7 +104,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { Check, ClipboardCheck, Pencil, Printer, Repeat, Trash2 } from 'lucide-vue-next'
+import { Calendar, Check, ClipboardCheck, Pencil, Printer, Repeat, Trash2 } from 'lucide-vue-next'
 import type { Exercise, TemplateItem, WorkoutSectionKey, WorkoutTemplate } from '@/types/workout'
 import { SECTIONS, fmtDuration, kgToLb, prettifyKey } from '@/utils/workoutPayload'
 import { formatDayMonth, formatRelativeTime } from '@/utils/format'

--- a/frontend/src/components/__tests__/WorkoutTemplateCard.test.ts
+++ b/frontend/src/components/__tests__/WorkoutTemplateCard.test.ts
@@ -118,4 +118,11 @@ describe('WorkoutTemplateCard', () => {
     })
     expect(w.text()).toContain('Not logged')
   })
+
+  it('shows the scheduled date when set (SB-335)', () => {
+    const w = mount(WorkoutTemplateCard, {
+      props: { template: { ...template, scheduled_for: '2026-07-28' } },
+    })
+    expect(w.text()).toContain('Jul 28')
+  })
 })

--- a/frontend/src/types/workout.ts
+++ b/frontend/src/types/workout.ts
@@ -86,6 +86,7 @@ export interface WorkoutTemplateInput {
   name: string
   type: WorkoutType
   rounds: number
+  scheduled_for?: string | null
   items: TemplateItemInput[]
 }
 
@@ -122,6 +123,8 @@ export interface WorkoutTemplate {
   notes: string | null
   items: TemplateItem[]
   created_at: string | null
+  // Optional date the workout is scheduled for (SB-335).
+  scheduled_for?: string | null
   // Completion (SB-334): a logged session references this template.
   has_session?: boolean
   last_session_date?: string | null

--- a/frontend/src/utils/workoutPayload.ts
+++ b/frontend/src/utils/workoutPayload.ts
@@ -49,6 +49,7 @@ export function buildTemplatePayload(
   type: WorkoutType,
   rounds: number,
   items: BuilderItem[],
+  scheduledFor?: string | null,
 ): WorkoutTemplateInput {
   const ordered = SECTION_ORDER.flatMap((section) =>
     items.filter((it) => it.section === section),
@@ -65,5 +66,5 @@ export function buildTemplatePayload(
     variant: it.variant?.trim() || null,
     notes: it.notes?.trim() || null,
   }))
-  return { name: name.trim(), type, rounds, items: apiItems }
+  return { name: name.trim(), type, rounds, scheduled_for: scheduledFor || null, items: apiItems }
 }

--- a/frontend/src/views/WorkoutBuilderView.vue
+++ b/frontend/src/views/WorkoutBuilderView.vue
@@ -26,6 +26,11 @@
           <input v-model.number="rounds" type="number" min="1" class="form-input w-20" data-testid="tpl-rounds" />
         </label>
       </div>
+      <label class="flex items-center gap-2 text-sm text-gray-600">
+        Scheduled for
+        <input v-model="scheduledFor" type="date" class="form-input" data-testid="tpl-scheduled-for" />
+        <span class="text-xs text-gray-400">(optional)</span>
+      </label>
     </div>
 
     <!-- Sections -->
@@ -135,6 +140,7 @@ const { exercises, load } = useExercises()
 const name = ref('')
 const type = ref<WorkoutType>('circuit')
 const rounds = ref(2)
+const scheduledFor = ref('')
 const items = ref<BuilderItem[]>([])
 const openSection = ref<WorkoutSectionKey | null>(null)
 const saving = ref(false)
@@ -190,7 +196,13 @@ const save = async (): Promise<void> => {
   saving.value = true
   error.value = null
   try {
-    const payload = buildTemplatePayload(name.value, type.value, rounds.value, items.value)
+    const payload = buildTemplatePayload(
+      name.value,
+      type.value,
+      rounds.value,
+      items.value,
+      scheduledFor.value,
+    )
     if (editingId) await updateTemplate(editingId, payload, athleteId)
     else await createTemplate(payload, athleteId)
     router.push(`/coach/${athleteId}`)
@@ -207,6 +219,7 @@ const prefillFrom = (templateId: string): Promise<void> =>
     name.value = tpl.name
     type.value = tpl.type
     rounds.value = tpl.rounds
+    scheduledFor.value = tpl.scheduled_for ?? ''
     const byKey = new Map(exercises.value.map((e) => [e.key, e]))
     items.value = tpl.items
       .slice()

--- a/frontend/src/views/__tests__/WorkoutBuilderView.test.ts
+++ b/frontend/src/views/__tests__/WorkoutBuilderView.test.ts
@@ -104,6 +104,20 @@ describe('WorkoutBuilderView', () => {
     expect(h.push).toHaveBeenCalledWith('/coach/ath1')
   })
 
+  it('includes scheduled_for in the saved payload (SB-335)', async () => {
+    h.createTemplate.mockResolvedValue({ id: 't1' })
+    const w = await mountBuilder()
+    await w.find('[data-testid="tpl-name"]').setValue('Sched')
+    await w.find('[data-testid="add-main"]').trigger('click')
+    await w.find('[data-testid="ex-farmers_carry"]').trigger('click')
+    await w.find('[data-testid="tpl-scheduled-for"]').setValue('2026-07-28')
+    await w.find('[data-testid="save"]').trigger('click')
+    await flushPromises()
+
+    const [payload] = h.createTemplate.mock.calls[0]
+    expect(payload.scheduled_for).toBe('2026-07-28')
+  })
+
   it('edit mode: prefills from the template and saves via updateTemplate', async () => {
     h.params = { athleteId: 'ath1', templateId: 't9' }
     h.getTemplate.mockResolvedValue({

--- a/src/shared/models/workout.py
+++ b/src/shared/models/workout.py
@@ -186,6 +186,7 @@ class WorkoutTemplateCreate(BaseModel):
     rounds: int = Field(default=1, ge=1)
     source: str | None = None
     notes: str | None = None
+    scheduled_for: date | None = None  # optional date the workout is for (SB-335)
     items: list[TemplateItemCreate] = Field(default_factory=list)
 
 
@@ -201,6 +202,7 @@ class WorkoutTemplate(BaseModel):
     rounds: int
     source: str | None = None
     notes: str | None = None
+    scheduled_for: date | None = None  # optional date the workout is for (SB-335)
     items: list[TemplateItem] = Field(default_factory=list)
     created_at: datetime | None = None
     # Completion (SB-334), populated by the list query: a template is "done"

--- a/supabase/migrations/20260726000000_workout_scheduled_for.sql
+++ b/supabase/migrations/20260726000000_workout_scheduled_for.sql
@@ -1,0 +1,10 @@
+-- =====================================================
+-- Scheduled date for a workout template (SB-335)
+-- =====================================================
+-- An optional date a coach-assigned workout is scheduled for. Distinct from
+-- created_at (when it was built) and from completion (a logged session). The
+-- template name ("Monday At-Home") carried no real date before this. Nullable;
+-- existing rows are unaffected and inherit the table's RLS policies.
+
+ALTER TABLE workout_templates ADD COLUMN IF NOT EXISTS scheduled_for DATE;
+COMMENT ON COLUMN workout_templates.scheduled_for IS 'Optional date the workout is scheduled for (SB-335)';


### PR DESCRIPTION
Fixes SB-335.

Adds a real **scheduled-for date** to a workout template — distinct from `created_at` (when it was built) and from completion (a logged session). Before this, "Monday At-Home" was just a name with no actual date.

## Backend
- **Migration** `20260726000000_workout_scheduled_for.sql` — `workout_templates.scheduled_for DATE`, nullable, `ADD COLUMN IF NOT EXISTS`; existing rows unaffected, inherit the table's RLS.
- **Model** — `scheduled_for` on `WorkoutTemplateCreate` + `WorkoutTemplate`. Routes (`model_dump`) and repo (`create`/`update` spread payload, `select("*")` read-back) already pass it through — no further backend change.

## Frontend
- **Builder** — an optional `<input type="date">` in the meta section; threaded through `buildTemplatePayload` and prefilled on edit.
- **Card** — a sky calendar chip with the date, using the timezone-safe `formatDayMonth` (date-only, no `new Date()` day-shift).

## Tests
- `test_workout_repository.py` — create round-trips `scheduled_for`.
- `WorkoutBuilderView.test.ts` — the date lands in the saved payload.
- `WorkoutTemplateCard.test.ts` — chip renders.

Backend 261/261; frontend new tests pass, no new regressions (the 2 failing suites are the pre-existing `localStorage` gap, SB-345).

## ⚠️ Deploy note
The migration must be applied to Supabase (local + prod) on deploy — it's not auto-run by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)