### PR TITLE
feat: add prod test-account seeder (SB-368)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -48,6 +48,48 @@ python scripts/query_runs.py
 
 **All distances in miles!**
 
+## 👥 Seed Scripts
+
+Two mirror-image seeders. Each refuses to run against the environment the other one owns, so neither can be pointed at the wrong database by accident.
+
+### seed_local_users.py
+
+Local-only (refuses anything but `127.0.0.1`/`localhost`). Free to delete rows and repoint orphans. Seeds `admin@test.local`, `coach@test.local`, `a1@test.local`, `a2@test.local`.
+
+```bash
+eval "$(supabase status -o env | sed 's/^/export SB_/')"
+SUPABASE_URL=$SB_API_URL SERVICE_KEY=$SB_SERVICE_ROLE_KEY \
+  uv run python scripts/seed_local_users.py
+```
+
+### seed_prod_test_users.py
+
+Prod-only (refuses localhost) and **non-destructive** — never deletes an auth user, never touches a row outside `@test.myrunstreak.run`, and refuses to repoint a conflicting `users` row rather than guessing. Re-running is a no-op.
+
+| account | roles | notes |
+|---|---|---|
+| `coach@test.myrunstreak.run` | `coach` + `runner` | the working proof that multi-role works |
+| `runner@test.myrunstreak.run` | `runner` | |
+| `a1@test.myrunstreak.run` | `runner` | linked athlete "Test Athlete One", coached by `coach@` |
+
+All rows get `is_test_account = TRUE` so a future follow/social feature can exclude them. `test.myrunstreak.run` has no MX record and accounts are created with `email_confirm: true`, so no mail ever reaches these addresses.
+
+Requires migration `20260727000000_runner_role_and_test_accounts` — the script checks and fails with instructions if it hasn't been applied.
+
+```bash
+export SUPABASE_URL=https://<prod-ref>.supabase.co
+export SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
+export STK_TEST_PASSWORD=<shared password, 12+ chars>
+
+# preview every write, touching nothing
+uv run python scripts/seed_prod_test_users.py --dry-run
+
+# actually seed
+uv run python scripts/seed_prod_test_users.py --confirm-prod
+```
+
+To find the test accounts later: `SELECT * FROM users WHERE is_test_account;`
+
 ## 🔐 AWS Setup Scripts
 
 ### setup_smashrun_tokens.py

