### PR TITLE
chore(test): shared vitest localStorage polyfill — full suite green (SB-345)

### DIFF
--- a/frontend/src/router/__tests__/index.test.ts
+++ b/frontend/src/router/__tests__/index.test.ts
@@ -1,27 +1,4 @@
-import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
-
-// Navigating loads view components that pull useSync → window.localStorage,
-// which this test env doesn't provide. Shim it so navigation doesn't crash.
-beforeAll(() => {
-  if (!window.localStorage) {
-    const store: Record<string, string> = {}
-    Object.defineProperty(window, 'localStorage', {
-      configurable: true,
-      value: {
-        getItem: (k: string) => store[k] ?? null,
-        setItem: (k: string, v: string) => {
-          store[k] = String(v)
-        },
-        removeItem: (k: string) => {
-          delete store[k]
-        },
-        clear: () => {
-          for (const k of Object.keys(store)) delete store[k]
-        },
-      },
-    })
-  }
-})
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // Auth store: always authenticated with a session so the guard skips init.
 const authState = {

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,0 +1,50 @@
+// Shared vitest setup (SB-345).
+//
+// The happy-dom test environment doesn't provide window.localStorage /
+// sessionStorage here, so any test that touches them — or that loads a module
+// which does at import time (useSync, useUserPreferences, and views/routers that
+// pull them in) — crashes with "Cannot read properties of undefined". This
+// installs a minimal in-memory Storage on window + globalThis when absent, so
+// storage-backed code runs in tests without per-file shims.
+
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>()
+
+  get length(): number {
+    return this.store.size
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) as string) : null
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value))
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key)
+  }
+
+  clear(): void {
+    this.store.clear()
+  }
+}
+
+function install(name: 'localStorage' | 'sessionStorage'): void {
+  const storage = new MemoryStorage()
+  const targets: object[] = [globalThis]
+  if (typeof window !== 'undefined') targets.push(window)
+  for (const target of targets) {
+    if (!(name in target) || (target as Record<string, unknown>)[name] == null) {
+      Object.defineProperty(target, name, { value: storage, configurable: true, writable: true })
+    }
+  }
+}
+
+install('localStorage')
+install('sessionStorage')

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   test: {
     environment: 'happy-dom',
     globals: true,
+    setupFiles: ['./src/test-setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,js}'],
   },
 })


### PR DESCRIPTION
Fixes SB-345.

## Problem
happy-dom didn't provide `window.localStorage` in this test env, so `useSync` and `useUserPreferences` (and any test loading them — including navigation-triggered view loads) failed with "Cannot read properties of undefined" — ~7 tests, long-standing. SB-331 worked around it with a per-file shim in the router test.

## Fix
- **`src/test-setup.ts`** — a minimal in-memory `Storage` installed on `window` + `globalThis` when absent (get/set/remove/clear/length/key).
- **`vitest.config.ts`** — register it via `setupFiles`.
- Removed the now-redundant local shim in `router/__tests__/index.test.ts` (from SB-331).

## Result
Full frontend suite is now **green: 252 passed (was 7 failing)**. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)