### PR TITLE
perf(backfill): 500 GPS polylines/day via 4 smaller passes (SB-310)

### DIFF
--- a/backend/jobs/backfill_tracks.py
+++ b/backend/jobs/backfill_tracks.py
@@ -2,13 +2,14 @@
 
 Store-on-read (the /track endpoint) already stores a run's polyline whenever its
 map is viewed. This job fills the long tail of never-viewed runs a gentle batch
-at a time — one bounded, rate-limited pass per user per day — so the territory
+at a time — one bounded, rate-limited pass per user per firing — so the territory
 heatmap grows toward full history without ever flooding SmashRun (250 req/hr).
 
 Resumable by construction: each run picks up the oldest runs that still lack a
 polyline, so re-running (daily) advances until nothing remains.
 
-Batch size is BACKFILL_TRACKS_DAILY_LIMIT (default 100).
+Batch size is BACKFILL_TRACKS_BATCH_LIMIT (default 100). The CronJob fires
+several times a day, so the daily total is that limit times the schedule.
 """
 
 from __future__ import annotations
@@ -28,7 +29,13 @@ def main() -> int:
     logging.basicConfig(level=settings.log_level)
     logger = logging.getLogger("backfill-tracks-cron")
 
-    daily_limit = int(os.environ.get("BACKFILL_TRACKS_DAILY_LIMIT", "100"))
+    # DAILY_LIMIT is the old name — still honoured so a chart/image rollout in
+    # either order keeps the configured batch size.
+    batch_limit = int(
+        os.environ.get("BACKFILL_TRACKS_BATCH_LIMIT")
+        or os.environ.get("BACKFILL_TRACKS_DAILY_LIMIT")
+        or "100"
+    )
 
     supabase = get_supabase_client()
     rows = supabase.table("user_sources").select("user_id").eq("source_type", "smashrun").execute()
@@ -41,7 +48,7 @@ def main() -> int:
     failures = 0
     for user_id in user_ids:
         try:
-            result = backfill_user_tracks(user_id, limit=daily_limit)
+            result = backfill_user_tracks(user_id, limit=batch_limit)
             logger.info(
                 "Backfilled %s tracks for %s (%s processed, %s remaining)",
                 result["tracks_stored"],

--- a/helm/myrunstreak/templates/cronjob-backfill-tracks.yaml
+++ b/helm/myrunstreak/templates/cronjob-backfill-tracks.yaml
@@ -1,8 +1,9 @@
 {{- if and .Values.backend.enabled .Values.backend.cronjobs.backfillTracks.enabled }}
-# Daily gentle trickle-backfill of GPS polylines (SB-310). One bounded,
-# rate-limited pass/user/day fills the long tail of never-viewed runs so the
-# territory heatmap grows toward full history without flooding SmashRun
-# (250 req/hr). Resumable — advances oldest-first until nothing remains.
+# Trickle-backfill of GPS polylines (SB-310). Bounded, rate-limited passes fill
+# the long tail of never-viewed runs so the territory heatmap grows toward full
+# history without flooding SmashRun (250 req/hr) — hence several small passes a
+# day rather than one big one. Resumable — advances oldest-first until nothing
+# remains.
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -36,8 +37,8 @@ spec:
                   value: {{ .Values.backend.env.environment | default "dev" | quote }}
                 - name: LOG_LEVEL
                   value: {{ .Values.backend.env.logLevel | default "INFO" | quote }}
-                - name: BACKFILL_TRACKS_DAILY_LIMIT
-                  value: {{ .Values.backend.cronjobs.backfillTracks.dailyLimit | default 100 | quote }}
+                - name: BACKFILL_TRACKS_BATCH_LIMIT
+                  value: {{ .Values.backend.cronjobs.backfillTracks.batchLimit | default 100 | quote }}
                 - name: SUPABASE_URL
                   valueFrom:
                     secretKeyRef:

--- a/helm/myrunstreak/values.yaml
+++ b/helm/myrunstreak/values.yaml
@@ -130,12 +130,13 @@ backend:
           memory: 256Mi
     backfillTracks:
       enabled: true
-      # 09:00 UTC — after the morning sync + recompute, off-peak. One gentle
-      # batch/user/day trickles GPS polylines for the heatmap without flooding
-      # SmashRun (250 req/hr). dailyLimit runs/day -> full history in weeks; no
-      # rush (SB-310). Store-on-read fills viewed runs in the meantime.
-      schedule: "0 9 * * *"
-      dailyLimit: 100
+      # Every 6h at 00/06/12/18 UTC — clear of the syncs (14:00, 17:00) and the
+      # plan recompute (08:00). batchLimit runs per pass x 4 passes = 500/day,
+      # and each pass stays well under SmashRun's 250 req/hr: one 500-run burst
+      # would finish in ~6 min and get rate-limited halfway (SB-310).
+      # Store-on-read fills viewed runs in the meantime.
+      schedule: "0 0,6,12,18 * * *"
+      batchLimit: 125
       resources:
         requests:
           cpu: 50m


### PR DESCRIPTION
## What

The GPS-polyline trickle-backfill (SB-310) was running once a day at 100 runs/user. Last cron log: `Backfilled 100 tracks (100 processed, 3804 remaining)` — ~38 days to finish.

Now 500/day, split into 4 passes of 125.

## Why not one 500-run pass

500 requests would land in ~6 minutes (0.4s sleep + fetch), against SmashRun's 250 req/hr ceiling — the back half would rate-limit. Four passes 6h apart keep peak load at ~125 req/hr.

Schedule `0 0,6,12,18 * * *` avoids the existing SmashRun-touching jobs (sync at 14:00/17:00) and the plan recompute (08:00). Each pod runs ~100s, well under the existing `activeDeadlineSeconds: 900`.

ETA to full history: ~8 days instead of ~38.

## Rename

`dailyLimit` → `batchLimit`, `BACKFILL_TRACKS_DAILY_LIMIT` → `BACKFILL_TRACKS_BATCH_LIMIT` — it's a per-pass number now. The job still falls back to the old env var, so the chart and image can roll out in either order without silently reverting to the default 100.

## Test

- `uv run --project backend python -m pytest backend/tests/test_backfill_tracks.py -q` → 4 passed
- `helm template` renders `schedule: "0 0,6,12,18 * * *"`
- ruff lint + format clean (pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)