### PR TITLE
feat(web): route frequency card on run detail (SB-395)

### DIFF
--- a/backend/routes/runs.py
+++ b/backend/routes/runs.py
@@ -12,6 +12,7 @@ from backend.routes.sync import _resolve_access_token
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 from src.shared.geo import simplify_and_encode
+from src.shared.route_shape import SHAPE_GROUPING_ENABLED
 from src.shared.smashrun import SmashRunAPIClient
 from src.shared.supabase_client import get_supabase_client
 from src.shared.supabase_ops import RunsRepository, TokenRepository
@@ -264,7 +265,9 @@ async def _routes(user_id: UUID, min_runs: int, shape: bool) -> dict[str, Any]:
 async def route_leaderboard(
     user_id: UUID = Depends(authenticate_request),
     min_runs: int = Query(2, ge=1, le=100, description="Only routes run at least this many times"),
-    shape: bool = Query(False, description="Group by GPS track shape instead of start cell"),
+    shape: bool = Query(
+        SHAPE_GROUPING_ENABLED, description="Group by GPS track shape instead of start cell"
+    ),
 ) -> dict[str, Any]:
     """Repeated-route leaderboard (SB-291): GPS runs grouped by start cell +
     distance bucket, sorted by run count. Answers "how many times have I run
@@ -336,7 +339,11 @@ async def _track(user_id: UUID, activity_id: str) -> dict[str, Any]:
             pass
 
     # How many times this route has been run (count + rank), so the card can say
-    # "run N times, #k of M" (SB-296). Needs the run's own start coords.
+    # "run N times, #k of M" (SB-297). Needs the run's own start coords.
+    #
+    # The polyline was just stored above, so a run whose map is being opened for
+    # the first time is shape-matchable by the time we group (SB-395) — no
+    # "1 run of this route" on a freshly synced run.
     route = None
     run_lat, run_lon, run_dist = (
         run.get("start_latitude"),
@@ -345,7 +352,12 @@ async def _track(user_id: UUID, activity_id: str) -> dict[str, Any]:
     )
     if run_lat is not None and run_lon is not None and run_dist is not None:
         route = RunsRepository(supabase).get_route_for_run(
-            user_id, float(run_lat), float(run_lon), float(run_dist)
+            user_id,
+            float(run_lat),
+            float(run_lon),
+            float(run_dist),
+            run_id=run["id"],
+            use_shape=SHAPE_GROUPING_ENABLED,
         )
 
     return {

--- a/frontend/src/components/RouteFrequency.vue
+++ b/frontend/src/components/RouteFrequency.vue
@@ -1,0 +1,63 @@
+<template>
+  <div
+    v-if="visible"
+    class="bg-white rounded-xl border border-gray-100 shadow-sm p-6 mt-4"
+    data-testid="route-frequency"
+  >
+    <div class="flex items-start justify-between flex-wrap gap-3">
+      <div>
+        <h2 class="font-semibold text-gray-900">You've run this route</h2>
+        <p class="text-xs text-gray-400 mt-0.5">
+          #{{ route!.rank }} of {{ route!.total_routes }} routes by how often you run it
+        </p>
+      </div>
+      <p class="text-3xl font-bold text-gray-900">
+        {{ route!.run_count }}<span class="text-base font-normal text-gray-400"> times</span>
+      </p>
+    </div>
+
+    <div class="grid grid-cols-2 gap-3 mt-5">
+      <div class="bg-gray-50 rounded-lg px-4 py-3">
+        <p class="text-xs text-gray-500">This version</p>
+        <p class="text-lg font-semibold text-gray-900">
+          {{ route!.variant_run_count }}<span class="text-xs font-normal text-gray-400"> of {{ route!.run_count }}</span>
+        </p>
+      </div>
+      <div class="bg-gray-50 rounded-lg px-4 py-3">
+        <p class="text-xs text-gray-500">Best on this route</p>
+        <p class="text-lg font-semibold text-gray-900">{{ formatPace(route!.best_pace_min_per_km, unit) }}</p>
+      </div>
+    </div>
+
+    <p v-if="variantNote" class="text-xs text-gray-500 mt-3">{{ variantNote }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { RunRoute, Unit } from '@/types/runs'
+import { formatPace } from '@/utils/format'
+
+const props = defineProps<{ route?: RunRoute | null; unit: Unit }>()
+
+/**
+ * Only shown when the count means what it says.
+ *
+ * variant_run_count is present only when the backend identified the route by
+ * the path it traced (SB-396). Without that, run_count lumps together every run
+ * of roughly this distance starting near here — for a home-based runner that's
+ * several different routes, so "you've run this 1009 times" would be a real
+ * number answering a question nobody asked. A route run once isn't a repeat
+ * either, so it stays hidden too.
+ */
+const visible = computed(
+  () => props.route != null && props.route.variant_run_count != null && props.route.run_count > 1,
+)
+
+/** Names the family/variant split, but only when there is one to explain. */
+const variantNote = computed(() => {
+  const r = props.route
+  if (!r?.variant_run_count || r.variant_run_count >= r.run_count) return null
+  return `Counts your slight variations of this route together — you've run this exact version ${r.variant_run_count} time${r.variant_run_count === 1 ? '' : 's'}.`
+})
+</script>

--- a/frontend/src/components/__tests__/RouteFrequency.test.ts
+++ b/frontend/src/components/__tests__/RouteFrequency.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import RouteFrequency from '../RouteFrequency.vue'
+import type { RunRoute } from '@/types/runs'
+
+const shaped: RunRoute = {
+  run_count: 189,
+  rank: 1,
+  total_routes: 27,
+  best_pace_min_per_km: 5.04,
+  variant_run_count: 41,
+  variant_best_pace_min_per_km: 5.1,
+}
+
+const mountIt = (route: RunRoute | null | undefined) =>
+  mount(RouteFrequency, { props: { route, unit: 'mi' } })
+
+describe('RouteFrequency', () => {
+  it('shows the family count, rank and variant split', () => {
+    const text = mountIt(shaped).text()
+    expect(text).toContain('189')
+    expect(text).toContain('#1 of 27 routes')
+    expect(text).toContain('41')
+    expect(text).toContain('8:07 /mi') // 5.04 min/km
+    expect(text).toContain("you've run this exact version 41 times")
+  })
+
+  it('renders nothing when the run has no route (treadmill / no GPS)', () => {
+    expect(mountIt(null).find('[data-testid="route-frequency"]').exists()).toBe(false)
+    expect(mountIt(undefined).find('[data-testid="route-frequency"]').exists()).toBe(false)
+  })
+
+  it('renders nothing for a route run only once', () => {
+    const once: RunRoute = { ...shaped, run_count: 1, variant_run_count: 1 }
+    expect(mountIt(once).find('[data-testid="route-frequency"]').exists()).toBe(false)
+  })
+
+  it('renders nothing without shape data, where run_count is not a route count', () => {
+    // Coarse start-cell grouping: no variant_run_count. 1009 "runs of this
+    // route" would really be every run of this distance from this area.
+    const coarse = { run_count: 1009, rank: 1, total_routes: 207, best_pace_min_per_km: 5.04 }
+    expect(mountIt(coarse).find('[data-testid="route-frequency"]').exists()).toBe(false)
+  })
+
+  it('drops the variant note when every run used the same version', () => {
+    const single: RunRoute = { ...shaped, run_count: 12, variant_run_count: 12 }
+    const text = mountIt(single).text()
+    expect(text).toContain('12')
+    expect(text).not.toContain('exact version')
+  })
+})

--- a/frontend/src/types/runs.ts
+++ b/frontend/src/types/runs.ts
@@ -171,6 +171,22 @@ export interface RunDetail {
 
 export type AudioType = 'podcast' | 'music' | 'audiobook' | 'other' | 'none'
 
+/** How often this run's route has been run, and where it ranks (SB-395).
+ *
+ * variant_* only appear once the backend groups by track shape (SB-396) — with
+ * the coarse start-cell grouping, run_count counts every run of that distance
+ * from that area, which is not a route. The UI keys off their presence.
+ */
+export interface RunRoute {
+  run_count: number
+  rank: number
+  total_routes: number
+  best_pace_min_per_km: number | null
+  /** Runs of this exact version of the route (the family holds several). */
+  variant_run_count?: number
+  variant_best_pace_min_per_km?: number | null
+}
+
 /** Per-point GPS track + aligned metric series for the route map (SB-298). */
 export interface RunTrack {
   activity_id: string
@@ -189,6 +205,7 @@ export interface RunTrack {
   avg_pace_min_per_km: number | null
   weather_type: string | null
   temperature_celsius: number | null
+  route?: RunRoute | null
 }
 
 /** Hot+humid pace penalty from the user's own history (SB-304). */

--- a/frontend/src/views/RunDetailView.vue
+++ b/frontend/src/views/RunDetailView.vue
@@ -63,6 +63,8 @@
 
       <RouteMap v-if="track && track.has_track" :track="track" :unit="unit" />
 
+      <RouteFrequency :route="track?.route" :unit="unit" />
+
       <div v-if="run.splits.length > 0" class="bg-white rounded-xl border border-gray-100 shadow-sm p-6 mt-4">
         <h2 class="font-semibold text-gray-900 mb-1">{{ splitNoun }} splits</h2>
         <p class="text-xs text-gray-400 mb-3">fastest split highlighted</p>
@@ -121,6 +123,7 @@ import { useConditionsPenalty } from '@/composables/useConditionsPenalty'
 import { useUserPreferences } from '@/composables/useUserPreferences'
 import { formatDate, formatDistance, formatDuration, formatPace, distanceLabel } from '@/utils/format'
 import RouteMap from '@/components/RouteMap.vue'
+import RouteFrequency from '@/components/RouteFrequency.vue'
 import AudioLog from '@/components/AudioLog.vue'
 
 const KM_PER_MI = 1.609344

--- a/src/shared/route_shape.py
+++ b/src/shared/route_shape.py
@@ -42,6 +42,12 @@ VARIANT_OVERLAP = 0.8
 # rather than burning seconds on a request. No real route hits this.
 MAX_CLUSTER_MEMBERS = 2000
 
+# The single switch for shape-based route identity. Off until the SB-310
+# polyline backfill drains — a run with no stored track can't be matched and
+# would stand alone, understating every count. Flipping this to True is SB-396;
+# consumers read it rather than hard-coding a default, so it's a one-line change.
+SHAPE_GROUPING_ENABLED = False
+
 Cell = tuple[int, int]
 Fingerprint = frozenset[Cell]
 


### PR DESCRIPTION
Fixes SB-395

## Problem

"How many times have I run this route" was answerable only in the terminal (`stk route show`). The web run-detail page had the interactive map (SB-299) but no count — and the API had been returning a `route` object on `GET /runs/{id}/track` the whole time, which the frontend never read.

## What ships

A `RouteFrequency` card under the map: times run, rank among all routes, how many of those used this exact version, and best pace on the route.

## It is deliberately invisible today

The card renders only when the backend grouped by **track shape**, which it doesn't yet — `SHAPE_GROUPING_ENABLED` stays off until the SB-310 polyline backfill drains (SB-396 flips it).

The gate is the presence of `variant_run_count`. With the current start-cell grouping, `run_count` lumps together every run of roughly this distance starting near here — **1009** for this user, which the stored polylines show is several different routes. "You've run this 1009 times" would be a real number answering a question nobody asked.

So rather than ship a wrong count and correct it in a second PR, the card stays hidden and appears on its own the moment shape grouping goes on. No follow-up frontend work needed.

Also hidden when `route` is null (treadmill / no GPS) and when the route was run only once.

## Backend

`/runs/{id}/track` now passes the run id and the shape flag through to `get_route_for_run`, so it can return family + variant counts. The run id matters because several families share one `(cell, distance)` key once shape grouping is on — only membership says which one a run traced.

Ordering note: the polyline is stored earlier in the same handler, so a freshly synced run is already shape-matchable by the time it's grouped. No "1 run of this route" on a run whose map you just opened.

## Copy

Leads with the family count (slight variations of the same route counted together — this user has 3-4 from the house) and explains the split underneath, only when there is one:

> Counts your slight variations of this route together — you've run this exact version 41 times.

## Test

- `npm test` -> **260 passed** (5 new)
- `npm run type-check` clean, `npm run build` clean
- `uv run --project backend python -m pytest backend/tests/ -q` -> **310 passed**
- New cases: renders count/rank/variant/pace; hidden with no route; hidden at one run; hidden without shape data; variant note dropped when every run used the same version

Not verified in a running app — the card is gated off, so there is nothing to see until SB-396. The markup is covered by the component tests.

## Known gap (separate)

New runs get a polyline only from store-on-read or the backfill cron, which is oldest-first — so a freshly synced run has no track until the backlog drains (~Aug 4) unless you open it. Affects `stk routes`, not this card. Worth a small sync-time forward-fill, mirroring how splits already work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)