### PR TITLE
fix: page past PostgREST's 1000-row cap in 3 full-history scans (SB-397)

### DIFF
--- a/backend/tests/test_track_pagination.py
+++ b/backend/tests/test_track_pagination.py
@@ -41,6 +41,12 @@ class _RangeCappedTable:
     def order(self, *_a: Any, **_k: Any) -> _RangeCappedTable:
         return self
 
+    def gte(self, *_a: Any, **_k: Any) -> _RangeCappedTable:
+        return self
+
+    def lte(self, *_a: Any, **_k: Any) -> _RangeCappedTable:
+        return self
+
     def range(self, lo: int, hi: int) -> _RangeCappedTable:
         self._lo, self._hi = lo, min(hi, lo + PAGE - 1)  # server caps span at 1000
         return self
@@ -67,6 +73,71 @@ def test_get_all_track_polylines_returns_more_than_one_page() -> None:
     assert len(out) == 2500  # not truncated to 1000
     assert out[0]["polyline"] == "p0"
     assert out[-1]["polyline"] == "p2499"
+
+
+def test_route_leaderboard_counts_the_whole_history() -> None:
+    """SB-397: the leaderboard grouped only the first 1000 runs.
+
+    Live symptom: `stk routes` reported 204 runs for a route with 1009, because
+    4,209 GPS runs were silently truncated to a PostgREST page.
+    """
+    same_route = [
+        {
+            "id": f"r{i}",
+            "start_latitude": 42.244,
+            "start_longitude": -71.651,
+            "distance_km": 5.5,
+            "average_pace_min_per_km": 5.5,
+            "start_date": "2020-01-01",
+        }
+        for i in range(2400)
+    ]
+    repo = RunsRepository(_Supabase({"runs": same_route}))  # type: ignore[arg-type]
+
+    routes = repo.get_route_leaderboard(USER, min_runs=2)
+    assert len(routes) == 1
+    assert routes[0]["run_count"] == 2400  # not 1000
+
+
+def test_conditions_penalty_sees_the_whole_history() -> None:
+    """SB-397: the steamy-pace comparison also stopped at 1000 runs."""
+    # 1200 cool runs first, so a truncated scan would never reach the steamy ones.
+    rows = [
+        {
+            "average_pace_min_per_km": 6.0,
+            "temperature_celsius": 10.0,
+            "humidity_percent": 40.0,
+            "start_date": "2020-01-01",
+        }
+        for _ in range(1200)
+    ] + [
+        {
+            "average_pace_min_per_km": 7.0,
+            "temperature_celsius": 30.0,
+            "humidity_percent": 85.0,
+            "start_date": "2021-01-01",
+        }
+        for _ in range(50)
+    ]
+    repo = RunsRepository(_Supabase({"runs": rows}))  # type: ignore[arg-type]
+
+    got = repo.get_conditions_penalty(USER)
+    assert got is not None
+    assert got["steamy_run_count"] == 50  # invisible to a capped scan
+    assert got["baseline_run_count"] == 1200
+
+
+def test_summarize_runs_aggregates_past_one_page() -> None:
+    """SB-397: 'aggregate the FULL filtered set' stopped at 1000 rows."""
+    rows = [
+        {"distance_km": 5.0, "average_pace_min_per_km": 6.0, "start_date": "2020-01-01"}
+        for _ in range(1500)
+    ]
+    repo = RunsRepository(_Supabase({"runs": rows}))  # type: ignore[arg-type]
+
+    out = repo.summarize_runs(USER)
+    assert out["count"] == 1500  # not 1000
+    assert out["total_km"] == 7500.0
 
 
 def test_missing_tracks_count_spans_full_history() -> None:

--- a/src/shared/supabase_ops/runs_repository.py
+++ b/src/shared/supabase_ops/runs_repository.py
@@ -355,20 +355,34 @@ class RunsRepository:
     def summarize_runs(self, user_id: UUID, **filters: Any) -> dict[str, Any]:
         """Aggregate the FULL filtered set (SB-269 conditions impact): count,
         total km, and distance-weighted avg pace. Fetches only two columns."""
-        query = (
-            self.supabase.table("runs")
-            .select("distance_km,average_pace_min_per_km")
-            .eq("user_id", str(user_id))
-        )
-        query = self._apply_run_filters(
-            query,
-            filters.pop("date_from", None),
-            filters.pop("date_to", None),
-            filters.pop("distance_min", None),
-            filters.pop("distance_max", None),
-            **filters,
-        )
-        rows = cast(list[dict[str, Any]], query.limit(10000).execute().data)
+
+        def page(off: int, size: int) -> list[dict[str, Any]]:
+            query = (
+                self.supabase.table("runs")
+                .select("distance_km,average_pace_min_per_km")
+                .eq("user_id", str(user_id))
+            )
+            query = self._apply_run_filters(
+                query,
+                filters.get("date_from"),
+                filters.get("date_to"),
+                filters.get("distance_min"),
+                filters.get("distance_max"),
+                **{
+                    k: v
+                    for k, v in filters.items()
+                    if k not in ("date_from", "date_to", "distance_min", "distance_max")
+                },
+            )
+            return cast(
+                list[dict[str, Any]],
+                query.order("start_date", desc=False)  # stable paging needs a total order
+                .range(off, off + size - 1)
+                .execute()
+                .data,
+            )
+
+        rows = self._paginate(page)
         total_km = 0.0
         weighted = 0.0
         paced_km = 0.0
