### PR TITLE
fix: lower seeder password floor to Supabase's minimum (SB-377)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -79,7 +79,7 @@ Requires migration `20260727000000_runner_role_and_test_accounts` — the script
 ```bash
 export SUPABASE_URL=https://<prod-ref>.supabase.co
 export SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
-export STK_TEST_PASSWORD=<shared password, 12+ chars>
+export STK_TEST_PASSWORD=<shared password, 6+ chars — Supabase Auth's minimum>
 
 # preview every write, touching nothing
 uv run python scripts/seed_prod_test_users.py --dry-run

--- a/scripts/seed_prod_test_users.py
+++ b/scripts/seed_prod_test_users.py
@@ -23,7 +23,7 @@ Requires migration 20260727000000 (runner role + is_test_account).
 Run:
     export SUPABASE_URL=https://<prod-ref>.supabase.co
     export SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
-    export STK_TEST_PASSWORD=<password for all three logins>
+    export STK_TEST_PASSWORD=<password for all three logins; 6+ chars>
     uv run python scripts/seed_prod_test_users.py --confirm-prod
 
     # see what it would do, touching nothing:
@@ -55,6 +55,10 @@ ACCOUNTS: dict[str, tuple[str, tuple[str, ...]]] = {
 }
 
 _LOCAL_HOSTS = ("127.0.0.1", "localhost", "0.0.0.0", "::1", "host.docker.internal")
+
+# Supabase Auth's default minimum. Matching it keeps these hand-typed test
+# logins as short as the platform allows (seed_local_users.py uses 6-8 too).
+MIN_PASSWORD_LEN = 6
 
 
 # --------------------------------------------------------------------------- #
@@ -92,11 +96,20 @@ def assert_confirmed(confirmed: bool, dry_run: bool) -> None:
 
 
 def assert_password(password: str) -> None:
-    """Passwords come from the environment; nothing is ever hardcoded here."""
+    """Passwords come from the environment; nothing is ever hardcoded here.
+
+    The floor is Supabase Auth's own default minimum, not a stricter house rule:
+    these accounts are typed by hand during manual testing, they hold no data,
+    and they carry ``is_test_account``. Anything shorter fails at the admin API
+    anyway, so checking here just turns a 422 into a readable message.
+    """
     if not password:
         raise GuardError("STK_TEST_PASSWORD is not set.")
-    if len(password) < 12:
-        raise GuardError("STK_TEST_PASSWORD must be at least 12 characters.")
+    if len(password) < MIN_PASSWORD_LEN:
+        raise GuardError(
+            f"STK_TEST_PASSWORD must be at least {MIN_PASSWORD_LEN} characters "
+            "(Supabase Auth's minimum)."
+        )
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_seed_prod_test_users.py
+++ b/tests/test_seed_prod_test_users.py
@@ -77,14 +77,21 @@ def test_dry_run_needs_no_confirmation() -> None:
     seed_mod.assert_confirmed(False, True)  # no raise
 
 
-@pytest.mark.parametrize("password", ["", "short"])
-def test_refuses_missing_or_weak_password(password: str) -> None:
+@pytest.mark.parametrize("password", ["", "abc", "12345"])
+def test_refuses_missing_or_too_short_password(password: str) -> None:
     with pytest.raises(GuardError):
         seed_mod.assert_password(password)
 
 
-def test_accepts_a_long_enough_password() -> None:
-    seed_mod.assert_password("a-long-enough-password")  # no raise
+@pytest.mark.parametrize("password", ["a12345", "coach123", "a-long-enough-password"])
+def test_accepts_anything_supabase_would_accept(password: str) -> None:
+    """The floor is Supabase Auth's minimum, not a stricter house rule — these
+    are hand-typed test logins, and seed_local_users.py already uses 6-8."""
+    seed_mod.assert_password(password)  # no raise
+
+
+def test_password_floor_matches_supabase_minimum() -> None:
+    assert seed_mod.MIN_PASSWORD_LEN == 6
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

`seed_prod_test_users.py` rejected anything under 12 characters:

```
STK_TEST_PASSWORD must be at least 12 characters.
```

That number was invented, not derived. Supabase Auth's default minimum is **6**, and `seed_local_users.py` already seeds `admin123` / `coach123` / `a12345` — so the prod seeder was stricter than both the platform and its own sibling, for accounts that exist to be typed by hand during manual testing.

Floor is now `MIN_PASSWORD_LEN = 6`, and the error names Supabase's minimum as the reason rather than asserting a threshold from nowhere. Anything shorter fails at the admin API regardless, so the check just turns a 422 into a readable message.

## Tradeoff, recorded rather than hidden

These are real logins against prod auth — a guessable password means someone could sign in as a coach in the live app. Accepted deliberately: the accounts hold no data, carry `is_test_account = TRUE`, and exist to be logged into manually. Documented in the `assert_password` docstring so a future reader sees the reasoning rather than re-litigating the number. If test accounts ever gain access to anything real, this should be revisited.

## Tests

42 (was 38). `""`, `"abc"`, `"12345"` still rejected; `"a12345"`, `"coach123"` now accepted. Added an explicit assertion that the constant is 6, so a future silent tightening fails a test instead of surprising someone mid-seed.

```
uv run pytest tests/ -q   # 126 passed
```

Docstring and `scripts/README.md` updated — both previously said 12+.

Fixes SB-377

🤖 Generated with [Claude Code](https://claude.com/claude-code)