### PR TITLE
feat(routes): identify routes by GPS track shape (SB-394)

### DIFF
--- a/backend/routes/runs.py
+++ b/backend/routes/runs.py
@@ -248,9 +248,15 @@ async def runs_head(
 
 
 @cached(ttl=60, key_prefix="runs:routes")
-async def _routes(user_id: UUID, min_runs: int) -> dict[str, Any]:
+async def _routes(user_id: UUID, min_runs: int, shape: bool) -> dict[str, Any]:
     repo = RunsRepository(get_supabase_client())
-    routes = repo.get_route_leaderboard(user_id, min_runs=min_runs)
+    routes = repo.get_route_leaderboard(user_id, min_runs=min_runs, use_shape=shape)
+    # run_ids exist so a single run can be located in its family; they'd add
+    # tens of KB of UUIDs to a leaderboard nobody reads them from.
+    for route in routes:
+        route.pop("run_ids", None)
+        for variant in route.get("variants", ()):
+            variant.pop("run_ids", None)
     return {"count": len(routes), "routes": routes}
 
 
@@ -258,11 +264,18 @@ async def _routes(user_id: UUID, min_runs: int) -> dict[str, Any]:
 async def route_leaderboard(
     user_id: UUID = Depends(authenticate_request),
     min_runs: int = Query(2, ge=1, le=100, description="Only routes run at least this many times"),
+    shape: bool = Query(False, description="Group by GPS track shape instead of start cell"),
 ) -> dict[str, Any]:
     """Repeated-route leaderboard (SB-291): GPS runs grouped by start cell +
     distance bucket, sorted by run count. Answers "how many times have I run
-    this route". Treadmill / no-GPS runs are excluded."""
-    return await _routes(user_id, min_runs)
+    this route". Treadmill / no-GPS runs are excluded.
+
+    ``shape=true`` (SB-394) instead groups by the path each run traced, so two
+    routes leaving the same house at the same distance stop being one row; each
+    row is then a route family with a ``variants`` list. Opt-in until the
+    SB-310 polyline backfill finishes — runs without a stored track can't be
+    shape-matched and fall back to standing alone."""
+    return await _routes(user_id, min_runs, shape)
 
 
 @cached(ttl=300, key_prefix="runs:tracks")

--- a/backend/tests/test_route_leaderboard.py
+++ b/backend/tests/test_route_leaderboard.py
@@ -8,6 +8,7 @@ from typing import Any
 from uuid import uuid4
 
 from backend.routes import runs as runs_module
+from src.shared.geo import decode_polyline, encode_polyline
 from src.shared.supabase_ops.runs_repository import RunsRepository
 
 USER = uuid4()
@@ -111,6 +112,129 @@ def test_get_route_for_run_none_for_unseen_start() -> None:
     assert _repo(rows).get_route_for_run(USER, 10.0, 10.0, 4.0) is None
 
 
+# ---- shape-based grouping (SB-394) ----
+
+
+class _FakeTables:
+    """Fake client that answers per table, so runs and run_tracks can differ."""
+
+    def __init__(self, runs: list[dict[str, Any]], tracks: list[dict[str, Any]]) -> None:
+        self._by_table = {"runs": runs, "run_tracks": tracks}
+
+    def table(self, name: str) -> _FakeQuery:
+        return _FakeQuery(self._by_table[name])
+
+
+def _shape_repo(runs: list[dict[str, Any]], tracks: list[dict[str, Any]]) -> RunsRepository:
+    return RunsRepository(_FakeTables(runs, tracks))  # type: ignore[arg-type]
+
+
+def _track_run(run_id: str, km: float, pace: float, date: str) -> dict[str, Any]:
+    """A home-start run — same cell and distance bucket for every one of these."""
+    return {"id": run_id, **_run(42.244, -71.651, km, pace, date)}
+
+
+def _poly(dlat: float, dlon: float) -> str:
+    """Encoded rectangular loop out of the home cell — the run's traced path."""
+    lat, lon = 42.244, -71.651
+    pts: list[tuple[float, float]] = []
+    corners = [(0.0, 0.0), (dlat, 0.0), (dlat, dlon), (0.0, dlon), (0.0, 0.0)]
+    for (a1, o1), (a2, o2) in zip(corners, corners[1:], strict=False):
+        for i in range(9):
+            t = i / 8
+            pts.append((lat + a1 + (a2 - a1) * t, lon + o1 + (o2 - o1) * t))
+    return encode_polyline(pts)
+
+
+NORTH = _poly(0.006, 0.006)
+SOUTH = _poly(-0.006, -0.006)
+
+
+def test_shape_splits_one_coarse_group_into_real_routes() -> None:
+    """Same house, same distance, different streets -> two routes, not one."""
+    runs = [
+        _track_run("r1", 5.5, 6.0, "2026-01-01"),
+        _track_run("r2", 5.5, 5.8, "2026-02-01"),
+        _track_run("r3", 5.5, 6.1, "2026-03-01"),
+        _track_run("r4", 5.5, 5.9, "2026-04-01"),
+    ]
+    tracks = [
+        {"run_id": "r1", "polyline": NORTH},
+        {"run_id": "r2", "polyline": NORTH},
+        {"run_id": "r3", "polyline": SOUTH},
+        {"run_id": "r4", "polyline": SOUTH},
+    ]
+    repo = _shape_repo(runs, tracks)
+
+    # Legacy grouping calls all four one route.
+    assert len(repo.get_route_leaderboard(USER, min_runs=2)) == 1
+
+    routes = repo.get_route_leaderboard(USER, min_runs=2, use_shape=True)
+    assert len(routes) == 2
+    assert [r["run_count"] for r in routes] == [2, 2]
+    # Keys stay distinct even though the coarse (cell, distance) key is shared.
+    assert routes[0]["route_key"] != routes[1]["route_key"]
+
+
+def test_shape_variants_nest_and_sum_to_the_family() -> None:
+    detour = encode_polyline([*decode_polyline(NORTH), (42.244, -71.6600), (42.244, -71.6650)])
+    runs = [
+        _track_run("r1", 5.5, 6.0, "2026-01-01"),
+        _track_run("r2", 5.5, 5.8, "2026-02-01"),
+        _track_run("r3", 5.5, 6.1, "2026-03-01"),
+    ]
+    tracks = [
+        {"run_id": "r1", "polyline": NORTH},
+        {"run_id": "r2", "polyline": NORTH},
+        {"run_id": "r3", "polyline": detour},
+    ]
+    routes = _shape_repo(runs, tracks).get_route_leaderboard(USER, min_runs=2, use_shape=True)
+
+    assert len(routes) == 1  # one family — the detour is a variation, not a new route
+    family = routes[0]
+    assert family["run_count"] == 3
+    assert sum(v["run_count"] for v in family["variants"]) == family["run_count"]
+    assert [v["run_count"] for v in family["variants"]] == [2, 1]  # biggest first
+
+
+def test_shape_keeps_runs_that_have_no_polyline() -> None:
+    """Backfill is incomplete; an untracked run must not vanish from the board."""
+    runs = [
+        _track_run("r1", 5.5, 6.0, "2026-01-01"),
+        _track_run("r2", 5.5, 5.8, "2026-02-01"),
+        _track_run("r3", 5.5, 6.1, "2026-03-01"),
+    ]
+    tracks = [{"run_id": "r1", "polyline": NORTH}, {"run_id": "r2", "polyline": NORTH}]
+    routes = _shape_repo(runs, tracks).get_route_leaderboard(USER, min_runs=1, use_shape=True)
+
+    assert sum(r["run_count"] for r in routes) == 3
+    assert sorted(r["run_count"] for r in routes) == [1, 2]  # r3 stands alone
+
+
+def test_get_route_for_run_by_id_returns_family_and_variant_counts() -> None:
+    detour = encode_polyline([*decode_polyline(NORTH), (42.244, -71.6600), (42.244, -71.6650)])
+    runs = [
+        _track_run("r1", 5.5, 6.0, "2026-01-01"),
+        _track_run("r2", 5.5, 5.8, "2026-02-01"),
+        _track_run("r3", 5.5, 6.1, "2026-03-01"),
+        _track_run("r4", 5.5, 6.2, "2026-04-01"),
+    ]
+    tracks = [
+        {"run_id": "r1", "polyline": NORTH},
+        {"run_id": "r2", "polyline": NORTH},
+        {"run_id": "r3", "polyline": detour},
+        {"run_id": "r4", "polyline": SOUTH},
+    ]
+    got = _shape_repo(runs, tracks).get_route_for_run(
+        USER, 42.244, -71.651, 5.5, run_id="r3", use_shape=True
+    )
+
+    assert got is not None
+    assert got["run_count"] == 3  # the family: two plain + the detour
+    assert got["variant_run_count"] == 1  # this exact version, run once
+    assert got["total_routes"] == 2  # the SOUTH loop is the other route
+
+
 # ---- endpoint wiring ----
 
 
@@ -121,8 +245,11 @@ class _EndpointRepo:
     def __call__(self, _supabase: Any) -> _EndpointRepo:
         return self
 
-    def get_route_leaderboard(self, user_id: Any, min_runs: int = 2) -> list[dict[str, Any]]:
+    def get_route_leaderboard(
+        self, user_id: Any, min_runs: int = 2, use_shape: bool = False
+    ) -> list[dict[str, Any]]:
         assert user_id == USER
+        self.used_shape = use_shape
         return self._routes
 
 
@@ -130,5 +257,25 @@ def test_endpoint_shapes_count_and_routes(monkeypatch: Any) -> None:
     monkeypatch.setattr(runs_module, "get_supabase_client", lambda: object())
     monkeypatch.setattr(runs_module, "RunsRepository", _EndpointRepo([{"run_count": 47}]))
 
-    out = asyncio.run(runs_module.route_leaderboard(user_id=USER, min_runs=2))
+    out = asyncio.run(runs_module.route_leaderboard(user_id=USER, min_runs=2, shape=False))
     assert out == {"count": 1, "routes": [{"run_count": 47}]}
+
+
+def test_endpoint_strips_run_ids_from_the_payload(monkeypatch: Any) -> None:
+    """run_ids are an internal lookup aid — tens of KB of UUIDs on the wire."""
+    repo = _EndpointRepo(
+        [
+            {
+                "run_count": 3,
+                "run_ids": ["a", "b", "c"],
+                "variants": [{"run_count": 3, "run_ids": []}],
+            }
+        ]
+    )
+    monkeypatch.setattr(runs_module, "get_supabase_client", lambda: object())
+    monkeypatch.setattr(runs_module, "RunsRepository", repo)
+
+    out = asyncio.run(runs_module.route_leaderboard(user_id=USER, min_runs=2, shape=True))
+    assert repo.used_shape is True
+    assert "run_ids" not in out["routes"][0]
+    assert "run_ids" not in out["routes"][0]["variants"][0]

--- a/backend/tests/test_route_shape.py
+++ b/backend/tests/test_route_shape.py
@@ -1,0 +1,113 @@
+"""SB-394: route identity from track shape — fingerprinting + two-level clustering."""
+
+from __future__ import annotations
+
+from src.shared.route_shape import (
+    cluster,
+    families_and_variants,
+    fingerprint,
+    similarity,
+)
+
+# A block near the owner's home cell. Coordinates are arbitrary but realistic in
+# scale: 0.01 deg latitude is ~1.1 km, so these are street-sized legs.
+HOME = (42.2440, -71.6510)
+
+
+def _leg(
+    start: tuple[float, float], dlat: float, dlon: float, steps: int = 4
+) -> list[tuple[float, float]]:
+    lat, lon = start
+    return [(lat + dlat * i / steps, lon + dlon * i / steps) for i in range(steps + 1)]
+
+
+def _loop(dlat: float, dlon: float) -> list[tuple[float, float]]:
+    """Rectangular loop out of HOME and back."""
+    a = _leg(HOME, dlat, 0.0)
+    b = _leg(a[-1], 0.0, dlon)
+    c = _leg(b[-1], -dlat, 0.0)
+    d = _leg(c[-1], 0.0, -dlon)
+    return a + b + c + d
+
+
+def test_fingerprint_fills_gaps_between_sparse_points() -> None:
+    """Simplified polylines are sparse; the fingerprint must cover the path."""
+    sparse = [HOME, (HOME[0] + 0.01, HOME[1])]  # ~1.1 km in two points
+    fp = fingerprint(sparse)
+    # ~1.1 km of 150 m cells -> several cells, not just the two endpoints.
+    assert len(fp) > 5
+
+
+def test_identical_tracks_match_exactly() -> None:
+    fp = fingerprint(_loop(0.006, 0.006))
+    assert similarity(fp, fp) == 1.0
+
+
+def test_reverse_direction_is_the_same_route() -> None:
+    """Cell sets have no direction, so a loop run backwards matches."""
+    forward = _loop(0.006, 0.006)
+    fp_a = fingerprint(forward)
+    fp_b = fingerprint(list(reversed(forward)))
+    assert similarity(fp_a, fp_b) > 0.95
+
+
+def test_disjoint_tracks_do_not_match() -> None:
+    home = fingerprint(_loop(0.006, 0.006))
+    away = fingerprint(_leg((41.8934, -87.6244), 0.01, 0.01, steps=20))
+    assert similarity(home, away) == 0.0
+
+
+def test_empty_fingerprint_never_matches() -> None:
+    assert similarity(frozenset(), fingerprint(_loop(0.006, 0.006))) == 0.0
+    assert fingerprint([]) == frozenset()
+    assert fingerprint([HOME]) == frozenset()
+
+
+def test_cluster_is_single_link_not_first_match() -> None:
+    """A bridging run chains both neighbours into one cluster, order-independently."""
+    a = frozenset({(0, 0), (0, 1), (0, 2), (0, 3)})
+    c = frozenset({(0, 2), (0, 3), (0, 4), (0, 5)})
+    bridge = frozenset({(0, 1), (0, 2), (0, 3), (0, 4)})
+    # a<->c overlap is only 2/6; each overlaps the bridge 3/5.
+    assert similarity(a, c) < 0.5
+    assert similarity(a, bridge) >= 0.5
+
+    assert cluster([a, bridge, c], threshold=0.5) == [[0, 1, 2]]
+    # Same answer whatever order they arrive in.
+    assert cluster([c, a, bridge], threshold=0.5) == [[0, 1, 2]]
+
+
+def test_variants_nest_inside_one_family() -> None:
+    """Slight variations = one family, several variants (the owner's 3-4 routes)."""
+    base = _loop(0.006, 0.006)
+    # Same loop plus a short out-and-back on a street the loop doesn't use —
+    # mostly shared path, but genuinely different ground for a stretch.
+    variation = base + _leg(base[-1], 0.0, -0.003)
+    tracks = [base, base, variation, variation, variation]
+    fps = [fingerprint(t) for t in tracks]
+
+    fams = families_and_variants(fps, family_overlap=0.4, variant_overlap=0.95)
+    assert len(fams) == 1  # one family
+    assert len(fams[0]) == 2  # two variants inside it
+    assert sorted(len(v) for v in fams[0]) == [2, 3]
+    # Counts add up: every run lands in exactly one variant of one family.
+    assert sum(len(v) for v in fams[0]) == len(tracks)
+
+
+def test_genuinely_different_routes_are_separate_families() -> None:
+    """Same start, same length, different streets -> two families, not one."""
+    north = _loop(0.006, 0.006)
+    south = _loop(-0.006, -0.006)
+    fps = [fingerprint(north), fingerprint(north), fingerprint(south), fingerprint(south)]
+
+    fams = families_and_variants(fps)
+    assert len(fams) == 2
+    assert sorted(sum(len(v) for v in f) for f in fams) == [2, 2]
+
+
+def test_untracked_runs_become_their_own_families() -> None:
+    """No polyline -> can't match anything, but must not vanish from the board."""
+    real = fingerprint(_loop(0.006, 0.006))
+    fams = families_and_variants([real, real, frozenset(), frozenset()])
+    sizes = sorted(sum(len(v) for v in f) for f in fams)
+    assert sizes == [1, 1, 2]  # the pair matched; the two empties stand alone

--- a/src/shared/route_shape.py
+++ b/src/shared/route_shape.py
@@ -1,0 +1,148 @@
+"""Route identity from GPS track shape (SB-394).
+
+The old identity — rounded start cell + distance bucket — cannot separate two
+routes that leave the same house and run the same distance, which is most of a
+home-based runner's history. This module identifies a route by the *path* the
+run traces.
+
+A track is fingerprinted as the set of grid cells its path passes through, and
+two runs are "the same" when their cell sets overlap enough (Jaccard). Sets have
+no direction, so running a loop backwards matches for free, and a detour only
+costs similarity in proportion to its length.
+
+Clustering is two-level so one number doesn't have to answer two questions:
+
+* **family** — loose overlap: "my 5.5 from home", counting slight variations
+  together (the streak-flavoured number).
+* **variant** — strict overlap *within* a family: the specific version.
+
+Single-link at both levels, so variants always nest inside their family and the
+counts add up.
+"""
+
+from __future__ import annotations
+
+import math
+
+# ~150 m at mid latitudes. Longitude is aspect-corrected by cos(lat) so cells
+# stay roughly square wherever the runs are.
+DEFAULT_CELL_DEG = 0.0015
+# A run's grid cells must cover this fraction of the union to count as the same
+# family / variant.
+#
+# Swept over the 403 prod tracks available at the time of writing: the pairwise
+# similarity distribution is bimodal — a heavy mass at >= 0.8 (the same route on
+# a different day) and a long spread below 0.6 (different routes), with the
+# trough at 0.4-0.5. Family sits in the trough; variant sits inside the dense
+# mass. Provisional — the sample is the oldest ~10% of history (backfill runs
+# oldest-first), so re-sweep once SB-310 drains.
+FAMILY_OVERLAP = 0.5
+VARIANT_OVERLAP = 0.8
+# Pairwise clustering is O(n^2); above this a group falls back to the coarse key
+# rather than burning seconds on a request. No real route hits this.
+MAX_CLUSTER_MEMBERS = 2000
+
+Cell = tuple[int, int]
+Fingerprint = frozenset[Cell]
+
+
+def fingerprint(
+    points: list[tuple[float, float]], cell_deg: float = DEFAULT_CELL_DEG
+) -> Fingerprint:
+    """The set of grid cells a track passes through.
+
+    Points come from a Douglas-Peucker-simplified polyline, so a straight
+    kilometre may be only two points — we walk each segment in sub-cell steps
+    rather than sampling the vertices, or the fingerprint would be full of holes
+    exactly where two routes run together.
+    """
+    if len(points) < 2:
+        return frozenset()
+
+    # Aspect-correct longitude once per track; a run doesn't span enough
+    # latitude for the factor to drift.
+    mean_lat = sum(p[0] for p in points) / len(points)
+    lon_scale = max(math.cos(math.radians(mean_lat)), 0.01)
+
+    cells: set[Cell] = set()
+    for (lat1, lon1), (lat2, lon2) in zip(points, points[1:], strict=False):
+        dlat = lat2 - lat1
+        dlon = (lon2 - lon1) * lon_scale
+        span = math.hypot(dlat, dlon)
+        steps = max(1, int(span / (cell_deg / 2)))
+        for i in range(steps + 1):
+            t = i / steps
+            cells.add(
+                (
+                    int(round((lat1 + dlat * t) / cell_deg)),
+                    int(round((lon1 * lon_scale + dlon * t) / cell_deg)),
+                )
+            )
+    return frozenset(cells)
+
+
+def similarity(a: Fingerprint, b: Fingerprint) -> float:
+    """Jaccard overlap of two fingerprints (0.0 - 1.0)."""
+    if not a or not b:
+        return 0.0
+    shared = len(a & b)
+    return shared / (len(a) + len(b) - shared)
+
+
+def cluster(fingerprints: list[Fingerprint], threshold: float) -> list[list[int]]:
+    """Single-link clusters of indices whose fingerprints overlap >= threshold.
+
+    Single-link (union-find over every qualifying pair) rather than
+    first-match-wins: a run that resembles two others chains them into one
+    cluster instead of landing in whichever was checked first, which would make
+    the result depend on input order.
+    """
+    n = len(fingerprints)
+    parent = list(range(n))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(x: int, y: int) -> None:
+        rx, ry = find(x), find(y)
+        if rx != ry:
+            parent[max(rx, ry)] = min(rx, ry)
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            if similarity(fingerprints[i], fingerprints[j]) >= threshold:
+                union(i, j)
+
+    groups: dict[int, list[int]] = {}
+    for i in range(n):
+        groups.setdefault(find(i), []).append(i)
+    # Deterministic order: by first member, so callers get stable output.
+    return [groups[k] for k in sorted(groups)]
+
+
+def families_and_variants(
+    fingerprints: list[Fingerprint],
+    family_overlap: float = FAMILY_OVERLAP,
+    variant_overlap: float = VARIANT_OVERLAP,
+) -> list[list[list[int]]]:
+    """Two-level clustering: families, each split into variants.
+
+    Returns one entry per family, each a list of variants, each a list of
+    indices into ``fingerprints``. Every index appears exactly once, so family
+    size is the sum of its variant sizes.
+
+    Runs with an empty fingerprint (no usable track) each become their own
+    single-member family — they can't be matched to anything, and dropping them
+    would silently lose runs from the leaderboard.
+    """
+    families: list[list[list[int]]] = []
+    for fam in cluster(fingerprints, family_overlap):
+        if len(fam) == 1:
+            families.append([fam])
+            continue
+        sub = cluster([fingerprints[i] for i in fam], variant_overlap)
+        families.append([[fam[i] for i in variant] for variant in sub])
+    return families

--- a/src/shared/supabase_ops/runs_repository.py
+++ b/src/shared/supabase_ops/runs_repository.py
@@ -8,6 +8,8 @@ from typing import Any, cast
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
+from src.shared.geo import decode_polyline
+from src.shared.route_shape import MAX_CLUSTER_MEMBERS, families_and_variants, fingerprint
 from supabase import Client
 
 logger = logging.getLogger(__name__)
@@ -161,6 +163,26 @@ class RunsRepository:
         return [
             {"polyline": r["polyline"], "encoded_precision": r["encoded_precision"]} for r in rows
         ]
+
+    def get_polylines_by_run_id(self, user_id: UUID) -> dict[str, str]:
+        """``{run_id: polyline}`` for every stored track (SB-394 shape grouping).
+
+        Same rows as :meth:`get_all_track_polylines`, keyed so the leaderboard
+        can attach a track to the run it belongs to.
+        """
+
+        def page(off: int, size: int) -> list[dict[str, Any]]:
+            return cast(
+                list[dict[str, Any]],
+                self.supabase.table("run_tracks")
+                .select("run_id, polyline, runs!inner(user_id)")
+                .eq("runs.user_id", str(user_id))
+                .range(off, off + size - 1)
+                .execute()
+                .data,
+            )
+
+        return {r["run_id"]: r["polyline"] for r in self._paginate(page) if r.get("polyline")}
 
     def count_tracks(self, user_id: UUID) -> int:
         """How many of a user's runs have a stored polyline (backfill progress)."""
@@ -458,12 +480,37 @@ class RunsRepository:
             "avg_pace_min_per_km": round(sum(paces) / len(paces), 2) if paces else 0,
         }
 
