### PR TITLE
fix(auth): password reset via recovery session + redirect allowlist (SB-171)

### DIFF
--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -149,6 +149,25 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
+  // Set a new password using the CURRENT session. On a recovery link Supabase
+  // (detectSessionInUrl) establishes a short-lived recovery session and fires
+  // PASSWORD_RECOVERY; updateUser then applies the change — no need to read the
+  // access_token from the URL hash (which Supabase strips on load). SB-171.
+  const updatePassword = async (newPassword: string) => {
+    loading.value = true
+    clearError()
+    try {
+      const { error: err } = await supabase.auth.updateUser({ password: newPassword })
+      if (err) throw err
+      return { success: true }
+    } catch (err: any) {
+      setError(err.message)
+      return { success: false, error: err.message }
+    } finally {
+      loading.value = false
+    }
+  }
+
   return {
     session,
     user,
@@ -162,6 +181,7 @@ export const useAuthStore = defineStore('auth', () => {
     signOut,
     requestPasswordReset,
     applyPasswordReset,
+    updatePassword,
     clearError,
   }
 })

--- a/frontend/src/views/ResetPasswordView.vue
+++ b/frontend/src/views/ResetPasswordView.vue
@@ -4,25 +4,38 @@
       <h1 class="text-2xl font-bold text-gray-900 mb-1">Reset your password</h1>
       <p class="text-gray-500 text-sm mb-6">Enter a new password below.</p>
 
-      <!-- No recovery token in URL → bad/expired link -->
+      <!-- Verifying the recovery link -->
+      <div v-if="status === 'checking'" class="text-sm text-gray-400 py-6 text-center">
+        Verifying your reset link…
+      </div>
+
+      <!-- Expired / already-used link (incl. Gmail link prefetch consuming the OTP) -->
       <div
-        v-if="!accessToken"
+        v-else-if="status === 'expired'"
         class="bg-amber-50 border border-amber-200 text-amber-700 text-sm rounded-lg px-3 py-2"
       >
-        This reset link is missing a recovery token. Request a new password reset email
-        from the
+        This reset link has expired or was already used. Request a new one from the
         <RouterLink to="/login" class="underline font-medium">login page</RouterLink>.
       </div>
 
-      <!-- Success state -->
+      <!-- No recovery session at all → bad link / opened directly -->
       <div
-        v-else-if="success"
+        v-else-if="status === 'invalid'"
+        class="bg-amber-50 border border-amber-200 text-amber-700 text-sm rounded-lg px-3 py-2"
+      >
+        This page needs a valid password-reset link. Request one from the
+        <RouterLink to="/login" class="underline font-medium">login page</RouterLink>.
+      </div>
+
+      <!-- Success -->
+      <div
+        v-else-if="status === 'success'"
         class="bg-green-50 border border-green-200 text-green-700 text-sm rounded-lg px-3 py-2"
       >
         Password updated. Redirecting to login…
       </div>
 
-      <!-- Form -->
+      <!-- Form (recovery session present) -->
       <form v-else @submit.prevent="handleSubmit" class="space-y-4">
         <div>
           <label for="new-password" class="form-label">New password</label>
@@ -56,11 +69,7 @@
           {{ formError }}
         </div>
 
-        <button
-          type="submit"
-          class="btn-primary w-full py-2.5"
-          :disabled="auth.loading"
-        >
+        <button type="submit" class="btn-primary w-full py-2.5" :disabled="auth.loading">
           {{ auth.loading ? 'Updating…' : 'Update password' }}
         </button>
       </form>
@@ -72,46 +81,44 @@
 import { computed, onMounted, ref } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
+import { supabase } from '@/config/supabase'
 
 const auth = useAuthStore()
 const router = useRouter()
 
 const newPassword = ref('')
 const confirmPassword = ref('')
-const success = ref(false)
 const localError = ref<string | null>(null)
+type Status = 'checking' | 'ready' | 'expired' | 'invalid' | 'success'
+const status = ref<Status>('checking')
 
