### PR TITLE
chore: add .env.prod.example + document switch-env.sh prod (SB-336)

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,14 @@
+# MyRunStreak — PRODUCTION env template (SB-336)
+#
+# Copy to .env.prod and fill SUPABASE_KEY, then `./switch-env.sh prod`.
+# NEVER commit .env.prod — it holds a live service-role key (bypasses RLS).
+#
+# One-liner (pulls the key from 1Password; needs biometric auth):
+#   printf 'SUPABASE_URL=https://dnwllbukmvdddwhlsmqb.supabase.co\nSUPABASE_KEY=%s\n' \
+#     "$(op read 'op://Personal/stk-prod/service_role_key')" > .env.prod
+
+# Production Supabase (public URL)
+SUPABASE_URL=https://dnwllbukmvdddwhlsmqb.supabase.co
+
+# Service-role key — resolve from 1Password: op://Personal/stk-prod/service_role_key
+SUPABASE_KEY=your-prod-service-role-key

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ terraform.tfplan
 .env
 .env.*
 !.env.example
+!.env.prod.example
 !.env.schema
 secrets.json
 credentials.json

--- a/README.md
+++ b/README.md
@@ -83,7 +83,16 @@ are gitignored; create them once:
   `CACHE_ENABLED=false`). **Also set `SUPABASE_KEY` to the service-role key** —
   the backend requires it or every DB route 500s. Seed dev users with
   `scripts/seed_local_users.py` (see below) instead of hand-setting admin IDs.
-- **`.env.prod`** — copy from `.env.example` and fill with the real cloud keys.
+- **`.env.prod`** — cloud Supabase. Copy `.env.prod.example` (has the prod URL)
+  and fill `SUPABASE_KEY` with the service-role key from 1Password. `switch-env.sh
+  prod` fails until this file exists. Quick create:
+
+  ```bash
+  printf 'SUPABASE_URL=https://dnwllbukmvdddwhlsmqb.supabase.co\nSUPABASE_KEY=%s\n' \
+    "$(op read 'op://Personal/stk-prod/service_role_key')" > .env.prod
+  ```
+
+  ⚠️ Never commit `.env.prod` — it holds a live service-role key (bypasses RLS).
 
 Or do it by hand:
 


### PR DESCRIPTION
Fixes SB-336.

`./switch-env.sh prod` failed out of the box — `.env.prod` was missing and the prod-key source undocumented (buried in `scripts/restore_prod_to_local.sh`).

## Changes
- **`.env.prod.example`** — the public prod `SUPABASE_URL` + a placeholder `SUPABASE_KEY`, with the 1Password path (`op://Personal/stk-prod/service_role_key`) and a create-it one-liner in comments.
- **`.gitignore`** — re-include `.env.prod.example` (the `.env.*` rule was hiding it); `.env.prod` itself stays ignored.
- **README** — the `.env.prod` bullet now points at the example, shows the `op read` one-liner, and warns the file holds a live service-role key (bypasses RLS).

## Verify
- `git status` shows `.env.prod.example` tracked; `git check-ignore .env.prod` still ignores the real file.
- Following the README from a fresh clone reaches prod read-only without spelunking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)