### PR TITLE
feat: add runner role and is_test_account flag (SB-367)

### DIFF
--- a/backend/routes/athletes.py
+++ b/backend/routes/athletes.py
@@ -75,8 +75,18 @@ class AssignCoachRequest(BaseModel):
 
 @me_router.get("/roles")
 def my_roles(user_id: UUID = Depends(authenticate_request)) -> dict[str, Any]:
-    """The caller's platform roles."""
-    roles = UserRolesRepository(get_supabase_client()).list_roles(user_id)
+    """The caller's platform roles.
+
+    Granted roles (admin/coach/runner) come from ``user_roles``. "athlete" is
+    *derived* from an ``athletes`` row linking back to this user rather than
+    stored as a role — that keeps one source of truth, and a managed athlete
+    has no user row to hold a role anyway. Having a coach is irrelevant: an
+    athlete without one is still an athlete.
+    """
+    supabase = get_supabase_client()
+    roles = set(UserRolesRepository(supabase).list_roles(user_id))
+    if AthletesRepository(supabase).get_by_linked_user(user_id) is not None:
+        roles.add("athlete")
     return {"roles": sorted(roles), "is_admin": "admin" in roles}
 
 

--- a/backend/tests/test_me_roles.py
+++ b/backend/tests/test_me_roles.py
@@ -1,0 +1,115 @@
+"""SB-367: GET /me/roles — granted roles plus the derived "athlete" entry.
+
+admin/coach/runner are rows in ``user_roles``; "athlete" is derived from an
+``athletes`` row pointing back at the caller, so the two are asserted
+separately here.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+
+@contextmanager
+def _roles_env(*, roles: set[str], linked_athlete: dict[str, Any] | None = None) -> Any:
+    roles_repo = MagicMock()
+    roles_repo.list_roles.return_value = set(roles)
+    athletes_repo = MagicMock()
+    athletes_repo.get_by_linked_user.return_value = linked_athlete
+
+    with (
+        patch("backend.routes.athletes.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.athletes.UserRolesRepository", return_value=roles_repo),
+        patch("backend.routes.athletes.AthletesRepository", return_value=athletes_repo),
+    ):
+        yield
+
+
+def test_granted_roles_are_returned_sorted() -> None:
+    from backend.routes.athletes import my_roles
+
+    with _roles_env(roles={"runner", "coach"}):
+        assert my_roles(user_id=uuid4()) == {"roles": ["coach", "runner"], "is_admin": False}
+
+
+def test_a_user_can_hold_several_roles_at_once() -> None:
+    """The point of the (user_id, role) PK: coach + runner is not a conflict."""
+    from backend.routes.athletes import my_roles
+
+    with _roles_env(roles={"admin", "coach", "runner"}):
+        result = my_roles(user_id=uuid4())
+
+    assert result["roles"] == ["admin", "coach", "runner"]
+    assert result["is_admin"] is True
+
+
+def test_no_roles_and_no_athlete_row_is_an_empty_list() -> None:
+    from backend.routes.athletes import my_roles
+
+    with _roles_env(roles=set()):
+        assert my_roles(user_id=uuid4()) == {"roles": [], "is_admin": False}
+
+
+def test_athlete_is_derived_from_the_linked_row() -> None:
+    from backend.routes.athletes import my_roles
+
+    with _roles_env(roles={"runner"}, linked_athlete={"id": str(uuid4())}):
+        assert my_roles(user_id=uuid4())["roles"] == ["athlete", "runner"]
+
+
+def test_athlete_without_a_coach_is_still_an_athlete() -> None:
+    """Athlete-ness never consults coach_athletes — an uncoached athlete counts."""
+    from backend.routes.athletes import my_roles
+
+    with _roles_env(roles=set(), linked_athlete={"id": str(uuid4()), "linked_user_id": None}):
+        assert my_roles(user_id=uuid4())["roles"] == ["athlete"]
+
+
+def test_athlete_is_absent_when_no_row_links_back() -> None:
+    from backend.routes.athletes import my_roles
+
+    with _roles_env(roles={"coach"}, linked_athlete=None):
+        assert "athlete" not in my_roles(user_id=uuid4())["roles"]
+
+
+def test_derived_athlete_is_looked_up_for_the_caller() -> None:
+    from backend.routes.athletes import my_roles
+
+    uid = uuid4()
+    athletes_repo = MagicMock()
+    athletes_repo.get_by_linked_user.return_value = None
+    roles_repo = MagicMock()
+    roles_repo.list_roles.return_value = set()
+
+    with (
+        patch("backend.routes.athletes.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.athletes.UserRolesRepository", return_value=roles_repo),
+        patch("backend.routes.athletes.AthletesRepository", return_value=athletes_repo),
+    ):
+        my_roles(user_id=uid)
+
+    roles_repo.list_roles.assert_called_once_with(uid)
+    athletes_repo.get_by_linked_user.assert_called_once_with(uid)
+
+
+def test_granted_roles_set_is_not_mutated_by_the_derived_entry() -> None:
+    """my_roles copies the repo's set — adding "athlete" must not leak back."""
+    from backend.routes.athletes import my_roles
+
+    granted = {"runner"}
+    roles_repo = MagicMock()
+    roles_repo.list_roles.return_value = granted
+    athletes_repo = MagicMock()
+    athletes_repo.get_by_linked_user.return_value = {"id": str(uuid4())}
+
+    with (
+        patch("backend.routes.athletes.get_supabase_client", return_value=MagicMock()),
+        patch("backend.routes.athletes.UserRolesRepository", return_value=roles_repo),
+        patch("backend.routes.athletes.AthletesRepository", return_value=athletes_repo),
+    ):
+        my_roles(user_id=uuid4())
+
+    assert granted == {"runner"}