-// Supabase puts the recovery token in the URL fragment (after #), e.g.
-//   /auth/reset-password#access_token=...&type=recovery&...
-// onMounted reads it once; we don't watch — the user only resets once per
-// page load.
-const accessToken = ref<string | null>(null)
-
-onMounted(() => {
-  const hash = window.location.hash.startsWith('#')
-    ? window.location.hash.slice(1)
-    : window.location.hash
+// Supabase (detectSessionInUrl) processes the recovery link on load: it either
+// establishes a short-lived RECOVERY SESSION (→ we can updateUser), or leaves an
+// error in the hash (expired/consumed link — e.g. Gmail prefetch used the OTP).
+// We read the SESSION, not the access_token from the hash (Supabase strips it).
+onMounted(async () => {
+  const hash = window.location.hash.replace(/^#/, '')
   const params = new URLSearchParams(hash)
-  accessToken.value = params.get('access_token')
+  if (params.get('error') || params.get('error_code')) {
+    status.value = 'expired'
+    return
+  }
+  const { data } = await supabase.auth.getSession()
+  status.value = data.session ? 'ready' : 'invalid'
 })
 
 const formError = computed(() => localError.value ?? auth.error)
 
 const handleSubmit = async () => {
   localError.value = null
-
   if (newPassword.value !== confirmPassword.value) {
     localError.value = 'Passwords do not match.'
     return
   }
-  if (!accessToken.value) {
-    localError.value = 'Missing recovery token.'
-    return
-  }
-
-  const result = await auth.applyPasswordReset(accessToken.value, newPassword.value)
+  const result = await auth.updatePassword(newPassword.value)
   if (result.success) {
-    success.value = true
+    status.value = 'success'
+    await auth.signOut()
     setTimeout(() => router.push('/login'), 1500)
   }
 }

--- a/frontend/src/views/__tests__/ResetPasswordView.test.ts
+++ b/frontend/src/views/__tests__/ResetPasswordView.test.ts
@@ -2,8 +2,23 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { createRouter, createMemoryHistory } from 'vue-router'
+
+// Mock the Supabase client the view + store use.
+const getSessionMock = vi.fn()
+const updateUserMock = vi.fn()
+const signOutMock = vi.fn().mockResolvedValue({})
+vi.mock('@/config/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: (...a: unknown[]) => getSessionMock(...a),
+      updateUser: (...a: unknown[]) => updateUserMock(...a),
+      signOut: (...a: unknown[]) => signOutMock(...a),
+      onAuthStateChange: vi.fn(),
+    },
+  },
+}))
+
 import ResetPasswordView from '../ResetPasswordView.vue'
