### PR TITLE
feat(coach): guard against duplicate athletes on create (SB-349 part B)

### DIFF
--- a/backend/routes/athletes.py
+++ b/backend/routes/athletes.py
@@ -108,12 +108,40 @@ def my_workouts(user_id: UUID = Depends(authenticate_request)) -> list[WorkoutTe
 @router.post("", response_model=Athlete, status_code=status.HTTP_201_CREATED)
 def create_athlete(
     body: AthleteCreate,
+    force: bool = False,
     user_id: UUID = Depends(authenticate_request),
 ) -> Athlete:
-    """Create a managed athlete and make the caller their (first) coach."""
+    """Create a managed athlete and make the caller their (first) coach.
+
+    Guards against duplicates (SB-349): if a similar athlete already exists
+    (same name-ish + birth year), returns 409 with the candidates instead of
+    silently creating another. Pass ?force=true to create anyway (genuinely a
+    different person)."""
     require_coach(user_id)
     supabase = get_supabase_client()
-    row = AthletesRepository(supabase).create(
+    repo = AthletesRepository(supabase)
+    if not force:
+        dups = repo.find_possible_duplicates(body.display_name, body.birth_year)
+        if dups:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                detail={
+                    "message": (
+                        "A similar athlete already exists. If this is the same "
+                        "person, ask an admin to add you as their coach; if it's a "
+                        "different person, resubmit with force=true."
+                    ),
+                    "candidates": [
+                        {
+                            "id": d["id"],
+                            "display_name": d["display_name"],
+                            "birth_year": d.get("birth_year"),
+                        }
+                        for d in dups
+                    ],
+                },
+            )
+    row = repo.create(
         created_by=user_id,
         display_name=body.display_name,
         birth_year=body.birth_year,

--- a/backend/tests/test_coach_foundation.py
+++ b/backend/tests/test_coach_foundation.py
@@ -132,6 +132,7 @@ def test_create_athlete_creates_and_self_assigns() -> None:
     coach = uuid4()
     aid = uuid4()
     athletes_repo = MagicMock()
+    athletes_repo.find_possible_duplicates.return_value = []
     athletes_repo.create.return_value = {
         "id": str(aid),
         "display_name": "Gabe",
@@ -153,6 +154,82 @@ def test_create_athlete_creates_and_self_assigns() -> None:
 
     assert out.display_name == "Gabe"
     links_repo.assign.assert_called_once_with(coach, aid)
+
+
+def test_create_athlete_blocks_possible_duplicate() -> None:
+    """A similar athlete (name-ish + same birth year) → 409 with candidates, no
+    create/assign (SB-349)."""
+    from backend.routes.athletes import create_athlete
+    from src.shared.models import AthleteCreate
+
+    coach = uuid4()
+    athletes_repo = MagicMock()
+    athletes_repo.find_possible_duplicates.return_value = [
+        {"id": str(uuid4()), "display_name": "Gabe", "birth_year": 2012}
+    ]
+    links_repo = MagicMock()
+
+    with (
+        _admin_env(roles={"coach"}),
+        patch("backend.routes.athletes.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.athletes.AthletesRepository", return_value=athletes_repo),
+        patch("backend.routes.athletes.CoachAthletesRepository", return_value=links_repo),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            create_athlete(AthleteCreate(display_name="Gabe Drake", birth_year=2012), user_id=coach)
+
+    assert exc.value.status_code == 409
+    assert exc.value.detail["candidates"][0]["display_name"] == "Gabe"
+    athletes_repo.create.assert_not_called()
+    links_repo.assign.assert_not_called()
+
+
+def test_create_athlete_force_bypasses_duplicate_guard() -> None:
+    """force=true skips the dup check and creates anyway (SB-349)."""
+    from backend.routes.athletes import create_athlete
+    from src.shared.models import AthleteCreate
+
+    coach, aid = uuid4(), uuid4()
+    athletes_repo = MagicMock()
+    athletes_repo.create.return_value = {
+        "id": str(aid),
+        "display_name": "Gabe Drake",
+        "birth_year": 2012,
+        "linked_user_id": None,
+        "created_by": str(coach),
+        "notes": None,
+        "created_at": "2026-07-26T00:00:00+00:00",
+    }
+    links_repo = MagicMock()
+
+    with (
+        _admin_env(roles={"coach"}),
+        patch("backend.routes.athletes.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.athletes.AthletesRepository", return_value=athletes_repo),
+        patch("backend.routes.athletes.CoachAthletesRepository", return_value=links_repo),
+    ):
+        out = create_athlete(
+            AthleteCreate(display_name="Gabe Drake", birth_year=2012), force=True, user_id=coach
+        )
+
+    assert out.display_name == "Gabe Drake"
+    athletes_repo.find_possible_duplicates.assert_not_called()
+    links_repo.assign.assert_called_once_with(coach, aid)
+
+
+def test_is_possible_duplicate_matcher() -> None:
+    from src.shared.supabase_ops.athletes_repository import is_possible_duplicate
+
+    # first-name subset + same birth year → the Gabe/Gabe Drake case
+    assert is_possible_duplicate("Gabe Drake", 2012, "Gabe", 2012)
+    assert is_possible_duplicate("Gabe", 2012, "Gabe Drake", 2012)
+    # same name tokens, different year → not a dup
+    assert not is_possible_duplicate("Gabe", 2012, "Gabe", 2010)
+    # unrelated names → not a dup
+    assert not is_possible_duplicate("Gabe Drake", 2012, "Maya Lin", 2012)
+    # year unknown on one side → require identical token sets
+    assert is_possible_duplicate("Gabe Drake", None, "gabe  drake", 2012)
+    assert not is_possible_duplicate("Gabe", None, "Gabe Drake", 2012)
 
 
 def test_assign_coach_grants_role_and_links() -> None:

--- a/frontend/src/composables/__tests__/useCoach.test.ts
+++ b/frontend/src/composables/__tests__/useCoach.test.ts
@@ -126,7 +126,7 @@ describe('useCoach roster', () => {
     const { useCoach } = await freshModule()
     const { athletes, createAthlete } = useCoach()
     const result = await createAthlete({ display_name: 'New' })
-    expect(result).toEqual(created)
+    expect(result).toEqual({ status: 'created', athlete: created })
     expect(athletes.value).toContainEqual(created)
     const [path, opts] = apiCallMock.mock.calls[0]
     expect(path).toBe('/athletes')
@@ -134,14 +134,39 @@ describe('useCoach roster', () => {
     expect(JSON.parse(opts.body)).toEqual({ display_name: 'New' })
   })
 
-  it('createAthlete surfaces an error and returns null on failure', async () => {
+  it('createAthlete surfaces an error on failure', async () => {
     apiCallMock.mockRejectedValue(new Error('nope'))
     const { useCoach } = await freshModule()
     const { athletes, error, createAthlete } = useCoach()
     const result = await createAthlete({ display_name: 'X' })
-    expect(result).toBeNull()
+    expect(result).toEqual({ status: 'error', message: 'nope' })
     expect(error.value).toBe('nope')
     expect(athletes.value).toHaveLength(0)
+  })
+
+  it('createAthlete returns duplicate candidates on a 409 (SB-349)', async () => {
+    const err = Object.assign(new Error('dup'), {
+      status: 409,
+      body: { detail: { candidates: [{ id: 'a1', display_name: 'Gabe', birth_year: 2012 }] } },
+    })
+    apiCallMock.mockRejectedValue(err)
+    const { useCoach } = await freshModule()
+    const { athletes, createAthlete } = useCoach()
+    const result = await createAthlete({ display_name: 'Gabe Drake', birth_year: 2012 })
+    expect(result).toEqual({
+      status: 'duplicate',
+      candidates: [{ id: 'a1', display_name: 'Gabe', birth_year: 2012 }],
+    })
+    expect(athletes.value).toHaveLength(0) // not added
+  })
+
+  it('createAthlete(force) posts to the force endpoint', async () => {
+    const created = { id: 'a9', display_name: 'Gabe Drake', birth_year: 2012, linked_user_id: null, created_by: 'c1', notes: null, created_at: 'x' }
+    apiCallMock.mockResolvedValue(created)
+    const { useCoach } = await freshModule()
+    const { createAthlete } = useCoach()
+    await createAthlete({ display_name: 'Gabe Drake', birth_year: 2012 }, true)
+    expect(apiCallMock.mock.calls[0][0]).toBe('/athletes?force=true')
   })
 })
 

--- a/frontend/src/composables/useCoach.ts
+++ b/frontend/src/composables/useCoach.ts
@@ -107,6 +107,18 @@ export async function removeCoach(athleteId: string, coachId: string): Promise<v
   await apiCall(`/athletes/${athleteId}/coaches/${coachId}`, { method: 'DELETE' })
 }
 
+/** A possible-duplicate athlete surfaced by the create guard (SB-349). */
+export interface DuplicateAthlete {
+  id: string
+  display_name: string
+  birth_year: number | null
+}
+
+export type CreateAthleteResult =
+  | { status: 'created'; athlete: Athlete }
+  | { status: 'duplicate'; candidates: DuplicateAthlete[] }
+  | { status: 'error'; message: string }
+
 export function useCoach() {
   const athletes = ref<Athlete[]>([])
   const loading = ref(false)
@@ -124,18 +136,29 @@ export function useCoach() {
     }
   }
 
-  const createAthlete = async (body: AthleteCreate): Promise<Athlete | null> => {
+  const createAthlete = async (
+    body: AthleteCreate,
+    force = false,
+  ): Promise<CreateAthleteResult> => {
     error.value = null
     try {
-      const created = await apiCall<Athlete>('/athletes', {
+      const created = await apiCall<Athlete>(force ? '/athletes?force=true' : '/athletes', {
         method: 'POST',
         body: JSON.stringify(body),
       })
       athletes.value = [...athletes.value, created]
-      return created
+      return { status: 'created', athlete: created }
     } catch (e) {
+      const err = e as Error & {
+        status?: number
+        body?: { detail?: { candidates?: DuplicateAthlete[] } }
+      }
+      // Possible-duplicate guard (SB-349): let the caller offer "create anyway".
+      if (err.status === 409 && err.body?.detail?.candidates) {
+        return { status: 'duplicate', candidates: err.body.detail.candidates }
+      }
       error.value = e instanceof Error ? e.message : 'Failed to create athlete'
-      return null
+      return { status: 'error', message: error.value }
     }
   }
 

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -26,8 +26,19 @@ export const apiCall = async <T>(
   })
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({ message: 'Request failed' }))
-    throw new Error(error.detail || error.message || `HTTP ${response.status}`)
+    const body = await response.json().catch(() => ({ message: 'Request failed' }))
+    // `detail` may be a string (most 4xx) or a structured object (e.g. the
+    // dup-athlete 409, SB-349). Keep the human message on .message, and attach
+    // status + parsed body so callers can act on structured errors.
+    const detail = body?.detail
+    const message =
+      (detail && typeof detail === 'object' ? detail.message : detail) ||
+      body?.message ||
+      `HTTP ${response.status}`
+    const err = new Error(message) as Error & { status?: number; body?: unknown }
+    err.status = response.status
+    err.body = body
+    throw err
   }
 
   if (response.status === 204 || response.headers.get('content-length') === '0') {

--- a/frontend/src/views/CoachView.vue
+++ b/frontend/src/views/CoachView.vue
@@ -42,6 +42,31 @@
         placeholder="Notes (optional)"
         class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm"
       />
+
+      <div
+        v-if="duplicates.length"
+        class="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800"
+      >
+        <p class="font-semibold">A similar athlete already exists:</p>
+        <ul class="mt-1 list-disc pl-5">
+          <li v-for="d in duplicates" :key="d.id">
+            {{ d.display_name }}<span v-if="d.birth_year"> ({{ d.birth_year }})</span>
+          </li>
+        </ul>
+        <p class="mt-2">
+          If it's the same person, ask an admin to add you as their coach. If it's a different
+          person, create anyway.
+        </p>
+        <button
+          type="button"
+          :disabled="saving"
+          class="btn-secondary text-xs mt-2"
+          @click="createAnyway"
+        >
+          {{ saving ? 'Creating…' : 'Create anyway' }}
+        </button>
+      </div>
+
       <button type="submit" :disabled="saving" class="btn-primary text-sm">
         {{ saving ? 'Saving…' : 'Create athlete' }}
       </button>
@@ -117,7 +142,7 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref } from 'vue'
 import { RouterLink } from 'vue-router'
-import { useCoach } from '@/composables/useCoach'
+import { useCoach, type DuplicateAthlete } from '@/composables/useCoach'
 import { useCoachHome } from '@/composables/useCoachHome'
 import type { AthleteCreate } from '@/types/coach'
 
@@ -129,6 +154,7 @@ const cards = computed(() => home.value?.athletes ?? [])
 const showForm = ref(false)
 const saving = ref(false)
 const form = reactive<AthleteCreate>({ display_name: '', birth_year: null, notes: null })
+const duplicates = ref<DuplicateAthlete[]>([])
 
 const formatDay = (iso: string): string => {
   const d = new Date(`${iso}T00:00:00`)
@@ -140,22 +166,34 @@ const formatDay = (iso: string): string => {
   return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
 }
 
-const submit = async () => {
+const doCreate = async (force: boolean) => {
   saving.value = true
-  const created = await createAthlete({
-    display_name: form.display_name,
-    birth_year: form.birth_year || null,
-    notes: form.notes || null,
-  })
+  const res = await createAthlete(
+    {
+      display_name: form.display_name,
+      birth_year: form.birth_year || null,
+      notes: form.notes || null,
+    },
+    force,
+  )
   saving.value = false
-  if (created) {
+  if (res.status === 'duplicate') {
+    duplicates.value = res.candidates
+    return
+  }
+  if (res.status === 'created') {
     form.display_name = ''
     form.birth_year = null
     form.notes = null
+    duplicates.value = []
     showForm.value = false
     await load()
   }
+  // 'error' → error surfaced by the composable; keep the form open.
 }
+
+const submit = () => doCreate(false)
+const createAnyway = () => doCreate(true)
 
 onMounted(load)
 </script>

--- a/src/shared/supabase_ops/athletes_repository.py
+++ b/src/shared/supabase_ops/athletes_repository.py
@@ -7,11 +7,37 @@ can_access_athlete; these repos are the plain data layer.
 
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime
 from typing import Any, cast
 from uuid import UUID
 
 from supabase import Client
+
+
+def _name_tokens(name: str) -> set[str]:
+    return set(re.sub(r"[^a-z0-9]+", " ", name.lower()).split())
+
+
+def is_possible_duplicate(
+    new_name: str,
+    new_birth_year: int | None,
+    existing_name: str,
+    existing_birth_year: int | None,
+) -> bool:
+    """Heuristic athlete-duplicate match (SB-349): one name's tokens are a subset
+    of the other's AND — when both birth years are known — they match; if either
+    year is unknown, require identical token sets. Catches 'Gabe' vs 'Gabe Drake'
+    born the same year, without flagging unrelated same-first-name people of
+    different ages."""
+    nt, et = _name_tokens(new_name), _name_tokens(existing_name)
+    if not nt or not et:
+        return False
+    if not (nt <= et or et <= nt):
+        return False
+    if new_birth_year is not None and existing_birth_year is not None:
+        return new_birth_year == existing_birth_year
+    return nt == et
 
 
 class UserRolesRepository:
@@ -60,6 +86,23 @@ class AthletesRepository:
         result = self.supabase.table("athletes").select("*").eq("id", str(athlete_id)).execute()
         data = cast(list[dict[str, Any]], result.data)
         return data[0] if data else None
+
+    def find_possible_duplicates(
+        self, display_name: str, birth_year: int | None
+    ) -> list[dict[str, Any]]:
+        """Existing athletes that look like the same person (SB-349). Scans the
+        athletes table (small) and filters with is_possible_duplicate."""
+        rows = cast(
+            list[dict[str, Any]],
+            self.supabase.table("athletes").select("id,display_name,birth_year").execute().data,
+        )
+        return [
+            r
+            for r in rows
+            if is_possible_duplicate(
+                display_name, birth_year, r["display_name"], r.get("birth_year")
+            )
+        ]
 
     def get_by_linked_user(self, user_id: UUID) -> dict[str, Any] | None:
         """The athlete this user IS (via linked_user_id), or None."""


### PR DESCRIPTION
Fixes SB-349 (part B). Part A (prod data reconciliation) was completed earlier — see the ticket comment.

## Problem
Coach onboarding let a coach create a brand-new athlete that duplicates an existing person — how Matthew ended up with a second, empty "Gabe Drake" (2012) alongside tom.drake's "Gabe" (2012).

## Backend
- `is_possible_duplicate` / `AthletesRepository.find_possible_duplicates` — match on **name-token subset + same birth year**. Catches "Gabe" vs "Gabe Drake" (same year) without flagging same-first-name people of different ages.
- `POST /athletes` returns **409** with candidate(s) when a match exists; **`?force=true`** creates anyway. No create/assign happens on the 409.

## Frontend
- `apiCall` now attaches `status` + parsed `body` to thrown errors (backward-compatible — `.message` unchanged), so callers can act on structured 4xx.
- `createAthlete` returns a typed result (`created` | `duplicate` | `error`) and takes a `force` flag; **CoachView** shows the candidate(s) with a "Create anyway" action and guidance ("ask an admin to add you as their coach").

## Tests
- Matcher: subset+year, different year, unrelated names, unknown-year cases.
- Route: 409 blocks create/assign; `force` bypasses.
- Composable: duplicate result surfaces candidates; `force` hits `?force=true`.

Backend 264/264, frontend 254/254 — all green.

## Follow-up
SB-354 (athlete self-logging) filed separately — print/record/note/how-felt from `/my/workouts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)