### PR TITLE
fix: send recovery redirect_to in the query string (SB-380)

### DIFF
--- a/backend/routes/auth_routes.py
+++ b/backend/routes/auth_routes.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from urllib.parse import urlencode
 from uuid import UUID
 
 import httpx
@@ -191,10 +192,15 @@ async def forgot_password(body: ForgotPasswordRequest) -> dict[str, str]:
     Always returns success-shape, even when the email doesn't exist —
     standard practice to avoid leaking which addresses are registered.
     Supabase itself does this; we just forward.
+
+    ``redirect_to`` MUST go in the query string: GoTrue reads it from there for
+    ``/recover`` and ignores it in the JSON body — silently, with no error. Sent
+    in the body it falls back to Site URL, so the recovery link drops the user
+    at ``/`` already signed in and they never see the reset form (SB-380).
     """
     _proxy_supabase_auth(
-        "/recover",
-        {"email": body.email, "redirect_to": body.redirect_to},
+        f"/recover?{urlencode({'redirect_to': body.redirect_to})}",
+        {"email": body.email},
     )
     return {"message": "If an account exists for that email, a reset link has been sent."}
 

--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -5,6 +5,7 @@ We mock httpx.post so the endpoints can be exercised without a real Supabase.
 
 from typing import Any
 from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs
 
 import httpx
 import pytest
@@ -206,12 +207,34 @@ def test_forgot_password_returns_generic_success(client: TestClient) -> None:
 
     assert r.status_code == 200
     assert "reset link" in r.json()["message"].lower()
-    # Verify we forwarded the email + the default redirect_to to Supabase /recover
     args, kwargs = mock_req.call_args
     assert args[0] == "POST"
-    assert args[1].endswith("/auth/v1/recover")
     assert kwargs["json"]["email"] == "u@example.com"
-    assert kwargs["json"]["redirect_to"] == "https://myrunstreak.run/auth/reset-password"
+
+
+def _recover_redirect(mock_req: MagicMock) -> str | None:
+    """The redirect_to GoTrue will actually honour: the query-string one."""
+    url = mock_req.call_args.args[1]
+    path, _, query = url.partition("?")
+    assert path.endswith("/auth/v1/recover")
+    return parse_qs(query).get("redirect_to", [None])[0]
+
+
+def test_forgot_password_sends_redirect_to_in_the_query_string(client: TestClient) -> None:
+    """SB-380: GoTrue reads redirect_to from the query string for /recover and
+    ignores it in the JSON body — silently. Sent in the body it falls back to
+    Site URL, so the recovery link drops the user at / already signed in and
+    they never see the reset form."""
+    with patch(
+        "backend.routes.auth_routes.httpx.request",
+        return_value=_mock_response(200, ""),
+    ) as mock_req:
+        r = client.post("/auth/forgot-password", json={"email": "u@example.com"})
+
+    assert r.status_code == 200
+    assert _recover_redirect(mock_req) == "https://myrunstreak.run/auth/reset-password"
+    # Body-only would be silently dropped, so it must not be the sole carrier.
+    assert "redirect_to" not in mock_req.call_args.kwargs["json"]
 
 
 def test_forgot_password_accepts_explicit_redirect(client: TestClient) -> None:
@@ -229,8 +252,26 @@ def test_forgot_password_accepts_explicit_redirect(client: TestClient) -> None:
         )
 
     assert r.status_code == 200
-    _, kwargs = mock_req.call_args
-    assert kwargs["json"]["redirect_to"] == "http://localhost:5174/auth/reset-password"
+    assert _recover_redirect(mock_req) == "http://localhost:5174/auth/reset-password"
+
+
+def test_forgot_password_url_encodes_the_redirect(client: TestClient) -> None:
+    """A raw '://' or '?' in the query would truncate the target."""
+    with patch(
+        "backend.routes.auth_routes.httpx.request",
+        return_value=_mock_response(200, ""),
+    ) as mock_req:
+        client.post(
+            "/auth/forgot-password",
+            json={
+                "email": "u@example.com",
+                "redirect_to": "https://myrunstreak.run/auth/reset-password?next=/plan",
+            },
+        )
+
+    raw_query = mock_req.call_args.args[1].partition("?")[2]
+    assert "%3A%2F%2F" in raw_query  # the scheme separator survived encoding
+    assert _recover_redirect(mock_req) == ("https://myrunstreak.run/auth/reset-password?next=/plan")
 
 
 def test_forgot_password_rejects_invalid_email(client: TestClient) -> None:


### PR DESCRIPTION
## Symptom

Clicking a password-reset link logs the user straight into the app. No prompt to set a new password. Reproduced in prod once mail actually started flowing (SB-378).

## Cause

```python
_proxy_supabase_auth("/recover", {"email": ..., "redirect_to": ...})
```

GoTrue reads `redirect_to` from the **query string** for `/recover` and ignores it in the JSON body — silently, no error. Supabase's own JS client issues `POST /recover?redirect_to=<encoded>` with only `{email}` in the body.

So our value was discarded and GoTrue fell back to Site URL, `https://myrunstreak.run` — the root. The recovery link established a session and dropped the user at `/`; `router.beforeEach` (index.ts:160) then saw an authenticated user arriving via the `/` redirect and forwarded them to their landing page. Hence "it just logs me in".

## Why SB-171 appeared fixed

Everything SB-171 built is correct and its tests pass:

- `/auth/reset-password` exists with no `requiresAuth`, so no guard interferes
- `ResetPasswordView` reads the recovery session properly and handles the expired case
- the frontend sends `redirect_to: ${window.location.origin}/auth/reset-password`

The link just never arrived there. And none of it was reachable in prod anyway — SB-378 meant no recovery mail was being sent at all, so the regression sat hidden behind an outage.

## Why the tests didn't catch it

They asserted the bug:

```python
assert kwargs["json"]["redirect_to"] == "https://myrunstreak.run/auth/reset-password"
```

That checks we sent the value *somewhere* — never that Supabase reads it there. A test can only protect the contract it actually encodes.

Replaced with assertions on the query string, plus an explicit check that the body is no longer the sole carrier, and a case proving the value is URL-encoded so a target carrying its own query (`?next=/plan`) survives intact.

## Audit

Checked every other GoTrue call for the same trap: `/signup` passes no redirect, and invites uses the admin API with `email_confirm` (no email, no redirect). `/recover` was the only occurrence.

## Verify

```
uv run --project backend python -m pytest backend/tests/ -q   # 296 passed
```

End-to-end confirmation needs a real inbox: trigger forgot-password, click the link, land on `/auth/reset-password` with a prompt.

Fixes SB-380

🤖 Generated with [Claude Code](https://claude.com/claude-code)