### PR TITLE
perf(backfill): 2400 polylines/day to drain the backlog (SB-310)

### DIFF
--- a/helm/myrunstreak/values.yaml
+++ b/helm/myrunstreak/values.yaml
@@ -130,13 +130,23 @@ backend:
           memory: 256Mi
     backfillTracks:
       enabled: true
-      # Every 6h at 00/06/12/18 UTC — clear of the syncs (14:00, 17:00) and the
-      # plan recompute (08:00). batchLimit runs per pass x 4 passes = 500/day,
-      # and each pass stays well under SmashRun's 250 req/hr: one 500-run burst
-      # would finish in ~6 min and get rate-limited halfway (SB-310).
-      # Store-on-read fills viewed runs in the meantime.
-      schedule: "0 0,6,12,18 * * *"
-      batchLimit: 125
+      # Every 2h — batchLimit per pass x 12 passes = 2400/day, draining the
+      # ~3,700-run backlog in ~1.5 days instead of a week (SB-310).
+      #
+      # SmashRun's ~250 req/hr is a *rolling hour*, so exposure is the pass size,
+      # not the daily total: 200 in one ~2.5 min pass, then nothing for 2h. That
+      # leaves more headroom than 250-per-pass would while running 2.4x faster.
+      # Keep passes <= 200 and >= 2h apart if this is tuned again.
+      #
+      # 14:00 and 17:00 collide with the sync, the only other SmashRun caller.
+      # A sync is a handful of requests plus inline splits for the day's run, so
+      # the worst rolling hour is ~210 — still inside the cap.
+      #
+      # This cadence is for draining the backlog. Once it's done, one new run a
+      # day needs nothing like this — drop back to a single small daily pass
+      # (SB-396). Store-on-read fills viewed runs in the meantime.
+      schedule: "0 */2 * * *"
+      batchLimit: 200
       resources:
         requests:
           cpu: 50m


### PR DESCRIPTION
## Why

3,678 runs still lack a stored polyline. At the current 500/day that's ~7.4 days, and SB-396 (turning on shape-based route identity, which lights up the SB-395 web card) can't start until it's done.

## The change

| | Per day | Peak rolling hour | Drains in |
|---|---|---|---|
| now: 125 x 4 (6h) | 500 | 125 | ~7.4 days |
| **this: 200 x 12 (2h)** | **2400** | **200** | **~1.5 days** |
| 250 x 4 (6h) | 1000 | 250 | ~3.7 days |

SmashRun's ~250 req/hr is a **rolling-hour** limit, so exposure is the size of a single pass, not the daily total — 200 requests in ~2.5 minutes, then nothing for two hours. That makes this both 2.4x faster than today *and* lower-peaking than the 250-per-pass alternative.

## Headroom check

Worst rolling hour is 14:00 and 17:00, where the daily sync also calls SmashRun — a handful of requests plus inline splits for the day's run, so ~210 total. Inside the cap.

Pass runtime scales fine: the last 125-run pass took 89s, so 200 is ~145s against the existing `activeDeadlineSeconds: 900`.

If this gets tuned again, the rule is: keep passes <= 200 and >= 2h apart.

## Temporary by design

This cadence exists to drain the backlog. Once it's clear, one new run a day needs nothing like it — dropping back to a single small daily pass is a step in SB-396.

## Caveats

The 250/hr figure comes from a comment in this repo, not from SmashRun docs I verified. If we do hit 429s, the job catches failures per-run and retries them on the next pass, so it self-heals rather than breaking.

## Test

`helm template` renders `schedule: "0 */2 * * *"` and `BACKFILL_TRACKS_BATCH_LIMIT: "200"`. Values-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)