@@ -546,19 +560,25 @@ class RunsRepository:
             pace_series (chronological avg pace per run, for a sparkline), and
             with use_shape also variants (the same shape, one level down).
         """
-        result = (
-            self.supabase.table("runs")
-            .select(
-                "id, start_latitude, start_longitude, distance_km, "
-                "average_pace_min_per_km, start_date"
+
+        def page(off: int, size: int) -> list[dict[str, Any]]:
+            return cast(
+                list[dict[str, Any]],
+                self.supabase.table("runs")
+                .select(
+                    "id, start_latitude, start_longitude, distance_km, "
+                    "average_pace_min_per_km, start_date"
+                )
+                .eq("user_id", str(user_id))
+                .not_.is_("start_latitude", "null")
+                .not_.is_("start_longitude", "null")
+                .order("start_date", desc=False)  # stable paging needs a total order
+                .range(off, off + size - 1)
+                .execute()
+                .data,
             )
-            .eq("user_id", str(user_id))
-            .not_.is_("start_latitude", "null")
-            .not_.is_("start_longitude", "null")
-            .limit(10000)
-            .execute()
-        )
-        rows = cast(list[dict[str, Any]], result.data)
+
+        rows = self._paginate(page)
 
         groups: dict[tuple[float, float, float], list[dict[str, Any]]] = {}
         for r in rows:
@@ -701,15 +721,21 @@ class RunsRepository:
         Returns the penalty in seconds/mile plus the run counts, or None if
         there aren't enough steamy runs to be meaningful.
         """
-        result = (
-            self.supabase.table("runs")
-            .select("average_pace_min_per_km, temperature_celsius, humidity_percent")
-            .eq("user_id", str(user_id))
-            .not_.is_("average_pace_min_per_km", "null")
-            .limit(10000)
-            .execute()
-        )
-        rows = cast(list[dict[str, Any]], result.data)
+
+        def page(off: int, size: int) -> list[dict[str, Any]]:
+            return cast(
+                list[dict[str, Any]],
+                self.supabase.table("runs")
+                .select("average_pace_min_per_km, temperature_celsius, humidity_percent")
+                .eq("user_id", str(user_id))
+                .not_.is_("average_pace_min_per_km", "null")
+                .order("start_date", desc=False)  # stable paging needs a total order
+                .range(off, off + size - 1)
+                .execute()
+                .data,
+            )
+
+        rows = self._paginate(page)
 
         steamy: list[float] = []
         baseline: list[float] = []


### PR DESCRIPTION
Fixes SB-397

## How it surfaced

`stk routes --min-runs 20` reported **204** runs for the top home route. The same grouping, run locally over a complete pull of prod, gave **1009**.

## Cause

`.limit(10000)` does not defeat PostgREST's response cap. Verified against prod:

```
GET /rest/v1/runs?...&limit=10000  ->  1000 rows
```

With 4,209 GPS runs, the leaderboard was grouping 1,000 of them — and with no `.order()`, not even a defined 1,000. `204/1009 ≈ 1000/4209`; the ratio gives it away.

`RunsRepository._paginate` exists for exactly this and documents the cap in its docstring. These call sites just didn't use it.

## Fixed

| Method | Impact |
|---|---|
| `get_route_leaderboard` | route counts ~4x low; `get_route_for_run`, `stk route show` and SB-395's card all inherit it |
| `get_conditions_penalty` | SB-304 hot+humid penalty computed from an arbitrary 1,000 runs |
| `summarize_runs` | docstring says "aggregate the FULL filtered set" — wrong for any filter matching >1,000 runs |

Each also gets an explicit `.order()`: range-based paging without a total order can repeat or skip rows between pages.

## Left alone (deliberately)

`get_user_overall_stats` and `get_current_streak` also carry `.limit(10000)`, but both call an RPC first and only fall back to a capped client-side scan, with the limit called out in a comment. `get_runs_by_date_range` is bounded by its date range — still capped for very wide ranges, worth a look but not urgent.

## Verified against prod (read-only)

| | Before | After |
|---|---|---|
| Top route | 204 runs | **1009** |
| Routes with >=20 runs | 13 | **25** |
| Conditions penalty sample | <=1000 runs | 162 steamy / 4618 baseline -> 23 s/mi |

Heads up: the hot+humid penalty shown in the app will shift, since it was previously computed on a truncated sample.

## Test

`uv run --project backend python -m pytest backend/tests/ -q` -> **313 passed** (3 new).

The new tests use the existing fake that honours `.range()` and caps a page at 1000 rows, so a truncating query fails rather than silently passing. The conditions-penalty case puts 1,200 cool runs ahead of 50 steamy ones, so a capped scan would never reach the data it needs.

## Context

Same bug class as SB-209 (streaks) and SB-312 (track queries), each fixed in isolation at the time rather than swept. This sweep covers the remaining unprotected full-history scans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)