### PR TITLE
fix: reject an invalid weather_type with 422, not 500 (SB-275)

### DIFF
--- a/backend/routes/runs.py
+++ b/backend/routes/runs.py
@@ -16,6 +16,7 @@ from src.shared.route_shape import SHAPE_GROUPING_ENABLED
 from src.shared.smashrun import SmashRunAPIClient
 from src.shared.supabase_client import get_supabase_client
 from src.shared.supabase_ops import RunsRepository, TokenRepository
+from src.shared.supabase_ops.mappers import WeatherType
 
 router = APIRouter(prefix="/runs", tags=["runs"])
 
@@ -138,7 +139,9 @@ async def list_runs(
     date_to: date | None = Query(None, description="Runs on/before this date (inclusive)"),
     distance_min: float | None = Query(None, ge=0, description="Min distance in km"),
     distance_max: float | None = Query(None, ge=0, description="Max distance in km"),
-    weather_type: str | None = Query(None, description="Exact weather condition"),
+    # Validated against the Postgres enum: an unknown value used to reach
+    # PostgREST, fail the cast and surface as a 500 (SB-275).
+    weather_type: WeatherType | None = Query(None, description="Exact weather condition"),
     temp_min: float | None = Query(None, description="Min temperature (C)"),
     temp_max: float | None = Query(None, description="Max temperature (C)"),
     pace_min: float | None = Query(None, ge=0, description="Min pace (min/km) — slower bound"),
@@ -188,7 +191,7 @@ async def runs_summary(
     date_to: date | None = Query(None),
     distance_min: float | None = Query(None, ge=0),
     distance_max: float | None = Query(None, ge=0),
-    weather_type: str | None = Query(None),
+    weather_type: WeatherType | None = Query(None),
     temp_min: float | None = Query(None),
     temp_max: float | None = Query(None),
     pace_min: float | None = Query(None, ge=0),

--- a/backend/tests/test_weather_filter_validation.py
+++ b/backend/tests/test_weather_filter_validation.py
@@ -1,0 +1,87 @@
+"""SB-275: an invalid weather_type must be rejected, not 500.
+
+weather_type is a Postgres enum. An unknown value used to reach PostgREST,
+fail the cast, and surface as an unhandled 500 — e.g. `stk summary --weather
+rain` (the valid value is `rainy`).
+
+The existing filter tests (test_run_filters.py) cover the repository layer with
+valid input only, so nothing exercised the route with a bad value.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+from src.shared.supabase_ops.mappers import WEATHER_TYPE_MAP, WEATHER_TYPES
+
+USER_ID = UUID("00000000-0000-0000-0000-0000000000cc")
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    from backend.app import create_app
+    from backend.auth import authenticate_request
+
+    app = create_app()
+    app.dependency_overrides[authenticate_request] = lambda: USER_ID
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.parametrize("endpoint", ["/runs", "/runs/summary"])
+def test_invalid_weather_type_is_422_not_500(client: TestClient, endpoint: str) -> None:
+    """The repro from the ticket: 'rain' is not the enum value 'rainy'."""
+    r = client.get(endpoint, params={"weather_type": "rain"})
+
+    assert r.status_code == 422, f"{endpoint} returned {r.status_code}"
+    # The rejection has to name the allowed values, or the caller is guessing.
+    assert "rainy" in r.text
+
+
+@pytest.mark.parametrize("endpoint", ["/runs", "/runs/summary"])
+def test_empty_string_is_rejected(client: TestClient, endpoint: str) -> None:
+    """An empty filter is a caller bug, not 'no filter' — don't cast it."""
+    assert client.get(endpoint, params={"weather_type": ""}).status_code == 422
+
+
+@pytest.mark.parametrize("endpoint", ["/runs", "/runs/summary"])
+def test_sql_injection_shaped_value_is_rejected(client: TestClient, endpoint: str) -> None:
+    assert (
+        client.get(endpoint, params={"weather_type": "rainy'; DROP TABLE runs;--"}).status_code
+        == 422
+    )
+
+
+def test_literal_matches_the_database_enum() -> None:
+    """The Literal must stay in step with the Postgres enum it validates.
+
+    Reads the migration rather than restating the values, so adding a weather
+    type in SQL without updating the Literal fails here instead of 500ing in
+    production.
+    """
+    import re
+    from pathlib import Path
+
+    migration = (
+        Path(__file__).resolve().parents[2]
+        / "supabase/migrations/20251119133437_initial_schema.sql"
+    )
+    sql = migration.read_text()
+    match = re.search(r"CREATE TYPE weather_type AS ENUM \(([^)]+)\)", sql)
+    assert match, "weather_type enum not found — did the migration move?"
+
+    in_db = {v.strip().strip("'") for v in match.group(1).split(",")}
+    assert in_db == set(WEATHER_TYPES), (
+        f"drift: only in DB {in_db - set(WEATHER_TYPES)}, only in code {set(WEATHER_TYPES) - in_db}"
+    )
+
+
+def test_mapper_only_ever_produces_valid_enum_values() -> None:
+    """Sync guard: a SmashRun mapping that emits a non-enum value would write a
+    row Postgres rejects — the same class of bug, one layer upstream.
+    """
+    produced = {v for v in WEATHER_TYPE_MAP.values() if v is not None}
+    assert produced <= set(WEATHER_TYPES), f"mapper emits unknown: {produced - set(WEATHER_TYPES)}"

--- a/src/shared/supabase_ops/mappers.py
+++ b/src/shared/supabase_ops/mappers.py
@@ -1,12 +1,18 @@
 """Data mappers for converting between API models and Supabase schema."""
 
-from typing import Any
+from typing import Any, Literal, get_args
 from uuid import UUID
 
 from ..models import Activity, Split
 
-# Map SmashRun weather types to database enum values
-# Database: 'sunny', 'cloudy', 'rainy', 'snowy', 'windy', 'hot', 'cold'
+# The Postgres `weather_type` enum
+# (supabase/migrations/20251119133437_initial_schema.sql:78). PostgREST fails
+# the cast on anything else, so callers must be validated against this rather
+# than passing a bare string through (SB-275).
+WeatherType = Literal["sunny", "cloudy", "rainy", "snowy", "windy", "hot", "cold"]
+WEATHER_TYPES: tuple[str, ...] = get_args(WeatherType)
+
+# Map SmashRun weather types to database enum values.
 WEATHER_TYPE_MAP: dict[str, str | None] = {
     "clear": "sunny",
     "cloudy": "cloudy",


### PR DESCRIPTION
Fixes SB-275

## Problem

`GET /runs?weather_type=rain` and `/runs/summary?weather_type=rain` returned **500**.

`weather_type` is a Postgres enum (`sunny, cloudy, rainy, snowy, windy, hot, cold`). Both handlers took a bare `str`, so an unknown value reached PostgREST, failed the enum cast, and surfaced as an unhandled error. Repro from the ticket: `stk summary --weather rain` — the valid value is `rainy`.

## Fix

Both handlers now take a `Literal` of the enum values, so FastAPI rejects the request with a **422 naming the allowed values** before anything touches the database.

The values previously existed only in a code comment above `WEATHER_TYPE_MAP`. This makes one source of truth — `WeatherType` and `WEATHER_TYPES` sit next to the map that produces them.

## Was this covered before?

No. `test_run_filters.py:41` tests the *repository* layer with a valid value (`weather_type="rainy"`), asserting the `eq` filter is built. Nothing exercised either route with a bad value, so the 500 had no coverage at all — and that existing test would still pass if the route accepted garbage, since it never reaches the route.

## Tests (8 new)

- The ticket's repro on **both** endpoints -> 422, and the response names `rainy`
- Empty string rejected — a blank filter is a caller bug, not "no filter"
- Injection-shaped value rejected
- **Drift guard:** the `Literal` is compared against the enum parsed out of `20251119133437_initial_schema.sql`, so adding a weather type in SQL without updating the code fails here rather than 500ing in production
- **Upstream guard:** `WEATHER_TYPE_MAP` is checked to only ever emit values the database accepts — the same bug class one layer up, where a bad mapping would write a row Postgres rejects

`uv run --project backend python -m pytest backend/tests/ -q` -> **321 passed**. ruff lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)