--- a/src/shared/models/athlete.py
+++ b/src/shared/models/athlete.py
@@ -35,6 +35,8 @@ class Athlete(BaseModel):
     created_by: UUID | None = None
     notes: str | None = None
     created_at: datetime
+    # Seeded test athlete (SB-367) — excluded from future social/discovery surfaces.
+    is_test_account: bool = False
     profile: AthleteProfile | None = None
 
 

--- a/src/shared/supabase_ops/athletes_repository.py
+++ b/src/shared/supabase_ops/athletes_repository.py
@@ -41,7 +41,12 @@ def is_possible_duplicate(
 
 
 class UserRolesRepository:
-    """Who is an admin / coach."""
+    """Granted platform roles: admin / coach / runner (the ``user_role`` enum).
+
+    A user may hold any combination — the table's PK is ``(user_id, role)``, so
+    a coach who also runs is two rows, not a conflict. "athlete" is NOT a role
+    here; it is derived from ``athletes.linked_user_id`` (see ``/me/roles``).
+    """
 
     def __init__(self, supabase: Client):
         self.supabase = supabase

--- a/supabase/migrations/20260727000000_runner_role_and_test_accounts.sql
+++ b/supabase/migrations/20260727000000_runner_role_and_test_accounts.sql
@@ -1,0 +1,43 @@
+-- =====================================================
+-- Runner role + test-account flag (SB-367).
+--
+-- `user_roles` is already many-to-many (PK (user_id, role)), so a user can hold
+-- admin + coach + runner at once — that needed no change. What was missing:
+--
+--   1. The `user_role` enum had no 'runner', so "this user runs" (and its
+--      converse, "this coach does not run") could not be expressed. Running was
+--      implicit in being a user, which stops working once coaches exist who
+--      only coach.
+--   2. Nothing marked an account as a test account, so a future follow / social
+--      feature would surface the seeded test users alongside real ones.
+--
+-- Athlete-ness is deliberately NOT a role: it is derived from
+-- `athletes.linked_user_id`. A role row would be a second copy of the same fact
+-- and would drift when an athlete is linked or unlinked, and a *managed*
+-- athlete has no user row to hold one at all. An athlete does not need a coach
+-- — `coach_athletes` is a separate table and the derived check never consults
+-- it. `GET /me/roles` synthesizes "athlete" so the API still returns a uniform
+-- role list.
+--
+-- NOTE: `ALTER TYPE ... ADD VALUE` cannot be *used* in the transaction that
+-- adds it, and Supabase wraps each migration in one. Nothing here inserts a
+-- 'runner' row, so this is safe as a single migration — but any future
+-- migration that grants the runner role must live in its own file.
+-- =====================================================
+
+ALTER TYPE user_role ADD VALUE IF NOT EXISTS 'runner';
+
+-- ---- test-account flag ------------------------------
+
+ALTER TABLE users ADD COLUMN is_test_account BOOLEAN NOT NULL DEFAULT FALSE;
+COMMENT ON COLUMN users.is_test_account IS
+    'Seeded test login (SB-367); exclude from social/discovery surfaces';
+
+ALTER TABLE athletes ADD COLUMN is_test_account BOOLEAN NOT NULL DEFAULT FALSE;
+COMMENT ON COLUMN athletes.is_test_account IS
+    'Seeded test athlete (SB-367); exclude from social/discovery surfaces';
+
+-- Partial indexes: the flagged set is tiny and the interesting query is always
+-- "which are the test rows", never "which are the real ones".
+CREATE INDEX idx_users_test_account ON users (user_id) WHERE is_test_account;
+CREATE INDEX idx_athletes_test_account ON athletes (id) WHERE is_test_account;


### PR DESCRIPTION
## What

Groundwork for flagged prod test accounts (SB-368) and for an explicit running role.

**The multi-role question is already answered by the existing schema**: `user_roles`' PK is `(user_id, role)`, and `UserRolesRepository.list_roles()` returns a set. A user could always hold admin + coach + runner simultaneously — no migration needed for that.

What was actually missing:

1. `user_role` enum was `('admin','coach')` only, so "this user runs" — and its converse, "this coach does not run" — couldn't be expressed. Running was implicit in being a user, which stops working once coach-only accounts exist.
2. Nothing marked an account as a test account, so a future follow/social feature would surface seeded test users next to real ones.

## Why athlete is not a role

Athlete-ness is **derived** from `athletes.linked_user_id`:

```sql
SELECT EXISTS (SELECT 1 FROM athletes WHERE linked_user_id = :caller);
```

A `user_roles` row would be a second copy of the same fact, and it drifts: link an athlete and forget the role insert → athlete pages work but `/me/roles` disagrees; unlink and leave the row → the user reads as an athlete forever. A **managed** athlete has no user row to hold a role at all.

`GET /me/roles` synthesizes `"athlete"` into its response, so the frontend still sees one uniform list (`["athlete","coach","runner"]`) while the DB keeps a single source of truth.

**An athlete does not need a coach.** The derived check never consults `coach_athletes`, so an uncoached athlete still counts — covered by a test.

## Changes

- `supabase/migrations/20260727000000_runner_role_and_test_accounts.sql` — `ALTER TYPE user_role ADD VALUE IF NOT EXISTS 'runner'`; `is_test_account BOOLEAN NOT NULL DEFAULT FALSE` on `users` and `athletes`, each with a partial index (the interesting query is always "which rows are test rows").
- `GET /me/roles` — derived `athlete` entry; copies the repo's set so the synthesized role can't leak back into it.
- `Athlete` model — `is_test_account` exposed on the read shape.
- `UserRolesRepository` docstring — documents the enum and that athlete is deliberately not in it.
- `backend/tests/test_me_roles.py` — 8 tests: sorted output, multi-role, empty, derived athlete, **uncoached athlete**, absent when unlinked, lookup args, no set mutation.

### Postgres caveat

`ALTER TYPE ... ADD VALUE` cannot be *used* in the transaction that adds it, and Supabase wraps each migration in one. Nothing in this migration inserts a `runner` row, so a single file is safe — but any future migration that grants the role must live in its own file. Noted in the migration header.

## Verify

```
uv run --project backend python -m pytest backend/tests/ -q   # 294 passed
uv run pytest tests/ -q                                       # 84 passed
```

Migration SQL is validated by this repo's `supabase db push --dry-run` PR check (Docker is down locally, so it was not applied to a local stack). **Applying to prod stays a manual `workflow_dispatch`.**

## Noticed, not fixed

`athletes.created_by` is `NOT NULL REFERENCES users(user_id) ON DELETE SET NULL` — contradictory. Deleting a user who created an athlete row fails on the NOT NULL rather than nulling the column. Worth its own ticket.

Fixes SB-367

🤖 Generated with [Claude Code](https://claude.com/claude-code)