### PR TITLE
test(backend): cover /plan/* and /stats/splits route handlers (SB-176)

### DIFF
--- a/backend/tests/test_plan_routes.py
+++ b/backend/tests/test_plan_routes.py
@@ -1,0 +1,330 @@
+"""Route-handler tests for /plan/* via FastAPI TestClient.
+
+Auth is bypassed with ``app.dependency_overrides[authenticate_request]`` (a
+fixed user_id) and every repository / planner call in ``backend.routes.plan``
+is patched, so nothing touches Supabase. CACHE_ENABLED=false (conftest) makes
+``invalidate_user`` a no-op.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import date
+from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+USER_ID = UUID("00000000-0000-0000-0000-0000000000aa")
+
+_METRIC_TYPE = {
+    "key": "distance_km",
+    "display_name": "Distance",
+    "unit": "km",
+    "aggregation": "sum",
+}
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    from backend.app import create_app
+    from backend.auth import authenticate_request
+
+    app = create_app()
+    app.dependency_overrides[authenticate_request] = lambda: USER_ID
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _plan_result(period_start: date, period_end: date) -> dict[str, object]:
+    """A minimal PlanResult-shaped dict the response_model accepts."""
+    return {
+        "period_start": period_start.isoformat(),
+        "period_end": period_end.isoformat(),
+        "generated_for": period_start.isoformat(),
+        "days": [
+            {
+                "metric_key": "distance_km",
+                "plan_on": period_start.isoformat(),
+                "prescribed_value": 5.0,
+                "kind": "easy",
+            }
+        ],
+        "goals": [
+            {
+                "metric_key": "distance_km",
+                "kind": "volume",
+                "target": 100.0,
+                "done": 20.0,
+                "remaining": 80.0,
+                "projected": 105.0,
+                "status": "on_track",
+                "detail": None,
+            }
+        ],
+        "status": "on_track",
+        "at_risk_reasons": [],
+    }
+
+
+# ---------------------------------------------------------------- constraints
+
+
+def test_create_constraint_rejects_unknown_metric(client: TestClient) -> None:
+    types = MagicMock()
+    types.get.return_value = None
+    constraints = MagicMock()
+
+    with (
+        patch("backend.routes.plan.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.plan.MetricTypesRepository", return_value=types),
+        patch("backend.routes.plan.PlanConstraintsRepository", return_value=constraints),
+    ):
+        r = client.post(
+            "/plan/constraints",
+            json={
+                "metric_key": "nope",
+                "start_on": "2026-07-01",
+                "end_on": "2026-07-05",
+                "cap": 1.6,
+            },
+        )
+
+    assert r.status_code == 400
+    assert "nope" in r.json()["detail"]
+    constraints.create.assert_not_called()
+
+
+def test_create_constraint_persists_and_returns_record(client: TestClient) -> None:
+    types = MagicMock()
+    types.get.return_value = _METRIC_TYPE
+    row_id = uuid4()
+    constraints = MagicMock()
+    constraints.create.side_effect = lambda user_id, payload: {"id": str(row_id), **payload}
+
+    with (
+        patch("backend.routes.plan.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.plan.MetricTypesRepository", return_value=types),
+        patch("backend.routes.plan.PlanConstraintsRepository", return_value=constraints),
+    ):
+        r = client.post(
+            "/plan/constraints",
+            json={
+                "metric_key": "distance_km",
+                "start_on": "2026-07-01",
+                "end_on": "2026-07-05",
+                "cap": 1.6,
+                "floor": 1.6,
+                "reason": "Chicago trip",
+            },
+        )
+
+    assert r.status_code == 201
+    body = r.json()
+    assert body["id"] == str(row_id)
+    assert body["metric_key"] == "distance_km"
+    assert body["cap"] == 1.6
+
+    # user_id from the auth dependency, payload without the None fields.
+    assert constraints.create.call_args.args[0] == USER_ID
+    payload = constraints.create.call_args.args[1]
+    assert payload["start_on"] == "2026-07-01"
+    assert payload["reason"] == "Chicago trip"
+
+
+def test_create_constraint_422_when_end_before_start(client: TestClient) -> None:
+    # Model validation rejects it before any repo is touched.
+    with patch("backend.routes.plan.get_supabase_client", return_value=MagicMock()) as supa:
+        r = client.post(
+            "/plan/constraints",
+            json={"metric_key": "distance_km", "start_on": "2026-07-05", "end_on": "2026-07-01"},
+        )
+
+    assert r.status_code == 422
+    supa.assert_not_called()
+
+
+def test_list_constraints_passes_date_filters(client: TestClient) -> None:
+    row = {
+        "id": str(uuid4()),
+        "metric_key": "distance_km",
+        "start_on": "2026-07-01",
+        "end_on": "2026-07-05",
+        "cap": 1.6,
+        "floor": None,
+        "reason": None,
+    }
+    constraints = MagicMock()
+    constraints.list.return_value = [row]
+
+    with (
+        patch("backend.routes.plan.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.plan.PlanConstraintsRepository", return_value=constraints),
+    ):
+        r = client.get(
+            "/plan/constraints", params={"date_from": "2026-07-01", "date_to": "2026-07-31"}
+        )
+
+    assert r.status_code == 200
+    assert [c["id"] for c in r.json()] == [row["id"]]
+    constraints.list.assert_called_once_with(
+        USER_ID, date_from=date(2026, 7, 1), date_to=date(2026, 7, 31)
+    )
+
+
+def test_list_constraints_without_filters_passes_none(client: TestClient) -> None:
+    constraints = MagicMock()
+    constraints.list.return_value = []
+
+    with (
+        patch("backend.routes.plan.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.plan.PlanConstraintsRepository", return_value=constraints),
+    ):
+        r = client.get("/plan/constraints")
+
+    assert r.status_code == 200
+    assert r.json() == []
+    constraints.list.assert_called_once_with(USER_ID, date_from=None, date_to=None)
+
+
+def test_delete_constraint_204_when_deleted(client: TestClient) -> None:
+    constraint_id = uuid4()
+    constraints = MagicMock()
+    constraints.delete.return_value = True
+
+    with (
+        patch("backend.routes.plan.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.plan.PlanConstraintsRepository", return_value=constraints),
+    ):
+        r = client.delete(f"/plan/constraints/{constraint_id}")
+
+    assert r.status_code == 204
+    constraints.delete.assert_called_once_with(USER_ID, constraint_id)
+
+
+def test_delete_constraint_404_when_missing(client: TestClient) -> None:
+    constraints = MagicMock()
+    constraints.delete.return_value = False
+
+    with (
+        patch("backend.routes.plan.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.plan.PlanConstraintsRepository", return_value=constraints),
+    ):
+        r = client.delete(f"/plan/constraints/{uuid4()}")
+
+    assert r.status_code == 404
+    assert r.json()["detail"] == "Constraint not found"
+
+
+# ---------------------------------------------------------------- readiness
+
+
+def test_set_readiness_upserts_and_returns_recomputed_plan(client: TestClient) -> None:
+    readiness = MagicMock()
+    result = _plan_result(date(2026, 7, 1), date(2026, 7, 31))
+
+    with (
+        patch("backend.routes.plan.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.plan.ReadinessRepository", return_value=readiness),
+        patch("backend.routes.plan.build_and_store_plan", return_value=result) as build,
+    ):
+        r = client.post(
+            "/plan/readiness",
+            json={"log_on": "2026-07-14", "status": "tired", "note": "long day"},
+        )
+
+    assert r.status_code == 200
+    assert r.json()["status"] == "on_track"
+
+    assert readiness.upsert.call_args.args[0] == USER_ID
+    payload = readiness.upsert.call_args.args[1]
+    assert payload == {"log_on": "2026-07-14", "status": "tired", "note": "long day"}
+
+    # The plan is recomputed for the period the readiness day falls in.
+    assert build.call_args.args[2] == "2026-07"
+
+
+def test_set_readiness_defaults_status_to_good(client: TestClient) -> None:
+    readiness = MagicMock()
+    result = _plan_result(date(2026, 7, 1), date(2026, 7, 31))
+
+    with (
+        patch("backend.routes.plan.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.plan.ReadinessRepository", return_value=readiness),
+        patch("backend.routes.plan.build_and_store_plan", return_value=result),
+    ):
+        r = client.post("/plan/readiness", json={"log_on": "2026-07-14"})
+
+    assert r.status_code == 200
+    assert readiness.upsert.call_args.args[1]["status"] == "good"
+
+
+# ---------------------------------------------------------------- the plan
+
+
+def test_get_plan_returns_recomputed_result(client: TestClient) -> None:
+    result = _plan_result(date(2026, 7, 1), date(2026, 7, 31))
+
+    with (
+        patch("backend.routes.plan.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.plan.build_plan", return_value=result) as build,
+    ):
+        r = client.get("/plan/2026-07")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["period_start"] == "2026-07-01"
+    assert body["days"][0]["metric_key"] == "distance_km"
+    assert build.call_args.args[1] == USER_ID
+    assert build.call_args.args[2] == "2026-07"
+
+
+def test_get_plan_400_on_bad_period(client: TestClient) -> None:
+    with (
+        patch("backend.routes.plan.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.plan.build_plan", side_effect=ValueError("period must be 'YYYY-MM'")),
+    ):
+        r = client.get("/plan/not-a-period")
+
+    assert r.status_code == 400
+    assert "YYYY-MM" in r.json()["detail"]
+
+
+def test_recompute_plan_persists_and_returns_result(client: TestClient) -> None:
+    result = _plan_result(date(2026, 7, 1), date(2026, 7, 31))
+
+    with (
+        patch("backend.routes.plan.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.plan.build_and_store_plan", return_value=result) as build,
+    ):
+        r = client.post("/plan/2026-07/recompute")
+
+    assert r.status_code == 200
+    assert r.json()["status"] == "on_track"
+    build.assert_called_once()
+    assert build.call_args.args[1] == USER_ID
+    assert build.call_args.args[2] == "2026-07"
+
+
+def test_recompute_plan_400_on_bad_period(client: TestClient) -> None:
+    with (
+        patch("backend.routes.plan.get_supabase_client", return_value=MagicMock()),
+        patch(
+            "backend.routes.plan.build_and_store_plan",
+            side_effect=ValueError("month out of range in period '2026-13'"),
+        ),
+    ):
+        r = client.post("/plan/2026-13/recompute")
+
+    assert r.status_code == 400
+    assert "out of range" in r.json()["detail"]
+
+
+def test_plan_routes_require_auth() -> None:
+    """Without the dependency override the real JWT dependency rejects the call."""
+    from backend.app import create_app
+
+    with TestClient(create_app()) as unauthed:
+        assert unauthed.get("/plan/2026-07").status_code == 401
+        assert unauthed.get("/plan/constraints").status_code == 401

--- a/backend/tests/test_stats_splits_route.py
+++ b/backend/tests/test_stats_splits_route.py
@@ -1,0 +1,180 @@
+"""Route-handler tests for GET /stats/splits via FastAPI TestClient.
+
+Auth is bypassed with ``app.dependency_overrides[authenticate_request]`` and
+``RunsRepository`` is mocked, so the real split-analysis math runs over
+fixture rows without touching Supabase.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import date
+from typing import Any
+from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+USER_ID = UUID("00000000-0000-0000-0000-0000000000bb")
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    from backend.app import create_app
+    from backend.auth import authenticate_request
+
+    app = create_app()
+    app.dependency_overrides[authenticate_request] = lambda: USER_ID
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _splits(*pieces: tuple[float, float]) -> list[dict[str, Any]]:
+    """Build cumulative split rows from per-mile (distance_km, seconds) pieces."""
+    rows: list[dict[str, Any]] = []
+    cum_km = 0.0
+    cum_s = 0.0
+    for i, (km, secs) in enumerate(pieces, start=1):
+        cum_km += km
+        cum_s += secs
+        rows.append(
+            {
+                "split_number": i,
+                "cumulative_distance_km": cum_km,
+                "cumulative_seconds": cum_s,
+                "heart_rate": None,
+            }
+        )
+    return rows
+
+
+MILE_KM = 1.60934
+
+
+def test_splits_empty_when_no_runs_have_splits(client: TestClient) -> None:
+    repo = MagicMock()
+    repo.get_runs_with_splits.return_value = []
+
+    with (
+        patch("backend.routes.stats.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.stats.RunsRepository", return_value=repo),
+    ):
+        r = client.get("/stats/splits")
+
+    assert r.status_code == 200
+    assert r.json() == {"summary": {"runs_analyzed": 0}, "runs": []}
+    repo.get_splits_for_run.assert_not_called()
+
+
+def test_splits_populated_summarizes_and_breaks_down_per_run(client: TestClient) -> None:
+    neg_id, fade_id = str(uuid4()), str(uuid4())
+    repo = MagicMock()
+    repo.get_runs_with_splits.return_value = [
+        {"id": neg_id, "start_date": "2026-07-10", "distance_km": 2 * MILE_KM},
+        {"id": fade_id, "start_date": "2026-07-11", "distance_km": 2 * MILE_KM},
+    ]
+    by_run = {
+        # 10:00 then 9:00 → negative split.
+        UUID(neg_id): _splits((MILE_KM, 600.0), (MILE_KM, 540.0)),
+        # 9:00 then 10:00 → fade.
+        UUID(fade_id): _splits((MILE_KM, 540.0), (MILE_KM, 600.0)),
+    }
+    repo.get_splits_for_run.side_effect = lambda run_id: by_run[run_id]
+
+    with (
+        patch("backend.routes.stats.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.stats.RunsRepository", return_value=repo),
+    ):
+        r = client.get("/stats/splits")
+
+    assert r.status_code == 200
+    body = r.json()
+
+    assert body["summary"]["runs_analyzed"] == 2
+    assert body["summary"]["negative_split_rate_pct"] == 50.0
+
+    assert [run["run_id"] for run in body["runs"]] == [neg_id, fade_id]
+    negative, fading = body["runs"]
+    assert negative["negative_split"] is True
+    assert negative["fade_pct"] < 0
+    assert negative["date"] == "2026-07-10"
+    assert negative["distance_km"] == pytest.approx(2 * MILE_KM)
+    assert fading["negative_split"] is False
+    assert fading["fade_pct"] > 0
+
+    # The per-run breakdown drops the raw split list (summary payload only).
+    assert "splits" not in negative
+
+
+def test_splits_skips_runs_with_fewer_than_two_usable_splits(client: TestClient) -> None:
+    single_id, pair_id = str(uuid4()), str(uuid4())
+    repo = MagicMock()
+    repo.get_runs_with_splits.return_value = [
+        {"id": single_id, "start_date": "2026-07-10", "distance_km": MILE_KM},
+        {"id": pair_id, "start_date": "2026-07-11", "distance_km": 2 * MILE_KM},
+    ]
+    by_run = {
+        UUID(single_id): _splits((MILE_KM, 600.0)),
+        UUID(pair_id): _splits((MILE_KM, 600.0), (MILE_KM, 540.0)),
+    }
+    repo.get_splits_for_run.side_effect = lambda run_id: by_run[run_id]
+
+    with (
+        patch("backend.routes.stats.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.stats.RunsRepository", return_value=repo),
+    ):
+        r = client.get("/stats/splits")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert [run["run_id"] for run in body["runs"]] == [pair_id]
+    assert body["summary"]["runs_analyzed"] == 1
+
+
+def test_splits_passes_query_filters_through(client: TestClient) -> None:
+    repo = MagicMock()
+    repo.get_runs_with_splits.return_value = []
+
+    with (
+        patch("backend.routes.stats.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.stats.RunsRepository", return_value=repo),
+    ):
+        r = client.get(
+            "/stats/splits",
+            params={"since": "2026-06-01", "until": "2026-06-30", "limit": 5},
+        )
+
+    assert r.status_code == 200
+    repo.get_runs_with_splits.assert_called_once_with(
+        USER_ID, since=date(2026, 6, 1), until=date(2026, 6, 30), limit=5
+    )
+
+
+def test_splits_defaults_limit_to_30(client: TestClient) -> None:
+    repo = MagicMock()
+    repo.get_runs_with_splits.return_value = []
+
+    with (
+        patch("backend.routes.stats.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.stats.RunsRepository", return_value=repo),
+    ):
+        client.get("/stats/splits")
+
+    assert repo.get_runs_with_splits.call_args.kwargs["limit"] == 30
+
+
+@pytest.mark.parametrize("limit", [0, 201])
+def test_splits_rejects_out_of_range_limit(client: TestClient, limit: int) -> None:
+    with patch("backend.routes.stats.get_supabase_client", return_value=MagicMock()) as supa:
+        r = client.get("/stats/splits", params={"limit": limit})
+
+    assert r.status_code == 422
+    supa.assert_not_called()
+
+
+def test_splits_requires_auth() -> None:
+    from backend.app import create_app
+
+    with TestClient(create_app()) as unauthed:
+        assert unauthed.get("/stats/splits").status_code == 401


### PR DESCRIPTION
## What

FastAPI `TestClient` tests for the `/plan/*` and `/stats/splits` route handlers. Auth is bypassed via `app.dependency_overrides[authenticate_request]`; repositories and the planner are patched, so no Supabase is touched.

**`backend/tests/test_plan_routes.py`** (14 tests)
- `POST /plan/constraints` — 400 on unknown metric_key, 201 happy path (asserts user_id + payload reaching the repo), 422 on `end_on < start_on` before any I/O
- `GET /plan/constraints` — date filters passed through, and the no-filter `None` case
- `DELETE /plan/constraints/{id}` — 204 and 404
- `POST /plan/readiness` — upsert payload asserted, plan recomputed for the period the log day falls in, status defaults to `good`
- `GET /plan/{period}` and `POST /plan/{period}/recompute` — happy path plus 400 on a bad period
- 401 without the dependency override

**`backend/tests/test_stats_splits_route.py`** (8 tests)
- empty result when no runs have splits (no per-run fetch)
- populated: real `analyze_run`/`summarize` math over fixture cumulative rows — negative-split vs fade run, summary rate, per-run breakdown drops the raw `splits` list
- runs with <2 usable splits skipped
- `since`/`until`/`limit` passed through, `limit` defaults to 30, 422 outside `1..200`
- 401 without the dependency override

## Coverage (DoD)

| module | cover |
|---|---|
| `backend/routes/plan.py` | **100%** |
| `/stats/splits` handler (`stats.py:264-296`) | fully covered |

## Verify

```
uv run --project backend python -m pytest backend/tests/ -q
# 286 passed
```

Fixes SB-176

🤖 Generated with [Claude Code](https://claude.com/claude-code)