+    @staticmethod
+    def _summarize_route(
+        members: list[dict[str, Any]], route_key: str, lat: float, lon: float, bucket: float
+    ) -> dict[str, Any]:
+        """One leaderboard row from the runs that belong to it."""
+        chron = sorted(members, key=lambda m: m["start_date"])
+        paces = [
+            float(m["average_pace_min_per_km"])
+            for m in chron
+            if m["average_pace_min_per_km"] is not None
+        ]
+        return {
+            "route_key": route_key,
+            "start_latitude": lat,
+            "start_longitude": lon,
+            "distance_km": bucket,
+            "run_count": len(members),
+            "first_date": chron[0]["start_date"],
+            "last_date": chron[-1]["start_date"],
+            "best_pace_min_per_km": round(min(paces), 2) if paces else None,
+            "avg_pace_min_per_km": round(sum(paces) / len(paces), 2) if paces else None,
+            "pace_series": [round(p, 2) for p in paces],
+        }
+
     def get_route_leaderboard(
         self,
         user_id: UUID,
         min_runs: int = 2,
         precision: int = 2,
         dist_bucket_km: float = 0.5,
+        use_shape: bool = False,
     ) -> list[dict[str, Any]]:
         """Group a user's GPS runs into repeated routes (SB-291).
 
@@ -478,22 +525,32 @@ class RunsRepository:
         from one spot, so the distance bucket does the real separating; the
         coarser cell folds the boundary jitter back together.
 
+        ``use_shape=True`` (SB-394) subdivides each coarse group by the actual
+        path the runs traced, which is the only thing that separates two routes
+        leaving the same house at the same distance. Each returned row is then a
+        route *family* (slight variations counted together) carrying a
+        ``variants`` list. Off by default until the SB-310 polyline backfill
+        finishes — with partial coverage the split would be arbitrary.
+
         Args:
             user_id: User UUID
             min_runs: Only return routes run at least this many times
             precision: Decimal places to round start lat/lon (2 ≈ 1.1 km cell)
             dist_bucket_km: Distance bucket width in km
+            use_shape: Subdivide groups by track shape (needs stored polylines)
 
         Returns:
             Routes sorted by run count desc. Each: route_key, start_latitude,
             start_longitude, distance_km (bucket midpoint), run_count,
             first_date, last_date, best_pace_min_per_km, avg_pace_min_per_km,
-            pace_series (chronological avg pace per run, for a sparkline).
+            pace_series (chronological avg pace per run, for a sparkline), and
+            with use_shape also variants (the same shape, one level down).
         """
         result = (
             self.supabase.table("runs")
             .select(
-                "start_latitude, start_longitude, distance_km, average_pace_min_per_km, start_date"
+                "id, start_latitude, start_longitude, distance_km, "
+                "average_pace_min_per_km, start_date"
             )
             .eq("user_id", str(user_id))
             .not_.is_("start_latitude", "null")
@@ -510,33 +567,66 @@ class RunsRepository:
             bucket = round(float(r["distance_km"]) / dist_bucket_km) * dist_bucket_km
             groups.setdefault((lat, lon, round(bucket, 3)), []).append(r)
 
+        polylines = self.get_polylines_by_run_id(user_id) if use_shape else {}
+
         routes: list[dict[str, Any]] = []
         for (lat, lon, bucket), members in groups.items():
-            if len(members) < min_runs:
-                continue
-            chron = sorted(members, key=lambda m: m["start_date"])
-            paces = [
-                float(m["average_pace_min_per_km"])
-                for m in chron
-                if m["average_pace_min_per_km"] is not None
-            ]
-            routes.append(
-                {
-                    "route_key": f"{lat},{lon},{bucket}",
-                    "start_latitude": lat,
-                    "start_longitude": lon,
-                    "distance_km": bucket,
-                    "run_count": len(members),
-                    "first_date": chron[0]["start_date"],
-                    "last_date": chron[-1]["start_date"],
-                    "best_pace_min_per_km": round(min(paces), 2) if paces else None,
-                    "avg_pace_min_per_km": round(sum(paces) / len(paces), 2) if paces else None,
-                    "pace_series": [round(p, 2) for p in paces],
-                }
-            )
+            for route in self._split_group(members, lat, lon, bucket, polylines, use_shape):
+                if route["run_count"] >= min_runs:
+                    routes.append(route)
 
         routes.sort(key=lambda x: x["run_count"], reverse=True)
         return routes
+
+    def _split_group(
+        self,
+        members: list[dict[str, Any]],
+        lat: float,
+        lon: float,
+        bucket: float,
+        polylines: dict[str, str],
+        use_shape: bool,
+    ) -> list[dict[str, Any]]:
+        """One coarse (cell, distance) group -> the route rows it really holds.
+
+        Without shape data that's the single legacy row. With it, one row per
+        family, each carrying its variants. The route_key is suffixed with the
+        family's earliest run id so it stays stable as long as that run keeps
+        anchoring the family — the row's position in the list is not stable and
+        must never be used as an identity.
+        """
+        base_key = f"{lat},{lon},{bucket}"
+        if not use_shape or len(members) > MAX_CLUSTER_MEMBERS:
+            return [self._summarize_route(members, base_key, lat, lon, bucket)]
+
+        fingerprints = [
+            fingerprint(decode_polyline(polylines[m["id"]]))
+            if m["id"] in polylines
+            else frozenset()
+            for m in members
+        ]
+        out: list[dict[str, Any]] = []
+        for family in families_and_variants(fingerprints):
+            flat = [members[i] for variant in family for i in variant]
+            anchor = min(m["id"] for m in flat)
+            route = self._summarize_route(flat, f"{base_key}#{anchor}", lat, lon, bucket)
+            route["run_ids"] = [m["id"] for m in flat]
+            route["variants"] = [
+                self._summarize_route(
+                    [members[i] for i in variant],
+                    f"{base_key}#{min(members[i]['id'] for i in variant)}",
+                    lat,
+                    lon,
+                    bucket,
+                )
+                for variant in sorted(family, key=len, reverse=True)
+            ]
+            for variant, summary in zip(
+                sorted(family, key=len, reverse=True), route["variants"], strict=True
+            ):
+                summary["run_ids"] = [members[i]["id"] for i in variant]
+            out.append(route)
+        return out
 
     def get_route_for_run(
         self,
@@ -546,28 +636,52 @@ class RunsRepository:
         distance_km: float,
         precision: int = 2,
         dist_bucket_km: float = 0.5,
+        run_id: str | None = None,
+        use_shape: bool = False,
     ) -> dict[str, Any] | None:
-        """The route a given run belongs to, with its count + rank (SB-296).
+        """The route a given run belongs to, with its count + rank (SB-297).
 
         Reuses the leaderboard grouping so the route-card can show "run N times,
         #k of M" for a single activity. Returns None if the run has no GPS start
         (nothing to group on).
+
+        With ``use_shape`` the row is a route family, so the run is located by
+        id rather than by coordinates — several families share one (cell,
+        distance) key and only membership says which one this run traced. Adds
+        ``variant_run_count`` (how many times this exact version was run) beside
+        the family's ``run_count``. Falls back to the coordinate match when no
+        ``run_id`` is given.
         """
         board = self.get_route_leaderboard(
-            user_id, min_runs=1, precision=precision, dist_bucket_km=dist_bucket_km
+            user_id,
+            min_runs=1,
+            precision=precision,
+            dist_bucket_km=dist_bucket_km,
+            use_shape=use_shape,
         )
         lat = round(float(start_latitude), precision)
         lon = round(float(start_longitude), precision)
         bucket = round(round(float(distance_km) / dist_bucket_km) * dist_bucket_km, 3)
         key = f"{lat},{lon},{bucket}"
+
         for rank, route in enumerate(board, start=1):
-            if route["route_key"] == key:
-                return {
-                    "run_count": route["run_count"],
-                    "rank": rank,
-                    "total_routes": len(board),
-                    "best_pace_min_per_km": route["best_pace_min_per_km"],
-                }
+            if run_id is not None and use_shape:
+                if run_id not in route.get("run_ids", ()):
+                    continue
+            elif route["route_key"] != key:
+                continue
+            found = {
+                "run_count": route["run_count"],
+                "rank": rank,
+                "total_routes": len(board),
+                "best_pace_min_per_km": route["best_pace_min_per_km"],
+            }
+            for variant in route.get("variants", ()):
+                if run_id is not None and run_id in variant.get("run_ids", ()):
+                    found["variant_run_count"] = variant["run_count"]
+                    found["variant_best_pace_min_per_km"] = variant["best_pace_min_per_km"]
+                    break
+            return found
         return None
 
     def get_conditions_penalty(


### PR DESCRIPTION
Fixes SB-394

## Problem

Route identity is `(start cell rounded to ~1.1 km, distance bucket)`. For a home-based runner that collapses to **distance alone** — every route leaves the same cell, so "the 5.5 km route" just means "any 5.5 km run from home".

Measured against prod (4,209 GPS runs, read-only pull): the top row claims **1009 runs**. Clustering the 403 runs that already have stored polylines shows the longer home buckets each hold several genuinely different paths:

| Start cell | Bucket | Tracked | Distinct shapes |
|---|---|---|---|
| home | 10.5 km | 11 | **6** |
| home | 11.5 km | 9 | **5** |
| 42.42, -71.26 | 8.0 km | 44 | 1 |

Low-density start cells were always fine. The home cell — most of the history — was not.

## Approach

A track becomes the set of ~150 m grid cells its path passes through; two runs match when their sets overlap (Jaccard). Sets have no direction, so a loop run backwards matches for free, and a detour costs similarity in proportion to its length.

Douglas-Peucker leaves a straight kilometre as two points, so segments are walked in sub-cell steps rather than sampled at vertices — otherwise fingerprints are full of holes exactly where two routes run together.

**Two levels**, because "is this the same route?" has two right answers when several routes are slight variations of each other (which is this user's actual situation — 3-4 variations from the house):

```
family  (>=0.5 overlap) - "my 5.5 from home", variations counted together
variant (>=0.8 overlap) - the specific version, nested inside the family
```

Single-link via union-find at both levels, so variants always nest inside their family and the counts add up. Single-link rather than first-match-wins: otherwise the result depends on input order.

## Thresholds

Swept over the 403 real tracks. Pairwise similarity is cleanly bimodal — heavy mass at >=0.8 (same route, different day), a spread below 0.6 (different routes), trough at 0.4-0.5. Family sits in the trough, variant inside the dense mass.

Provisional: the sample is the oldest ~10% of history (backfill runs oldest-first), so re-sweep once SB-310 drains.

## Off by default

`use_shape=False` / `?shape=true` opt-in. Only ~10% of runs have a polyline right now; untracked runs can't be shape-matched and fall back to standing alone, which would understate counts if this were the default. Flip it when the backfill finishes (~8 days) and re-sweep.

The opt-in query param means the real output can be eyeballed against prod before that.

## Also

- `get_route_for_run` gains a `run_id` lookup — several families now share one `(cell, distance)` key, so only membership says which one a run traced. Returns family `run_count` plus `variant_run_count`.
- `/runs/routes` strips `run_ids` from the payload (internal lookup aid; tens of KB of UUIDs otherwise).
- Groups over 2,000 members skip clustering (it's O(n^2)) and fall back to the coarse key.

## Test

- `uv run --project backend python -m pytest backend/tests/ -q` -> **310 passed**
- 9 new unit tests on the clustering module (reverse-direction match, single-link chaining is order-independent, variants nest and sum, empty fingerprints never match)
- 5 new repository/endpoint tests (shape splits a coarse group, variants nest, untracked runs still appear, `get_route_for_run` by id, endpoint strips `run_ids`)
- ruff lint + format clean; mypy shows no new errors (same 8 pre-existing as `main`)

## Follow-up

SB-395 (web route badge) stays blocked until this is switched on — that's what makes the count it renders trustworthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)