--- a/scripts/seed_prod_test_users.py
+++ b/scripts/seed_prod_test_users.py
@@ -1,0 +1,324 @@
+"""Seed the flagged PROD test accounts for STK (SB-368).
+
+The mirror image of ``seed_local_users.py``: that one refuses to run against
+anything but localhost, this one refuses to run against localhost. It is
+deliberately non-destructive — it never deletes an auth user, never touches a
+row outside the test-email domain, and re-running it is a no-op.
+
+Creates (all with ``is_test_account = TRUE``):
+
+    coach@test.myrunstreak.run   -> roles: coach + runner
+    runner@test.myrunstreak.run  -> roles: runner
+    a1@test.myrunstreak.run      -> roles: runner; athlete "Test Athlete One",
+                                    linked to this login and coached by coach@
+
+``coach@`` holding two roles is the working proof that ``user_roles``
+(PK ``(user_id, role)``) supports a coach who also runs.
+
+The domain has no MX record, so mail to these addresses dead-ends. Accounts are
+created with ``email_confirm: true``, so no mail is ever sent to them either.
+
+Requires migration 20260727000000 (runner role + is_test_account).
+
+Run:
+    export SUPABASE_URL=https://<prod-ref>.supabase.co
+    export SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
+    export STK_TEST_PASSWORD=<password for all three logins>
+    uv run python scripts/seed_prod_test_users.py --confirm-prod
+
+    # see what it would do, touching nothing:
+    uv run python scripts/seed_prod_test_users.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+TEST_DOMAIN = "test.myrunstreak.run"
+
+COACH_EMAIL = f"coach@{TEST_DOMAIN}"
+RUNNER_EMAIL = f"runner@{TEST_DOMAIN}"
+ATHLETE_EMAIL = f"a1@{TEST_DOMAIN}"
+ATHLETE_NAME = "Test Athlete One"
+
+# email -> (display_name, granted roles)
+ACCOUNTS: dict[str, tuple[str, tuple[str, ...]]] = {
+    COACH_EMAIL: ("Test Coach", ("coach", "runner")),
+    RUNNER_EMAIL: ("Test Runner", ("runner",)),
+    ATHLETE_EMAIL: ("Test Athlete One", ("runner",)),
+}
+
+_LOCAL_HOSTS = ("127.0.0.1", "localhost", "0.0.0.0", "::1", "host.docker.internal")
+
+
+# --------------------------------------------------------------------------- #
+# Guards — pure, so they are unit-testable without a live project
+# --------------------------------------------------------------------------- #
+class GuardError(RuntimeError):
+    """A safety precondition was not met. Never raised mid-write."""
+
+
+def assert_not_local(url: str) -> None:
+    """This script writes real accounts; running it at a local stack is a mistake.
+
+    Use ``seed_local_users.py`` for that — it seeds a richer set and is free to
+    delete rows, which this script must never do.
+    """
+    if not url:
+        raise GuardError("SUPABASE_URL is not set.")
+    if any(h in url for h in _LOCAL_HOSTS):
+        raise GuardError(
+            f"REFUSING: SUPABASE_URL looks local ({url}). Use seed_local_users.py instead."
+        )
+
+
+def assert_test_domain(email: str) -> None:
+    """No row outside the test domain may ever be written by this script."""
+    if not email.endswith(f"@{TEST_DOMAIN}"):
+        raise GuardError(f"REFUSING: {email!r} is not on @{TEST_DOMAIN}.")
+
+
+def assert_confirmed(confirmed: bool, dry_run: bool) -> None:
+    if not (confirmed or dry_run):
+        raise GuardError(
+            "REFUSING: pass --confirm-prod to write to a remote project (or --dry-run to preview)."
+        )
+
+
+def assert_password(password: str) -> None:
+    """Passwords come from the environment; nothing is ever hardcoded here."""
+    if not password:
+        raise GuardError("STK_TEST_PASSWORD is not set.")
+    if len(password) < 12:
+        raise GuardError("STK_TEST_PASSWORD must be at least 12 characters.")
+
+
+# --------------------------------------------------------------------------- #
+# Supabase REST / admin API
+# --------------------------------------------------------------------------- #
+class Client:
+    def __init__(self, url: str, key: str, *, dry_run: bool = False):
+        self.url = url.rstrip("/")
+        self.key = key
+        self.dry_run = dry_run
+        self.headers = {
+            "apikey": key,
+            "Authorization": f"Bearer {key}",
+            "Content-Type": "application/json",
+        }
+
+    def _req(
+        self,
+        method: str,
+        path: str,
+        body: Any = None,
+        headers: dict[str, str] | None = None,
+    ) -> Any:
+        if self.dry_run and method != "GET":
+            print(f"  [dry-run] {method} {path} {json.dumps(body) if body else ''}".rstrip())
+            return None
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(
+            self.url + path, data=data, method=method, headers={**self.headers, **(headers or {})}
+        )
+        try:
+            with urllib.request.urlopen(req) as r:
+                raw = r.read()
+                return json.loads(raw) if raw else None
+        except urllib.error.HTTPError as e:
+            raise RuntimeError(f"{method} {path} -> {e.code}: {e.read().decode()[:300]}") from e
+
+    def rest(self, method: str, table: str, body: Any = None, params: str = "", prefer: str = ""):
+        out = self._req(
+            method, f"/rest/v1/{table}{params}", body, {"Prefer": prefer} if prefer else None
+        )
+        return out or []
+
+    # -- auth admin ---------------------------------------------------------
+    def auth_by_email(self, email: str) -> dict[str, Any] | None:
+        out = self._req("GET", f"/auth/v1/admin/users?per_page=200&filter={email}")
+        users = out.get("users", []) if isinstance(out, dict) else (out or [])
+        return next((u for u in users if u.get("email") == email), None)
+
+    def create_auth_user(self, email: str, password: str) -> str:
+        out = self._req(
+            "POST",
+            "/auth/v1/admin/users",
+            {"email": email, "password": password, "email_confirm": True},
+        )
+        # dry-run returns None; surface a placeholder so the plan keeps printing.
+        return out["id"] if out else f"<new:{email}>"
+
+    def set_password(self, uid: str, password: str) -> None:
+        self._req("PUT", f"/auth/v1/admin/users/{uid}", {"password": password})
+
+
+def assert_migration_applied(client: Client) -> None:
+    """Fail early and clearly if migration 20260727000000 has not been pushed."""
+    try:
+        client.rest("GET", "users", params="?select=is_test_account&limit=1")
+    except RuntimeError as exc:
+        raise GuardError(
+            "REFUSING: `users.is_test_account` is missing — apply migration "
+            "20260727000000_runner_role_and_test_accounts first "
+            "(Supabase Migrations workflow, confirm with 'migrate').\n"
+            f"  underlying error: {exc}"
+        ) from exc
+
+
+# --------------------------------------------------------------------------- #
+# Seeding
+# --------------------------------------------------------------------------- #
+def ensure_login(client: Client, email: str, display_name: str, password: str) -> str:
+    """Create-or-update the auth user and its `users` row. Returns the uid.
+
+    Unlike the local seeder this never deletes or re-points orphan rows: on prod
+    an unexpected duplicate is a situation for a human, not for a script.
+    """
+    assert_test_domain(email)
+    existing = client.auth_by_email(email)
+    if existing:
+        uid = existing["id"]
+        client.set_password(uid, password)
+        print(f"  login {email} -> {uid[:8]} (existing, password reset)")
+    else:
+        uid = client.create_auth_user(email, password)
+        print(f"  login {email} -> {uid[:8] if len(uid) > 8 else uid} (created)")
+
+    conflicting = [
+        row["user_id"]
+        for row in client.rest(
+            "GET", "users", params=f"?email=eq.{email}&user_id=neq.{uid}&select=user_id"
+        )
+    ]
+    if conflicting:
+        raise GuardError(
+            f"REFUSING: `users` rows {conflicting} already hold {email} under a different "
+            "id. Resolve by hand — this script will not repoint prod rows."
+        )
+
+    client.rest(
+        "POST",
+        "users",
+        {"user_id": uid, "email": email, "display_name": display_name, "is_test_account": True},
+        prefer="resolution=merge-duplicates",
+    )
+    return uid
+
+
+def grant_roles(client: Client, uid: str, roles: tuple[str, ...]) -> None:
+    for role in roles:
+        client.rest(
+            "POST",
+            "user_roles",
+            {"user_id": uid, "role": role},
+            prefer="resolution=merge-duplicates",
+        )
+    print(f"  roles {'+'.join(roles)}")
+
+
+def ensure_athlete(client: Client, *, coach_id: str, linked_uid: str, display_name: str) -> None:
+    """The athlete row for a1@, linked to its login and coached by coach@.
+
+    Matched on `linked_user_id` (stable) rather than display name, so renaming
+    the athlete in the UI doesn't make a re-run create a duplicate.
+    """
+    existing = client.rest("GET", "athletes", params=f"?linked_user_id=eq.{linked_uid}&select=id")
+    if existing:
+        athlete_id = existing[0]["id"]
+        client.rest(
+            "PATCH",
+            "athletes",
+            {"display_name": display_name, "is_test_account": True},
+            params=f"?id=eq.{athlete_id}",
+        )
+        print(f"  athlete {display_name!r} -> {athlete_id[:8]} (existing)")
+    else:
+        created = client.rest(
+            "POST",
+            "athletes",
+            {
+                "created_by": coach_id,
+                "linked_user_id": linked_uid,
+                "display_name": display_name,
+                "is_test_account": True,
+            },
+            prefer="return=representation",
+        )
+        athlete_id = created[0]["id"] if created else f"<new:{display_name}>"
+        print(f"  athlete {display_name!r} -> {athlete_id[:8]} (created)")
+
+    link = client.rest(
+        "GET",
+        "coach_athletes",
+        params=f"?coach_id=eq.{coach_id}&athlete_id=eq.{athlete_id}&status=eq.active&select=id",
+    )
+    if link:
+        print("  coach link already active")
+    else:
+        client.rest("POST", "coach_athletes", {"coach_id": coach_id, "athlete_id": athlete_id})
+        print("  coach link created")
+
+
+def seed(client: Client, password: str) -> None:
+    assert_migration_applied(client)
+
+    uids: dict[str, str] = {}
+    for email, (display_name, roles) in ACCOUNTS.items():
+        print(f"\n{email}")
+        uid = ensure_login(client, email, display_name, password)
+        grant_roles(client, uid, roles)
+        uids[email] = uid
+
+    print(f"\n{ATHLETE_NAME}")
+    ensure_athlete(
+        client,
+        coach_id=uids[COACH_EMAIL],
+        linked_uid=uids[ATHLETE_EMAIL],
+        display_name=ATHLETE_NAME,
+    )
+
+    print("\nseeded prod test accounts (password from $STK_TEST_PASSWORD):")
+    for email, (_, roles) in ACCOUNTS.items():
+        print(f"  {email:<32} {'+'.join(roles)}")
+    print(f"  {ATHLETE_NAME} — linked to {ATHLETE_EMAIL}, coached by {COACH_EMAIL}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--confirm-prod", action="store_true", help="required to write to a remote project"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="print the writes instead of performing them"
+    )
+    args = parser.parse_args(argv)
+
+    url = os.environ.get("SUPABASE_URL", "")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or os.environ.get("SERVICE_KEY", "")
+    password = os.environ.get("STK_TEST_PASSWORD", "")
+
+    try:
+        assert_not_local(url)
+        assert_confirmed(args.confirm_prod, args.dry_run)
+        if not key:
+            raise GuardError("SUPABASE_SERVICE_ROLE_KEY is not set.")
+        if not args.dry_run:
+            assert_password(password)
+    except GuardError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    print(f"target: {url}{' (DRY RUN)' if args.dry_run else ''}")
+    seed(Client(url, key, dry_run=args.dry_run), password)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_seed_prod_test_users.py
+++ b/tests/test_seed_prod_test_users.py
@@ -1,0 +1,286 @@
+"""Tests for scripts/seed_prod_test_users.py (SB-368).
+
+The script writes real accounts to prod, so its safety rails are the part worth
+testing: refuse localhost, refuse without confirmation, refuse a weak or absent
+password, refuse anything off the test domain, refuse before the migration is
+applied, and never repoint an existing prod row. The seeding itself is checked
+against a fake client that records the REST calls.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_PATH = Path(__file__).resolve().parents[1] / "scripts" / "seed_prod_test_users.py"
+_spec = importlib.util.spec_from_file_location("seed_prod_test_users", _PATH)
+assert _spec and _spec.loader
+seed_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(seed_mod)
+
+GuardError = seed_mod.GuardError
+PROD_URL = "https://abcdefgh.supabase.co"
+
+
+# --------------------------------------------------------------------------- #
+# Guards
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:54321",
+        "http://localhost:54321",
+        "http://0.0.0.0:54321",
+        "http://host.docker.internal:54321",
+    ],
+)
+def test_refuses_local_supabase_urls(url: str) -> None:
+    with pytest.raises(GuardError, match="REFUSING"):
+        seed_mod.assert_not_local(url)
+
+
+def test_refuses_empty_supabase_url() -> None:
+    with pytest.raises(GuardError):
+        seed_mod.assert_not_local("")
+
+
+def test_accepts_a_remote_supabase_url() -> None:
+    seed_mod.assert_not_local(PROD_URL)  # no raise
+
+
+def test_refuses_emails_off_the_test_domain() -> None:
+    with pytest.raises(GuardError, match="test.myrunstreak.run"):
+        seed_mod.assert_test_domain("silverbeer.io@gmail.com")
+
+
+def test_refuses_a_lookalike_domain_suffix() -> None:
+    # "eviltest.myrunstreak.run" must not pass as "test.myrunstreak.run".
+    with pytest.raises(GuardError):
+        seed_mod.assert_test_domain("a1@eviltest.myrunstreak.run.example.com")
+
+
+def test_accepts_the_configured_test_accounts() -> None:
+    for email in seed_mod.ACCOUNTS:
+        seed_mod.assert_test_domain(email)  # no raise
+
+
+def test_requires_confirmation_to_write() -> None:
+    with pytest.raises(GuardError, match="--confirm-prod"):
+        seed_mod.assert_confirmed(False, False)
+
+
+def test_dry_run_needs_no_confirmation() -> None:
+    seed_mod.assert_confirmed(False, True)  # no raise
+
+
+@pytest.mark.parametrize("password", ["", "short"])
+def test_refuses_missing_or_weak_password(password: str) -> None:
+    with pytest.raises(GuardError):
+        seed_mod.assert_password(password)
+
+
+def test_accepts_a_long_enough_password() -> None:
+    seed_mod.assert_password("a-long-enough-password")  # no raise
+
+
+# --------------------------------------------------------------------------- #
+# Fake client
+# --------------------------------------------------------------------------- #
+class _FakeClient:
+    """Records REST/admin calls; serves canned GET results keyed by table."""
+
+    def __init__(
+        self, gets: dict[str, list[dict[str, Any]]] | None = None, *, users_ok: bool = True
+    ):
+        self.gets = gets or {}
+        self.users_ok = users_ok
+        self.calls: list[tuple[str, str, Any, str]] = []
+        self.auth_users: dict[str, dict[str, Any]] = {}
+        self.created: list[str] = []
+        self.passwords_set: list[str] = []
+
+    def rest(self, method: str, table: str, body: Any = None, params: str = "", prefer: str = ""):
+        if table == "users" and "is_test_account" in params and not self.users_ok:
+            raise RuntimeError(
+                "GET /rest/v1/users -> 400: column users.is_test_account does not exist"
+            )
+        self.calls.append((method, table, body, params))
+        if method == "GET":
+            return list(self.gets.get(table, []))
+        if prefer == "return=representation":
+            return [{"id": "11111111-1111-1111-1111-111111111111"}]
+        return []
+
+    def auth_by_email(self, email: str):
+        return self.auth_users.get(email)
+
+    def create_auth_user(self, email: str, password: str) -> str:
+        self.created.append(email)
+        uid = f"uid-{len(self.created)}"
+        self.auth_users[email] = {"id": uid}
+        return uid
+
+    def set_password(self, uid: str, password: str) -> None:
+        self.passwords_set.append(uid)
+
+    # -- helpers ------------------------------------------------------------
+    def writes_to(self, table: str) -> list[Any]:
+        return [body for m, t, body, _ in self.calls if t == table and m in ("POST", "PATCH")]
+
+
+# --------------------------------------------------------------------------- #
+# assert_migration_applied
+# --------------------------------------------------------------------------- #
+def test_refuses_when_is_test_account_column_is_missing() -> None:
+    with pytest.raises(GuardError, match="20260727000000"):
+        seed_mod.assert_migration_applied(_FakeClient(users_ok=False))
+
+
+def test_proceeds_when_the_column_exists() -> None:
+    seed_mod.assert_migration_applied(_FakeClient())  # no raise
+
+
+# --------------------------------------------------------------------------- #
+# ensure_login
+# --------------------------------------------------------------------------- #
+def test_ensure_login_creates_and_flags_the_users_row() -> None:
+    client = _FakeClient()
+
+    uid = seed_mod.ensure_login(client, seed_mod.COACH_EMAIL, "Test Coach", "a-long-password")
+
+    assert client.created == [seed_mod.COACH_EMAIL]
+    row = client.writes_to("users")[0]
+    assert row == {
+        "user_id": uid,
+        "email": seed_mod.COACH_EMAIL,
+        "display_name": "Test Coach",
+        "is_test_account": True,
+    }
+
+
+def test_ensure_login_reuses_an_existing_auth_user() -> None:
+    client = _FakeClient()
+    client.auth_users[seed_mod.COACH_EMAIL] = {"id": "existing-uid"}
+
+    uid = seed_mod.ensure_login(client, seed_mod.COACH_EMAIL, "Test Coach", "a-long-password")
+
+    assert uid == "existing-uid"
+    assert client.created == []  # no duplicate auth user
+    assert client.passwords_set == ["existing-uid"]
+
+
+def test_ensure_login_refuses_to_repoint_a_conflicting_prod_row() -> None:
+    """The local seeder repoints orphans; on prod that is a human's decision."""
+    client = _FakeClient(gets={"users": [{"user_id": "someone-else"}]})
+
+    with pytest.raises(GuardError, match="Resolve by hand"):
+        seed_mod.ensure_login(client, seed_mod.COACH_EMAIL, "Test Coach", "a-long-password")
+
+
+def test_ensure_login_refuses_an_email_off_the_test_domain() -> None:
+    client = _FakeClient()
+
+    with pytest.raises(GuardError):
+        seed_mod.ensure_login(client, "silverbeer.io@gmail.com", "Owner", "a-long-password")
+
+    assert client.created == []
+
+
+# --------------------------------------------------------------------------- #
+# grant_roles / ensure_athlete
+# --------------------------------------------------------------------------- #
+def test_grant_roles_writes_one_row_per_role() -> None:
+    client = _FakeClient()
+
+    seed_mod.grant_roles(client, "uid-1", ("coach", "runner"))
+
+    assert client.writes_to("user_roles") == [
+        {"user_id": "uid-1", "role": "coach"},
+        {"user_id": "uid-1", "role": "runner"},
+    ]
+
+
+def test_ensure_athlete_creates_flagged_row_and_coach_link() -> None:
+    client = _FakeClient()
+
+    seed_mod.ensure_athlete(
+        client, coach_id="coach-uid", linked_uid="a1-uid", display_name="Test Athlete One"
+    )
+
+    athlete = client.writes_to("athletes")[0]
+    assert athlete["created_by"] == "coach-uid"
+    assert athlete["linked_user_id"] == "a1-uid"
+    assert athlete["is_test_account"] is True
+    assert client.writes_to("coach_athletes") == [
+        {"coach_id": "coach-uid", "athlete_id": "11111111-1111-1111-1111-111111111111"}
+    ]
+
+
+def test_ensure_athlete_is_idempotent_on_rerun() -> None:
+    """Existing athlete + active link -> patch only, no second athlete or link."""
+    client = _FakeClient(
+        gets={"athletes": [{"id": "athlete-1"}], "coach_athletes": [{"id": "link-1"}]}
+    )
+
+    seed_mod.ensure_athlete(
+        client, coach_id="coach-uid", linked_uid="a1-uid", display_name="Test Athlete One"
+    )
+
+    assert [m for m, t, _, _ in client.calls if t == "athletes"] == ["GET", "PATCH"]
+    assert client.writes_to("coach_athletes") == []
+
+
+def test_ensure_athlete_matches_on_linked_user_not_display_name() -> None:
+    """Renaming the athlete in the UI must not cause a duplicate on re-run."""
+    client = _FakeClient(gets={"athletes": [{"id": "athlete-1"}]})
+
+    seed_mod.ensure_athlete(
+        client, coach_id="coach-uid", linked_uid="a1-uid", display_name="Renamed Athlete"
+    )
+
+    lookup = next(params for m, t, _, params in client.calls if t == "athletes" and m == "GET")
+    assert "linked_user_id=eq.a1-uid" in lookup
+    assert "display_name" not in lookup
+
+
+# --------------------------------------------------------------------------- #
+# main() guard wiring
+# --------------------------------------------------------------------------- #
+def test_main_refuses_local_url(monkeypatch: pytest.MonkeyPatch, capsys: Any) -> None:
+    monkeypatch.setenv("SUPABASE_URL", "http://127.0.0.1:54321")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "key")
+    monkeypatch.setenv("STK_TEST_PASSWORD", "a-long-password")
+
+    assert seed_mod.main(["--confirm-prod"]) == 1
+    assert "REFUSING" in capsys.readouterr().err
+
+
+def test_main_refuses_without_confirmation(monkeypatch: pytest.MonkeyPatch, capsys: Any) -> None:
+    monkeypatch.setenv("SUPABASE_URL", PROD_URL)
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "key")
+    monkeypatch.setenv("STK_TEST_PASSWORD", "a-long-password")
+
+    assert seed_mod.main([]) == 1
+    assert "--confirm-prod" in capsys.readouterr().err
+
+
+def test_main_refuses_without_service_key(monkeypatch: pytest.MonkeyPatch, capsys: Any) -> None:
+    monkeypatch.setenv("SUPABASE_URL", PROD_URL)
+    monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
+    monkeypatch.delenv("SERVICE_KEY", raising=False)
+    monkeypatch.setenv("STK_TEST_PASSWORD", "a-long-password")
+
+    assert seed_mod.main(["--confirm-prod"]) == 1
+    assert "SERVICE_ROLE_KEY" in capsys.readouterr().err
+
+
+def test_main_refuses_without_password(monkeypatch: pytest.MonkeyPatch, capsys: Any) -> None:
+    monkeypatch.setenv("SUPABASE_URL", PROD_URL)
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "key")
+    monkeypatch.delenv("STK_TEST_PASSWORD", raising=False)
+
+    assert seed_mod.main(["--confirm-prod"]) == 1
+    assert "STK_TEST_PASSWORD" in capsys.readouterr().err