-import { useAuthStore } from '@/stores/auth'
 
 const buildRouter = () =>
   createRouter({
@@ -11,15 +26,11 @@ const buildRouter = () =>
     routes: [
       { path: '/', component: { template: '<div>home</div>' } },
       { path: '/login', component: { template: '<div>login</div>' } },
-      {
-        path: '/auth/reset-password',
-        component: ResetPasswordView,
-      },
+      { path: '/auth/reset-password', component: ResetPasswordView },
     ],
   })
 
 const mountWithHash = async (hash: string) => {
-  // jsdom respects window.location.hash if we set it before mount
   Object.defineProperty(window, 'location', {
     value: { hash, origin: 'http://localhost:5174' },
     writable: true,
@@ -27,74 +38,75 @@ const mountWithHash = async (hash: string) => {
   const router = buildRouter()
   await router.push(`/auth/reset-password${hash}`)
   await router.isReady()
-
-  const w = mount(ResetPasswordView, {
-    global: { plugins: [createPinia(), router] },
-  })
+  const w = mount(ResetPasswordView, { global: { plugins: [createPinia(), router] } })
   await flushPromises()
-  return { w, router }
+  return { w }
 }
+
+const withSession = () => getSessionMock.mockResolvedValue({ data: { session: { access_token: 't' } } })
+const noSession = () => getSessionMock.mockResolvedValue({ data: { session: null } })
 
 beforeEach(() => {
   setActivePinia(createPinia())
+  getSessionMock.mockReset()
+  updateUserMock.mockReset()
+  signOutMock.mockClear()
 })
 
-describe('ResetPasswordView', () => {
-  it('shows missing-token state when URL hash has no access_token', async () => {
-    const { w } = await mountWithHash('')
-    expect(w.text()).toContain('missing a recovery token')
+describe('ResetPasswordView (recovery session, SB-171)', () => {
+  it('shows expired state when the hash carries an error', async () => {
+    noSession()
+    const { w } = await mountWithHash('#error=access_denied&error_code=otp_expired')
+    expect(w.text()).toContain('expired or was already used')
     expect(w.find('form').exists()).toBe(false)
   })
 
-  it('renders the new-password form when access_token is present', async () => {
+  it('shows invalid state when there is no recovery session', async () => {
+    noSession()
+    const { w } = await mountWithHash('')
+    expect(w.text()).toContain('needs a valid password-reset link')
+    expect(w.find('form').exists()).toBe(false)
+  })
+
+  it('renders the form when a recovery session exists', async () => {
+    withSession()
     const { w } = await mountWithHash('#access_token=tok&type=recovery')
     expect(w.find('form').exists()).toBe(true)
     expect(w.find('#new-password').exists()).toBe(true)
-    expect(w.find('#confirm-password').exists()).toBe(true)
   })
 
   it('blocks submit when passwords do not match', async () => {
+    withSession()
     const { w } = await mountWithHash('#access_token=tok&type=recovery')
-
     await w.find('#new-password').setValue('hunter22hunter22')
     await w.find('#confirm-password').setValue('different11different')
     await w.find('form').trigger('submit.prevent')
     await flushPromises()
-
     expect(w.text()).toContain('Passwords do not match')
+    expect(updateUserMock).not.toHaveBeenCalled()
   })
 
-  it('calls applyPasswordReset with the token + new password on submit', async () => {
-    const { w } = await mountWithHash('#access_token=recovery-tok&type=recovery')
-
-    const auth = useAuthStore()
-    const spy = vi
-      .spyOn(auth, 'applyPasswordReset')
-      .mockResolvedValue({ success: true })
-
+  it('updates the password via the recovery session, then signs out', async () => {
+    withSession()
+    updateUserMock.mockResolvedValue({ error: null })
+    const { w } = await mountWithHash('#access_token=tok&type=recovery')
     await w.find('#new-password').setValue('hunter22hunter22')
     await w.find('#confirm-password').setValue('hunter22hunter22')
     await w.find('form').trigger('submit.prevent')
     await flushPromises()
-
-    expect(spy).toHaveBeenCalledWith('recovery-tok', 'hunter22hunter22')
+    expect(updateUserMock).toHaveBeenCalledWith({ password: 'hunter22hunter22' })
+    expect(signOutMock).toHaveBeenCalled()
     expect(w.text()).toContain('Password updated')
   })
 
-  it('shows the auth-store error when the apply call fails', async () => {
-    const { w } = await mountWithHash('#access_token=recovery-tok')
-
-    const auth = useAuthStore()
-    vi.spyOn(auth, 'applyPasswordReset').mockImplementation(async () => {
-      auth.error = 'Token expired'
-      return { success: false, error: 'Token expired' }
-    })
-
+  it('surfaces the error when the update fails', async () => {
+    withSession()
+    updateUserMock.mockResolvedValue({ error: { message: 'Token expired' } })
+    const { w } = await mountWithHash('#access_token=tok&type=recovery')
     await w.find('#new-password').setValue('hunter22hunter22')
     await w.find('#confirm-password').setValue('hunter22hunter22')
     await w.find('form').trigger('submit.prevent')
     await flushPromises()
-
     expect(w.text()).toContain('Token expired')
   })
 })

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -122,7 +122,15 @@ enabled = true
 # in emails.
 site_url = "http://127.0.0.1:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+# Wildcards so recovery/OAuth redirects (e.g. /auth/reset-password, /auth/callback)
+# are allowed — a bare origin here makes Supabase drop redirect_to and fall back to
+# site_url, which is why password-recovery links landed on /dashboard (SB-171).
+# NOTE: prod's allowlist lives in the Supabase dashboard (Auth → URL Configuration) —
+# add https://myrunstreak.run/** there too.
+additional_redirect_urls = [
+  "http://127.0.0.1:3000/**",
+  "https://127.0.0.1:3000/**",
+]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # Path to JWT signing key. DO NOT commit your signing keys file to git.


### PR DESCRIPTION
Fixes SB-171.

Recovery links landed on `/dashboard` with no way to set a new password. Two root causes, both fixed:

## A — redirect allowlist (config)
`config.toml` only allowed the bare origin, so Supabase dropped `redirect_to` and fell back to `site_url` (→ `/dashboard`). Now uses wildcard redirect URLs so `/auth/reset-password` is honored.
⚠️ **Prod**: add `https://myrunstreak.run/**` in the Supabase dashboard (Auth → URL Configuration) — noted inline in config.toml.

## B — reset page uses the recovery session (code)
The page read `access_token` from the URL hash, but `detectSessionInUrl: true` **strips the hash** on load → always "missing token". Rewritten to use the **recovery session** Supabase establishes from the link:
- `getSession()` gates the form (`checking` → `ready` / `invalid`)
- `auth.updatePassword()` → `supabase.auth.updateUser({ password })` (no token juggling)
- Expired/consumed links (`otp_expired`, incl. Gmail link-prefetch) show a clear "request a new one" instead of a dead form

## Tests
`ResetPasswordView.test.ts` rewritten for the session flow: expired / invalid / ready / password-mismatch / success+signout / update-error. **Full FE suite green (255).**

## Follow-ups (not blockers)
- Prod dashboard redirect entry (above).
- Reliable *delivery* depends on **SB-365** (Resend on `silverbeer.io`).
- Deeper `otp_expired`/PKCE hardening (deferred C) if prefetch keeps biting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)