### PR TITLE
fix(exercises): normalized search + duplicate guard on create/publish (SB-454)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,12 @@ jobs:
         run: uv run ruff format --check src/ tests/
       - name: Run tests (coverage floor 60%)
         run: uv run pytest tests/ -q --cov-fail-under=60
+      # SB-454: the catalog's dedup strategy is search-first selection, so a name
+      # that its own search can't find is a latent duplicate. Parses the seeded
+      # rows out of the migrations — no database needed — and fails on identical
+      # names or colliding aliases.
+      - name: Exercise catalog audit
+        run: uv run python scripts/audit_exercise_catalog.py
       - name: Coverage summary
         if: always()
         run: |

--- a/backend/routes/workouts.py
+++ b/backend/routes/workouts.py
@@ -9,6 +9,7 @@ Tracker epic (SB-189).
 from __future__ import annotations
 
 from datetime import date
+from typing import Any
 from uuid import UUID
 
 from backend.admin import is_admin, require_athlete_access
@@ -71,14 +72,49 @@ def search_exercises(
     return [Exercise(**r) for r in rows]
 
 
+def _duplicate_conflict(candidates: list[dict[str, Any]], message: str) -> HTTPException:
+    return HTTPException(
+        status.HTTP_409_CONFLICT,
+        detail={
+            "message": message,
+            "candidates": [
+                {
+                    "key": c["key"],
+                    "display_name": c["display_name"],
+                    "visibility": c.get("visibility"),
+                    "aliases": c.get("aliases") or [],
+                }
+                for c in candidates
+            ],
+        },
+    )
+
+
 @router.post("/exercises", response_model=Exercise, status_code=status.HTTP_201_CREATED)
 def create_exercise(
     body: ExerciseCreate,
+    force: bool = False,
     user_id: UUID = Depends(authenticate_request),
 ) -> Exercise:
-    """Add a coach-owned exercise (private by default; publishable later)."""
+    """Add a coach-owned exercise (private by default; publishable later).
+
+    Guards against duplicates (SB-454): if the catalog already holds this
+    movement under any spelling, returns 409 with the candidates rather than
+    silently creating a second row under a `_2` slug. Pass ?force=true when it
+    genuinely is a distinct movement.
+    """
+    repo = ExercisesRepository(get_supabase_client())
+    if not force:
+        dups = repo.find_possible_duplicates(user_id, body.display_name, body.aliases)
+        if dups:
+            raise _duplicate_conflict(
+                dups,
+                "An exercise with this name already exists. Use it instead of "
+                "adding a second row for the same movement — or resubmit with "
+                "force=true if this is genuinely different.",
+            )
     payload = body.model_dump(exclude_none=True, mode="json")
-    row = ExercisesRepository(get_supabase_client()).create(user_id, payload)
+    row = repo.create(user_id, payload)
     return Exercise(**row)
 
 
@@ -102,10 +138,30 @@ def update_exercise(
 @router.post("/exercises/{key}/publish", response_model=Exercise)
 def publish_exercise(
     key: str,
+    force: bool = False,
     user_id: UUID = Depends(authenticate_request),
 ) -> Exercise:
-    """Promote an owned private exercise to the public library."""
-    row = ExercisesRepository(get_supabase_client()).publish(user_id, key)
+    """Promote an owned private exercise to the public library.
+
+    This is the publish-time near-duplicate warning the catalog migration
+    promised (SB-454): if the shared library already has this movement, 409 with
+    the candidates instead of adding a second public row. ?force=true overrides.
+    """
+    repo = ExercisesRepository(get_supabase_client())
+    if not force:
+        own = repo.get(key)
+        if own is not None:
+            dups = repo.find_possible_duplicates(
+                user_id, own["display_name"], own.get("aliases"), public_only=True
+            )
+            if dups:
+                raise _duplicate_conflict(
+                    dups,
+                    "The public library already has this movement. Publishing "
+                    "would create a second canonical row — resubmit with "
+                    "force=true if it is genuinely distinct.",
+                )
+    row = repo.publish(user_id, key)
     if row is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Exercise not found or not yours")
     return Exercise(**row)

--- a/backend/tests/test_exercise_catalog.py
+++ b/backend/tests/test_exercise_catalog.py
@@ -85,6 +85,7 @@ def test_create_exercise_returns_created() -> None:
         "visibility": "private",
         "owner_id": str(uid),
     }
+    repo.find_possible_duplicates.return_value = []
     body = ExerciseCreate(display_name="Goblet Squat", category="strength", measures=["reps"])
     with (
         patch("backend.routes.workouts.get_supabase_client"),
@@ -104,6 +105,7 @@ def test_publish_exercise_404_when_not_owned() -> None:
     uid = uuid4()
     repo = _repo()
     repo.publish.return_value = None
+    repo.get.return_value = None  # nothing to dup-check against
     with (
         patch("backend.routes.workouts.get_supabase_client"),
         patch("backend.routes.workouts.ExercisesRepository", return_value=repo),
@@ -202,3 +204,129 @@ def test_delete_exercise_404_when_not_owned() -> None:
         with pytest.raises(HTTPException) as exc:
             delete_exercise(key="nope", user_id=uid)
     assert exc.value.status_code == 404
+
+
+# --- dedup guard: normalized matching + create/publish 409 (SB-454) -----------
+
+
+def test_repo_search_finds_the_catalog_blind_spots() -> None:
+    """The queries from the SB-454 audit, through the real repository path.
+
+    The folding itself is unit-tested in ``tests/test_exercise_matching.py``;
+    this covers `search` actually delegating to it, which is what regressed.
+    """
+    repo = ExercisesRepository(MagicMock())
+    repo.list_visible = MagicMock(  # type: ignore[method-assign]
+        return_value=[
+            {"key": "pushups", "display_name": "Push-ups", "aliases": []},
+            {"key": "row_hold", "display_name": "Bent-over row hold", "aliases": []},
+            {"key": "farmers_carry", "display_name": "Farmer's carry", "aliases": []},
+            {"key": "pro_agility", "display_name": "5-10-5 pro agility", "aliases": []},
+        ]
+    )
+    uid = uuid4()
+    assert [r["key"] for r in repo.search(uid, "push ups")] == ["pushups"]
+    assert [r["key"] for r in repo.search(uid, "bent over row")] == ["row_hold"]
+    assert [r["key"] for r in repo.search(uid, "farmers carry")] == ["farmers_carry"]
+    assert [r["key"] for r in repo.search(uid, "5 10 5")] == ["pro_agility"]
+
+
+def test_repo_find_possible_duplicates_public_only() -> None:
+    repo = ExercisesRepository(MagicMock())
+    repo.list_visible = MagicMock(  # type: ignore[method-assign]
+        return_value=[
+            {"key": "pushups", "display_name": "Push-ups", "aliases": [], "visibility": "public"},
+            {"key": "pushup_2", "display_name": "Pushups", "aliases": [], "visibility": "private"},
+        ]
+    )
+    uid = uuid4()
+    assert len(repo.find_possible_duplicates(uid, "Push ups")) == 2
+    public = repo.find_possible_duplicates(uid, "Push ups", public_only=True)
+    assert [r["key"] for r in public] == ["pushups"]
+
+
+def test_create_exercise_409_on_duplicate() -> None:
+    uid = uuid4()
+    repo = _repo()
+    repo.find_possible_duplicates.return_value = [
+        {"key": "pushups", "display_name": "Push-ups", "visibility": "public", "aliases": []}
+    ]
+    body = ExerciseCreate(display_name="Pushups", category="strength", measures=["reps"])
+    with (
+        patch("backend.routes.workouts.get_supabase_client"),
+        patch("backend.routes.workouts.ExercisesRepository", return_value=repo),
+    ):
+        from backend.routes.workouts import create_exercise
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            create_exercise(body=body, user_id=uid)
+
+    assert exc.value.status_code == 409
+    assert exc.value.detail["candidates"][0]["key"] == "pushups"
+    repo.create.assert_not_called()
+
+
+def test_create_exercise_force_bypasses_guard() -> None:
+    uid = uuid4()
+    repo = _repo()
+    repo.create.return_value = {
+        "key": "pushups_2",
+        "display_name": "Pushups",
+        "category": "strength",
+        "visibility": "private",
+    }
+    body = ExerciseCreate(display_name="Pushups", category="strength", measures=["reps"])
+    with (
+        patch("backend.routes.workouts.get_supabase_client"),
+        patch("backend.routes.workouts.ExercisesRepository", return_value=repo),
+    ):
+        from backend.routes.workouts import create_exercise
+
+        result = create_exercise(body=body, force=True, user_id=uid)
+
+    assert result.key == "pushups_2"
+    repo.find_possible_duplicates.assert_not_called()
+
+
+def test_publish_exercise_409_when_public_library_has_it() -> None:
+    uid = uuid4()
+    repo = _repo()
+    repo.get.return_value = {"key": "my_pushup", "display_name": "Pushups", "aliases": []}
+    repo.find_possible_duplicates.return_value = [
+        {"key": "pushups", "display_name": "Push-ups", "visibility": "public", "aliases": []}
+    ]
+    with (
+        patch("backend.routes.workouts.get_supabase_client"),
+        patch("backend.routes.workouts.ExercisesRepository", return_value=repo),
+    ):
+        from backend.routes.workouts import publish_exercise
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            publish_exercise(key="my_pushup", user_id=uid)
+
+    assert exc.value.status_code == 409
+    assert repo.find_possible_duplicates.call_args.kwargs["public_only"] is True
+    repo.publish.assert_not_called()
+
+
+def test_publish_exercise_force_bypasses_guard() -> None:
+    uid = uuid4()
+    repo = _repo()
+    repo.publish.return_value = {
+        "key": "my_pushup",
+        "display_name": "Pushups",
+        "category": "strength",
+        "visibility": "public",
+    }
+    with (
+        patch("backend.routes.workouts.get_supabase_client"),
+        patch("backend.routes.workouts.ExercisesRepository", return_value=repo),
+    ):
+        from backend.routes.workouts import publish_exercise
+
+        result = publish_exercise(key="my_pushup", force=True, user_id=uid)
+
+    assert result.visibility == "public"
+    repo.find_possible_duplicates.assert_not_called()

--- a/scripts/audit_exercise_catalog.py
+++ b/scripts/audit_exercise_catalog.py
@@ -1,0 +1,467 @@
+"""
+Scan the exercise catalog for duplicates and unresolved rows.
+
+Two sources, same checks:
+
+  * ``--from-migrations`` (default) parses every ``INSERT INTO exercises`` and
+    ``UPDATE exercises SET aliases`` statement under ``supabase/migrations/``.
+    No database, no network — safe to run in CI on every PR.
+  * ``--from-json FILE`` reads a live catalog dump (``stk workout exercises
+    --json``), which also covers coach-created rows that never appear in a
+    migration.
+
+Exit code is 1 for the two failures that are never defensible: a hard duplicate
+(identical name, colliding alias) and a search blind spot (a row its own search
+cannot find). Near-duplicate *candidates* are reported but never fail the build —
+real variants (push-up vs incline push-up) must be allowed to coexist, so that
+call stays with a human.
+
+Usage:
+    uv run python scripts/audit_exercise_catalog.py
+    uv run python scripts/audit_exercise_catalog.py --from-json /tmp/catalog.json
+    uv run python scripts/audit_exercise_catalog.py --threshold 0.90
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MIGRATIONS_DIR = REPO_ROOT / "supabase" / "migrations"
+
+# Words that distinguish real variants rather than signalling a duplicate. A pair
+# whose only difference is one of these is a variant, not a dupe, so it is not
+# reported even when the strings are otherwise near-identical.
+VARIANT_MARKERS = {
+    "left",
+    "right",
+    "single",
+    "double",
+    "incline",
+    "decline",
+    "hold",
+    "jump",
+    "reverse",
+    "front",
+    "back",
+    "side",
+    "wide",
+    "narrow",
+    "seated",
+    "standing",
+    "weighted",
+}
+
+PLACEHOLDER_PATTERNS = (
+    re.compile(r"\bTBD\b", re.I),
+    re.compile(r"confirm with", re.I),
+    re.compile(r"\bunknown\b", re.I),
+)
+
+
+# The normalizer is the one the running service uses (SB-454), imported rather
+# than reimplemented so this audit can never drift from production behaviour —
+# the search-blind-spot check below is only meaningful if they agree.
+sys.path.insert(0, str(REPO_ROOT))
+from src.shared.exercise_matching import matches_query, normalize  # noqa: E402
+
+
+@dataclass
+class ExerciseRow:
+    key: str
+    display_name: str
+    aliases: list[str] = field(default_factory=list)
+    instructions: str | None = None
+    source: str = ""
+
+    @property
+    def norm_name(self) -> str:
+        return normalize(self.display_name)
+
+    @property
+    def norm_aliases(self) -> list[str]:
+        """Deduped — two spellings of one alias on the same row ("press-up" and
+        "press up") are intentional, not a collision."""
+        return sorted({normalize(a) for a in self.aliases if a.strip()})
+
+
+# --------------------------------------------------------------- SQL parsing
+
+
+def _split_top_level(text: str, sep: str = ",") -> list[str]:
+    """Split on `sep`, ignoring separators inside quotes, parens or brackets.
+
+    Postgres escapes a quote by doubling it ("Farmer''s carry"), which this
+    handles because the doubled quote simply toggles the flag twice.
+    """
+    parts: list[str] = []
+    depth = 0
+    in_quote = False
+    current: list[str] = []
+    for ch in text:
+        if ch == "'":
+            in_quote = not in_quote
+        elif not in_quote and ch in "([":
+            depth += 1
+        elif not in_quote and ch in ")]":
+            depth -= 1
+        if ch == sep and depth == 0 and not in_quote:
+            parts.append("".join(current))
+            current = []
+            continue
+        current.append(ch)
+    parts.append("".join(current))
+    return parts
+
+
+def _unquote(literal: str) -> str | None:
+    literal = literal.strip()
+    if literal.upper().startswith("NULL"):
+        return None
+    if literal.startswith("'"):
+        end = literal.rfind("'")
+        return literal[1:end].replace("''", "'")
+    return None
+
+
+def _parse_array(literal: str) -> list[str]:
+    """ARRAY['a','b'] / ARRAY[]::text[] / '{"a","b"}' -> list[str]."""
+    literal = literal.strip()
+    match = re.match(r"ARRAY\s*\[(.*?)\]", literal, re.S | re.I)
+    if match:
+        inner = match.group(1).strip()
+        if not inner:
+            return []
+        return [v for v in (_unquote(p) for p in _split_top_level(inner)) if v]
+    curly = _unquote(literal)
+    if curly and curly.startswith("{"):
+        return [v.strip().strip('"') for v in curly[1:-1].split(",") if v.strip()]
+    return []
+
+
+def _strip_sql_comments(sql: str) -> str:
+    return re.sub(r"--[^\n]*", "", sql)
+
+
+def _statement_end(sql: str, start: int) -> int:
+    """Index of the `;` that ends the statement beginning at `start`.
+
+    A plain non-greedy `.*?;` is wrong here: seeded `instructions` text contains
+    semicolons ("Feet together; bend down into..."), which silently truncated the
+    scan and dropped every row after it. Walk the string tracking quotes and
+    bracket depth instead.
+    """
+    depth = 0
+    in_quote = False
+    i = start
+    while i < len(sql):
+        ch = sql[i]
+        if ch == "'":
+            # A doubled quote is an escaped literal quote, not a delimiter.
+            if in_quote and i + 1 < len(sql) and sql[i + 1] == "'":
+                i += 2
+                continue
+            in_quote = not in_quote
+        elif not in_quote:
+            if ch in "([":
+                depth += 1
+            elif ch in ")]":
+                depth -= 1
+            elif ch == ";" and depth == 0:
+                return i
+        i += 1
+    return len(sql)
+
+
+def parse_migrations(directory: Path) -> list[ExerciseRow]:
+    """Reconstruct the seeded catalog from the migration SQL.
+
+    INSERTs build the rows; later `UPDATE exercises SET aliases = ...` statements
+    overwrite them, mirroring what the database actually ends up holding.
+    """
+    rows: dict[str, ExerciseRow] = {}
+    insert_re = re.compile(
+        r"INSERT\s+INTO\s+exercises\s*\((?P<cols>[^)]*)\)\s*VALUES",
+        re.S | re.I,
+    )
+    alias_update_re = re.compile(
+        r"UPDATE\s+exercises\s+SET\s+(?P<sets>.*?)WHERE\s+key\s*=\s*'(?P<key>[^']+)'",
+        re.S | re.I,
+    )
+
+    for path in sorted(directory.glob("*.sql")):
+        sql = _strip_sql_comments(path.read_text())
+
+        for match in insert_re.finditer(sql):
+            columns = [c.strip().lower() for c in match.group("cols").split(",")]
+            body = sql[match.end() : _statement_end(sql, match.end())]
+            # Drop a trailing upsert clause so it isn't mistaken for a tuple.
+            body = re.split(r"\bON\s+CONFLICT\b", body, flags=re.I)[0]
+            # Values are a comma-separated list of parenthesised tuples; the
+            # top-level split isolates each tuple with its arrays intact.
+            for chunk in _split_top_level(body):
+                chunk = chunk.strip()
+                if not chunk.startswith("("):
+                    continue
+                tuple_body = chunk[1 : chunk.rfind(")")]
+                values = _split_top_level(tuple_body)
+                if len(values) != len(columns):
+                    continue
+                record = dict(zip(columns, values, strict=True))
+                key = _unquote(record.get("key", ""))
+                name = _unquote(record.get("display_name", ""))
+                if not key or not name:
+                    continue
+                rows[key] = ExerciseRow(
+                    key=key,
+                    display_name=name,
+                    aliases=_parse_array(record.get("aliases", "")),
+                    instructions=_unquote(record.get("instructions", "")),
+                    source=path.name,
+                )
+
+        for match in alias_update_re.finditer(sql):
+            key = match.group("key")
+            if key not in rows:
+                continue
+            for assignment in _split_top_level(match.group("sets")):
+                field_name, _, value = assignment.partition("=")
+                if field_name.strip().lower() == "aliases":
+                    rows[key].aliases = _parse_array(value)
+
+    return list(rows.values())
+
+
+def parse_json(path: Path) -> list[ExerciseRow]:
+    payload: Any = json.loads(path.read_text())
+    records = payload if isinstance(payload, list) else payload.get("exercises", [])
+    return [
+        ExerciseRow(
+            key=r["key"],
+            display_name=r["display_name"],
+            aliases=list(r.get("aliases") or []),
+            instructions=r.get("instructions"),
+            source="live",
+        )
+        for r in records
+    ]
+
+
+# ------------------------------------------------------------------- checks
+
+
+def _is_variant_pair(a: str, b: str) -> bool:
+    """True when the two names differ only by a variant marker."""
+    diff = set(a.split()) ^ set(b.split())
+    return bool(diff) and diff <= VARIANT_MARKERS
+
+
+def find_hard_duplicates(rows: list[ExerciseRow]) -> list[str]:
+    """Collisions that are always wrong: same name, or a shared/shadowed alias."""
+    problems: list[str] = []
+
+    by_name: dict[str, list[ExerciseRow]] = {}
+    for row in rows:
+        by_name.setdefault(row.norm_name, []).append(row)
+    for name, group in sorted(by_name.items()):
+        if len(group) > 1:
+            keys = ", ".join(f"{r.key} ({r.source})" for r in group)
+            problems.append(f"duplicate display_name {name!r}: {keys}")
+
+    alias_owner: dict[str, list[ExerciseRow]] = {}
+    for row in rows:
+        for alias in row.norm_aliases:
+            alias_owner.setdefault(alias, []).append(row)
+    for alias, group in sorted(alias_owner.items()):
+        if len(group) > 1:
+            keys = ", ".join(r.key for r in group)
+            problems.append(f"alias {alias!r} claimed by {len(group)} rows: {keys}")
+        owner = by_name.get(alias)
+        if owner:
+            for holder in group:
+                for target in owner:
+                    if target.key != holder.key:
+                        problems.append(
+                            f"alias {alias!r} on {holder.key} shadows the display_name "
+                            f"of {target.key} — searching it returns both"
+                        )
+
+    return problems
+
+
+def find_near_duplicates(rows: list[ExerciseRow], threshold: float) -> list[str]:
+    """Name pairs similar enough to warrant a human look."""
+    candidates: list[tuple[float, str]] = []
+    for i, a in enumerate(rows):
+        for b in rows[i + 1 :]:
+            if _is_variant_pair(a.norm_name, b.norm_name):
+                continue
+            ratio = SequenceMatcher(None, a.norm_name, b.norm_name).ratio()
+            tokens_a, tokens_b = set(a.norm_name.split()), set(b.norm_name.split())
+            jaccard = len(tokens_a & tokens_b) / len(tokens_a | tokens_b)
+            score = max(ratio, jaccard)
+            if score >= threshold:
+                candidates.append(
+                    (
+                        score,
+                        f"{score:.2f}  {a.key} ({a.display_name!r})  ~  {b.key} ({b.display_name!r})",
+                    )
+                )
+    return [line for _, line in sorted(candidates, reverse=True)]
+
+
+def find_placeholders(rows: list[ExerciseRow]) -> list[str]:
+    """Rows seeded with a note that says the movement was never pinned down."""
+    out = []
+    for row in rows:
+        text = row.instructions or ""
+        if any(p.search(text) for p in PLACEHOLDER_PATTERNS):
+            out.append(f"{row.key}: {text.strip()}")
+    return out
+
+
+def find_self_aliases(rows: list[ExerciseRow]) -> list[str]:
+    """Aliases that exist only to paper over the missing normalization.
+
+    "bicep curl" on a row already called "Bicep curls" adds nothing once search
+    folds case, punctuation and plurals. They are harmless, but they are a
+    symptom: the catalog is hand-maintaining what the matcher should do.
+    """
+    return [
+        f"{r.key}: alias {a!r} collapses onto its own display_name {r.display_name!r}"
+        for r in rows
+        for a in r.aliases
+        if normalize(a) == r.norm_name
+    ]
+
+
+def _plausible_queries(row: ExerciseRow) -> list[str]:
+    """Spellings a coach might reasonably type for this exercise.
+
+    Punctuation dropped, hyphens opened up, and the plural flipped — the three
+    ways a typed name diverges from the seeded one.
+    """
+    name = row.display_name
+    queries = {
+        name.lower(),
+        row.norm_name,
+        name.lower().replace("-", " "),
+        name.lower().replace("-", ""),
+        re.sub(r"[^a-z0-9 ]+", "", name.lower()),
+        row.norm_name.replace(" ", ""),
+    }
+    words = row.norm_name.split()
+    if words and not words[-1].endswith("s"):
+        queries.add(" ".join([*words[:-1], words[-1] + "s"]))
+    return [q for q in queries if q.strip()]
+
+
+def find_search_blind_spots(rows: list[ExerciseRow]) -> list[str]:
+    """Reasonable queries that production search fails to match.
+
+    Replays ``ExercisesRepository.search``'s real matcher against each row. A
+    zero-hit search is precisely when a coach gives up and creates a duplicate,
+    so this doubles as the regression guard for SB-454: if normalization is ever
+    weakened, these come back.
+    """
+    blind = []
+    for row in rows:
+        payload = {"display_name": row.display_name, "aliases": row.aliases}
+        for query in sorted(_plausible_queries(row)):
+            if not matches_query(query, payload):
+                blind.append(f"{row.key}: searching {query!r} does not match {row.display_name!r}")
+    return blind
+
+
+def find_aliasless(rows: list[ExerciseRow]) -> list[str]:
+    """No aliases means search-first selection can't find it, which is how a
+    coach ends up creating a second copy under a different name."""
+    return [f"{r.key} ({r.display_name})" for r in rows if not r.norm_aliases]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--from-json", type=Path, help="Live catalog dump instead of migrations")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.82,
+        help="Similarity at or above which a pair is reported as a candidate (default 0.82)",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Also fail the run on near-duplicate candidates",
+    )
+    args = parser.parse_args()
+
+    rows = parse_json(args.from_json) if args.from_json else parse_migrations(MIGRATIONS_DIR)
+    if not rows:
+        print("No exercises found — did the source move?", file=sys.stderr)
+        return 2
+
+    source = str(args.from_json) if args.from_json else str(MIGRATIONS_DIR)
+    print(f"Exercise catalog audit — {len(rows)} rows from {source}\n")
+
+    hard = find_hard_duplicates(rows)
+    near = find_near_duplicates(rows, args.threshold)
+    placeholders = find_placeholders(rows)
+    aliasless = find_aliasless(rows)
+
+    if hard:
+        print(f"FAIL — {len(hard)} hard duplicate(s):")
+        for line in hard:
+            print(f"  ✗ {line}")
+    else:
+        print("OK — no identical names and no alias collisions")
+
+    print(f"\nNear-duplicate candidates (>= {args.threshold:.2f}) — review, don't auto-merge:")
+    if near:
+        for line in near:
+            print(f"  ? {line}")
+    else:
+        print("  none")
+
+    blind = find_search_blind_spots(rows)
+    if blind:
+        print(f"\nFAIL — {len(blind)} search blind spot(s): the catalog's own name finds")
+        print("nothing, so search-first selection fails and a coach creates a second copy:")
+        for line in blind:
+            print(f"  ✗ {line}")
+    else:
+        print("\nOK — every row is findable by its own name and plausible misspellings")
+
+    self_aliases = find_self_aliases(rows)
+    if self_aliases:
+        print(f"\nAliases made redundant by normalization ({len(self_aliases)}) — they")
+        print("hand-maintain what a normalizing matcher would do for free:")
+        for line in self_aliases:
+            print(f"  - {line}")
+
+    if placeholders:
+        print("\nUnresolved rows (movement never pinned down):")
+        for line in placeholders:
+            print(f"  ! {line}")
+
+    if aliasless:
+        print(f"\nRows with no aliases ({len(aliasless)}) — invisible to search-first selection,")
+        print("which is the main way a duplicate gets created:")
+        for line in aliasless:
+            print(f"  - {line}")
+
+    if hard or blind:
+        return 1
+    if args.strict and near:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/shared/exercise_matching.py
+++ b/src/shared/exercise_matching.py
@@ -1,0 +1,111 @@
+"""Name matching for the exercise catalog: search and duplicate detection (SB-454).
+
+The catalog's dedup strategy is deliberately soft — no unique-on-name constraint,
+because real variants ("push-up" and "incline push-up") must coexist. What holds
+it together instead is:
+
+  1. search-first selection, so a coach finds the existing row before adding one, and
+  2. a duplicate guard on create/publish that returns candidates rather than
+     silently inserting a second row.
+
+Both need the same notion of "the same name", which is what ``normalize`` provides.
+``scripts/audit_exercise_catalog.py`` imports it too, so the offline audit can never
+drift from what the running service actually does.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+__all__ = [
+    "find_duplicate_candidates",
+    "matches_query",
+    "normalize",
+    "search_terms",
+    "squash",
+]
+
+
+def normalize(name: str) -> str:
+    """Fold the spellings a coach might use into one comparable form.
+
+    Lowercases, turns hyphens/underscores/punctuation into spaces, collapses
+    whitespace, and drops a trailing plural ``s`` from each token. ``"Bent-over
+    row"``, ``"bent over rows"`` and ``"BENT OVER ROW"`` all become
+    ``"bent over row"``.
+
+    ``ss`` endings keep their ``s`` so "press" doesn't become "pres". Plural
+    stripping is otherwise unconditional: it is not trying to be linguistically
+    correct, only *consistent*. Both sides of every comparison run through this
+    function, so an over-eager fold like "abs" → "ab" costs nothing, while a
+    conservative one leaves "ups" and "up" as different words.
+
+    Apostrophes are *deleted* rather than turned into a space: "Farmer's carry"
+    has to fold onto the "farmers carry" a coach types, and splitting on the
+    apostrophe would instead leave a stray "s" token that matches neither.
+    """
+    text = name.lower().replace("-", " ").replace("_", " ")
+    text = re.sub(r"['‘’ʼ]", "", text)
+    text = re.sub(r"[^a-z0-9 ]+", " ", text)
+    tokens = [
+        token[:-1] if len(token) > 1 and token.endswith("s") and not token.endswith("ss") else token
+        for token in text.split()
+    ]
+    return " ".join(tokens)
+
+
+def squash(name: str) -> str:
+    """Normalized with the word breaks removed: "Push-ups" -> "pushup".
+
+    Catches the coach who types the name as one word. "pushups", "warmup" and
+    "stepup" are at least as likely as the spaced spellings, and without this
+    they match nothing at all.
+    """
+    return normalize(name).replace(" ", "")
+
+
+def search_terms(row: dict[str, Any]) -> set[str]:
+    """Every string that should match this exercise: name + aliases, each in
+    both normalized and squashed form."""
+    raw = [row.get("display_name") or "", *(row.get("aliases") or [])]
+    terms: set[str] = set()
+    for term in raw:
+        for form in (normalize(str(term)), squash(str(term))):
+            if form:
+                terms.add(form)
+    return terms
+
+
+def matches_query(query: str, row: dict[str, Any]) -> bool:
+    """Substring match, applied to folded text on both sides.
+
+    Folding before the substring test is the whole fix: previously ``"bent over
+    row"`` missed ``"Bent-over row hold"`` on the hyphen and ``"pushups"``
+    missed ``"Push-ups"`` on the word break. A zero-hit search is exactly when a
+    coach gives up and creates a duplicate.
+    """
+    forms = [form for form in (normalize(query), squash(query)) if form]
+    if not forms:
+        return False
+    terms = search_terms(row)
+    return any(form in term for form in forms for term in terms)
+
+
+def find_duplicate_candidates(
+    display_name: str,
+    aliases: list[str] | None,
+    rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Rows that are the same movement under a different spelling.
+
+    Matches on **exact normalized equality** of any name/alias on either side —
+    not fuzzy similarity. That distinction is load-bearing: a fuzzy guard would
+    block "incline push-up" because "push-up" exists, which is a legitimate new
+    variant. Near-duplicates stay advisory in the audit report, where a human
+    reads them.
+    """
+    incoming = search_terms({"display_name": display_name, "aliases": aliases or []})
+    if not incoming:
+        return []
+    return [row for row in rows if incoming & search_terms(row)]

--- a/src/shared/supabase_ops/workout_repository.py
+++ b/src/shared/supabase_ops/workout_repository.py
@@ -16,6 +16,7 @@ from datetime import date
 from typing import Any, cast
 from uuid import UUID
 
+from src.shared.exercise_matching import find_duplicate_candidates, matches_query
 from supabase import Client
 
 
@@ -75,20 +76,41 @@ class ExercisesRepository:
         """Fuzzy match over display_name + aliases across the visible catalog.
 
         Drives search-first selection and the publish-time dedup warning. The
-        catalog is small, so we match in Python (case-insensitive substring)
-        rather than a DB text index; move to trigram/tsvector if it grows.
+        catalog is small, so we match in Python (normalized substring) rather
+        than a DB text index; move to trigram/tsvector if it grows.
+
+        Both sides are normalized (SB-454) so punctuation and plurals don't hide
+        a row from the coach looking for it — "push ups" has to find "Push-ups",
+        because a search that returns nothing is how duplicates get created.
         """
-        q = query.strip().lower()
-        if not q:
+        if not query.strip():
             return []
         hits = []
         for row in self.list_visible(user_id):
-            haystay = [row.get("display_name", "")] + list(row.get("aliases") or [])
-            if any(q in str(h).lower() for h in haystay):
+            if matches_query(query, row):
                 hits.append(row)
             if len(hits) >= limit:
                 break
         return hits
+
+    def find_possible_duplicates(
+        self,
+        user_id: UUID,
+        display_name: str,
+        aliases: list[str] | None = None,
+        *,
+        public_only: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Catalog rows that are the same movement under a different spelling.
+
+        Backs the 409 on create/publish (SB-454) — the guard the catalog
+        migration promised but never got. `public_only` is for publish, where the
+        question is whether the shared library already has this movement.
+        """
+        rows = self.list_visible(user_id)
+        if public_only:
+            rows = [r for r in rows if r.get("visibility") == "public"]
+        return find_duplicate_candidates(display_name, aliases, rows)
 
     def get(self, key: str) -> dict[str, Any] | None:
         result = self.supabase.table("exercises").select("*").eq("key", key).execute()
@@ -111,7 +133,12 @@ class ExercisesRepository:
         return f"{base}_{i}"
 
     def create(self, user_id: UUID, payload: dict[str, Any]) -> dict[str, Any]:
-        """Create a coach-owned exercise; the key is generated to stay unique."""
+        """Create a coach-owned exercise; the key is generated to stay unique.
+
+        Slug uniqueness is not duplicate protection — it is what lets a second
+        row for the same movement exist as ``pull_up_2``. The semantic guard is
+        ``find_possible_duplicates``, enforced by the route before it gets here.
+        """
         row = {
             **payload,
             "key": self._unique_key(payload["display_name"]),

--- a/tests/test_exercise_matching.py
+++ b/tests/test_exercise_matching.py
@@ -1,0 +1,107 @@
+"""Name folding for the exercise catalog (SB-454).
+
+These are the pure functions behind two things that have to agree: the search a
+coach uses to find an existing movement, and the duplicate guard that stops them
+creating a second row for it. ``scripts/audit_exercise_catalog.py`` imports the
+same module, so a regression here surfaces in CI as a catalog blind spot too.
+"""
+
+import pytest
+
+from src.shared.exercise_matching import (
+    find_duplicate_candidates,
+    matches_query,
+    normalize,
+    search_terms,
+    squash,
+)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("Push-ups", "push up"),
+        ("push ups", "push up"),
+        ("Bent-over row", "bent over row"),
+        ("bent over rows", "bent over row"),
+        ("5-10-5 pro agility", "5 10 5 pro agility"),
+        ("Farmer's carry", "farmer carry"),
+        ("farmers carry", "farmer carry"),
+        ("Bicep 90° hold", "bicep 90 hold"),
+        ("Shoulder press", "shoulder press"),  # 'ss' keeps its s
+        ("  Warm-up  ", "warm up"),
+        ("step_up_max_jumps", "step up max jump"),
+    ],
+)
+def test_normalize(raw: str, expected: str) -> None:
+    assert normalize(raw) == expected
+
+
+def test_normalize_is_idempotent() -> None:
+    """Both sides of every comparison are normalized, sometimes twice."""
+    for raw in ("Farmer's carry", "Push-ups", "5-10-5 pro agility"):
+        assert normalize(normalize(raw)) == normalize(raw)
+
+
+def test_squash_drops_word_breaks() -> None:
+    assert squash("Push-ups") == "pushup"
+    assert squash("pushups") == "pushup"
+    assert squash("Step-up max jumps") == "stepupmaxjump"
+
+
+def test_search_terms_covers_name_and_aliases_in_both_forms() -> None:
+    terms = search_terms({"display_name": "Push-ups", "aliases": ["press-up", ""]})
+    assert terms == {"push up", "pushup", "press up", "pressup"}
+
+
+@pytest.mark.parametrize(
+    "query,display_name",
+    [
+        ("push ups", "Push-ups"),
+        ("pushups", "Push-ups"),
+        ("PUSH UPS", "Push-ups"),
+        ("bent over row", "Bent-over row hold"),
+        ("farmers carry", "Farmer's carry"),
+        ("5 10 5", "5-10-5 pro agility"),
+        ("warmup", "Warm-up"),
+        ("cool down", "Cool-down"),
+        ("step up max jump", "Step-up max jumps"),
+        ("dynamic warm up drill", "Dynamic warm-up drills"),
+    ],
+)
+def test_matches_query_folds_punctuation_and_plurals(query: str, display_name: str) -> None:
+    """Every one of these was a blind spot the audit found in the live catalog."""
+    assert matches_query(query, {"display_name": display_name, "aliases": []})
+
+
+def test_matches_query_still_discriminates() -> None:
+    row = {"display_name": "Push-ups", "aliases": []}
+    assert not matches_query("squat", row)
+    assert not matches_query("   ", row)
+    assert not matches_query("", row)
+
+
+def test_find_duplicate_candidates_is_exact_not_fuzzy() -> None:
+    """Exact-normalized only. A fuzzy guard would block real variants, which is
+    the whole reason the catalog has no unique-on-name constraint."""
+    rows = [
+        {"key": "pushups", "display_name": "Push-ups", "aliases": ["press-up"]},
+        {"key": "plank", "display_name": "Plank", "aliases": []},
+    ]
+    assert [r["key"] for r in find_duplicate_candidates("push ups", [], rows)] == ["pushups"]
+    assert [r["key"] for r in find_duplicate_candidates("Pushups", [], rows)] == ["pushups"]
+    # an existing row's alias counts as that row's name
+    assert [r["key"] for r in find_duplicate_candidates("Press-ups", [], rows)] == ["pushups"]
+    # so does an incoming alias colliding
+    assert [r["key"] for r in find_duplicate_candidates("Floor press", ["plank"], rows)] == [
+        "plank"
+    ]
+    # real variants must remain creatable
+    assert find_duplicate_candidates("Incline push-up", [], rows) == []
+    assert find_duplicate_candidates("Side plank", [], rows) == []
+
+
+def test_find_duplicate_candidates_with_nothing_to_match() -> None:
+    rows = [{"key": "plank", "display_name": "Plank", "aliases": []}]
+    assert find_duplicate_candidates("", None, rows) == []
+    assert find_duplicate_candidates("Plank", None, []) == []


### PR DESCRIPTION
Fixes SB-454

## The gap

`20260705000000_exercise_catalog.sql` describes a deliberately **soft** dedup strategy — search-first selection, aliases folding synonyms, and a publish-time near-duplicate warning *enforced in the app, not by a unique-on-name constraint*, because real variants (push-up vs incline push-up) must coexist.

The warning was never built, and the search half didn't work well enough to carry the strategy alone. `search()` was a case-insensitive substring test over raw text, so **10 seeded rows could not be found by their own names**:

```
pushups:       'push ups'           does not match 'Push-ups'
farmers_carry: 'farmers carry'      does not match "Farmer's carry"
pro_agility:   '5 10 5 pro agility' does not match '5-10-5 pro agility'
...
```

A zero-hit search is exactly when a coach gives up and creates a second row — which `_unique_key` accepts silently as `pull_up_2`, splitting an athlete's history across two rows for one movement. Defect 2 causes defect 1.

## Changes

**`src/shared/exercise_matching.py`** — one normalizer (case, hyphens, underscores, punctuation, apostrophes, trailing plurals but not `ss`), plus a squashed form for the coach who types `pushups` as one word. Imported by `search()`, the duplicate guard **and** the audit script, so the offline audit can't drift from what production does.

**Search + guard** — `search()` folds both sides. `find_possible_duplicates()` backs a **409 with candidates** on `POST /exercises` and `POST /exercises/{key}/publish` (the latter against the public library — the warning the migration promised). `?force=true` overrides both, matching the `athletes` pattern from SB-349.

**Exact-normalized, never fuzzy, for the 409.** Blocking "incline push-up" because "push-up" exists is precisely the failure the no-unique-constraint design exists to avoid. Fuzzy pairs stay advisory in the audit report where a human reads them.

**`scripts/audit_exercise_catalog.py`** — parses the seeded rows straight out of the migrations (no DB, no network) and replays the real matcher against them. Now exits 1 on search blind spots as well as hard duplicates, and runs in the root CI job.

## Verification

```
$ uv run python scripts/audit_exercise_catalog.py
Exercise catalog audit — 48 rows from supabase/migrations
OK — no identical names and no alias collisions
OK — every row is findable by its own name and plausible misspellings
```

It's a real regression guard, not a report — stubbing the normalizer back to `str.lower()` resurfaces **89 blind spots** and fails the build.

Suites: 153 root, 327 backend, all passing.

## Note on coverage

The root job's 60% floor was already failing by 0.2pt on `main` (59.76% locally). The pure-function tests live in `tests/` where the module does, which puts it back over at **60.29%**.

## Left alone

The 18 aliases normalization makes redundant (`bicep curl` on a row already called "Bicep curls"). Harmless no-ops now; deleting rows from the canonical library is churn with a small risk of dropping a genuinely distinct spelling. The audit reports them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)