### PR DESCRIPTION
## What

`scripts/seed_prod_test_users.py` — the mirror image of the existing `seed_local_users.py`. That one refuses anything but localhost; this one refuses localhost. Neither can be pointed at the other's database by accident.

| account | roles | notes |
|---|---|---|
| `coach@test.myrunstreak.run` | `coach` + `runner` | working proof that `user_roles` supports a coach who also runs |
| `runner@test.myrunstreak.run` | `runner` | |
| `a1@test.myrunstreak.run` | `runner` | linked athlete "Test Athlete One", coached by `coach@` |

All rows written with `is_test_account = TRUE` (SB-367), so a future follow/social feature can exclude them with one `WHERE` clause.

## Safety

Prod is not local, so this script is deliberately more timid than its local sibling:

- **Refuses localhost** (`127.0.0.1`, `localhost`, `0.0.0.0`, `::1`, `host.docker.internal`).
- **Requires `--confirm-prod`**; `--dry-run` previews every write and touches nothing.
- **Never deletes an auth user.** The local seeder purges `p42.*`/`coach.verify*` junk; on prod that would be a foot-gun.
- **Never writes outside `@test.myrunstreak.run`** — checked per-email inside `ensure_login`, not just once at startup.
- **Refuses to repoint a conflicting row.** The local seeder repoints orphaned `users` rows automatically; here an unexpected duplicate is escalated to a human.
- **Passwords from `$STK_TEST_PASSWORD`**, 12-char minimum, nothing hardcoded.
- **Fails early with instructions** if migration `20260727000000` hasn't been applied, instead of erroring halfway through.

Idempotent: existing auth users are reused (password reset, stable uid), the athlete is matched on `linked_user_id` rather than display name — so renaming the athlete in the UI can't produce a duplicate on re-run — and an already-active coach link is left alone.

No mail can reach these addresses: `test.myrunstreak.run` has no MX record, and accounts are created with `email_confirm: true`.

## Tests

`tests/test_seed_prod_test_users.py` — 28 tests. Guards are pure functions, so they're exercised without a live project; seeding runs against a fake client that records REST calls. Covers each refusal path, both idempotency paths, the `linked_user_id`-not-display-name lookup, and `main()`'s guard wiring.

```
uv run pytest tests/ -q     # 112 passed
```

## Not done here

The script has **not been run** — it needs the prod service-role key, and migration `20260727000000` must be applied first (manual `workflow_dispatch`, confirm `migrate`). Suggested order: apply migration → `--dry-run` → `--confirm-prod`.

Fixes SB-368

🤖 Generated with [Claude Code](https://claude.com/claude-code)