### PR TITLE
fix(security): close the anon RLS leak on runs, splits, goals, user_sources (SB-453)

### DIFF
--- a/supabase/migrations/20251119133437_initial_schema.sql
+++ b/supabase/migrations/20251119133437_initial_schema.sql
@@ -287,29 +287,30 @@ ALTER TABLE recording_data ENABLE ROW LEVEL SECURITY;
 ALTER TABLE laps ENABLE ROW LEVEL SECURITY;
 ALTER TABLE user_sources ENABLE ROW LEVEL SECURITY;
 
--- Policy: Users can only see their own data
--- Note: auth.uid() will be NULL until proper Supabase Auth is implemented
--- For now, service role (Lambda) bypasses RLS
+-- Policy: Users can only see their own data.
+-- Owner-only, no anon escape: `OR auth.uid() IS NULL` here would be TRUE
+-- for every unauthenticated caller and leak the whole table (SB-453).
+-- The backend uses the service-role key, which bypasses RLS entirely.
 
 CREATE POLICY "Users can view their own runs"
     ON runs FOR SELECT
-    USING (user_id = auth.uid() OR auth.uid() IS NULL);
+    USING (user_id = auth.uid());
 
 CREATE POLICY "Users can insert their own runs"
     ON runs FOR INSERT
-    WITH CHECK (user_id = auth.uid() OR auth.uid() IS NULL);
+    WITH CHECK (user_id = auth.uid());
 
 CREATE POLICY "Users can update their own runs"
     ON runs FOR UPDATE
-    USING (user_id = auth.uid() OR auth.uid() IS NULL);
+    USING (user_id = auth.uid());
 
 CREATE POLICY "Users can view their own splits"
     ON splits FOR SELECT
-    USING (run_id IN (SELECT id FROM runs WHERE user_id = auth.uid() OR auth.uid() IS NULL));
+    USING (run_id IN (SELECT id FROM runs WHERE user_id = auth.uid()));
 
 CREATE POLICY "Users can view their own user_sources"
     ON user_sources FOR SELECT
-    USING (user_id = auth.uid() OR auth.uid() IS NULL);
+    USING (user_id = auth.uid());
 
 -- =====================================================
 -- FUNCTIONS & TRIGGERS

--- a/supabase/migrations/20260423124130_create_goals_table.sql
+++ b/supabase/migrations/20260423124130_create_goals_table.sql
@@ -58,15 +58,15 @@ ALTER TABLE goals ENABLE ROW LEVEL SECURITY;
 
 CREATE POLICY "Users can view their own goals"
     ON goals FOR SELECT
-    USING (user_id = auth.uid() OR auth.uid() IS NULL);
+    USING (user_id = auth.uid());
 
 CREATE POLICY "Users can insert their own goals"
     ON goals FOR INSERT
-    WITH CHECK (user_id = auth.uid() OR auth.uid() IS NULL);
+    WITH CHECK (user_id = auth.uid());
 
 CREATE POLICY "Users can update their own goals"
     ON goals FOR UPDATE
-    USING (user_id = auth.uid() OR auth.uid() IS NULL);
+    USING (user_id = auth.uid());
 
 -- Auto-update updated_at
 CREATE TRIGGER update_goals_updated_at BEFORE UPDATE ON goals

--- a/supabase/migrations/20260704010000_fix_security_advisor.sql
+++ b/supabase/migrations/20260704010000_fix_security_advisor.sql
@@ -29,12 +29,12 @@ ALTER TABLE users ENABLE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS "Users can view their own profile" ON users;
 CREATE POLICY "Users can view their own profile"
     ON users FOR SELECT
-    USING (user_id = auth.uid() OR auth.uid() IS NULL);
+    USING (user_id = auth.uid());
 
 DROP POLICY IF EXISTS "Users can update their own profile" ON users;
 CREATE POLICY "Users can update their own profile"
     ON users FOR UPDATE
-    USING (user_id = auth.uid() OR auth.uid() IS NULL);
+    USING (user_id = auth.uid());
 
 -- =====================================================
 -- 2. ENABLE RLS ON sync_history
@@ -48,7 +48,7 @@ CREATE POLICY "Users can view their own sync history"
     USING (
         source_id IN (
             SELECT id FROM user_sources
-            WHERE user_id = auth.uid() OR auth.uid() IS NULL
+            WHERE user_id = auth.uid()
         )
     );
 

--- a/supabase/migrations/20260731120000_rls_owner_only_runs_splits_goals_sources.sql
+++ b/supabase/migrations/20260731120000_rls_owner_only_runs_splits_goals_sources.sql
@@ -1,0 +1,88 @@
+-- Security fix (SB-453): remove the `OR auth.uid() IS NULL` escape hatch from
+-- every remaining RLS policy — runs, splits, goals and user_sources.
+--
+-- Same defect SB-227 established the guardrail for and 20260704020000 fixed for
+-- users/sync_history: `auth.uid()` is NULL for the anon role, so
+-- `USING (user_id = auth.uid() OR auth.uid() IS NULL)` is TRUE for every
+-- unauthenticated caller and the policy degrades to "allow everyone".
+--
+-- Confirmed exploitable on prod 2026-07-31, unauthenticated, using only the
+-- public anon key that ships in the frontend bundle:
+--
+--     runs          4,785 rows
+--     splits       20,677 rows
+--     goals             5 rows
+--     user_sources      1 row  — INCLUDING access_token, refresh_token and
+--                                access_token_secret
+--
+-- The user_sources exposure is the severe one: those are live SmashRun OAuth
+-- credentials, so this was account takeover, not just a data leak. Tokens are
+-- being rotated separately; this migration closes the hole.
+--
+-- Local dev never showed it because the anon role there lacks the table SELECT
+-- grant, so RLS was never reached. Do not treat a clean local as evidence.
+--
+-- The clause was never needed: the backend uses the service-role key, which
+-- BYPASSES RLS entirely. Authenticated browser sessions resolve auth.uid() to
+-- the caller, so they keep seeing exactly their own rows. Anon now matches
+-- nothing.
+--
+-- IDEMPOTENT: DROP IF EXISTS + CREATE. Safe to re-run; a no-op once applied.
+
+-- =====================================================
+-- runs — owner-only
+-- =====================================================
+
+DROP POLICY IF EXISTS "Users can view their own runs" ON runs;
+CREATE POLICY "Users can view their own runs"
+    ON runs FOR SELECT
+    USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "Users can insert their own runs" ON runs;
+CREATE POLICY "Users can insert their own runs"
+    ON runs FOR INSERT
+    WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "Users can update their own runs" ON runs;
+CREATE POLICY "Users can update their own runs"
+    ON runs FOR UPDATE
+    USING (user_id = auth.uid())
+    WITH CHECK (user_id = auth.uid());  -- explicit: post-update row stays owned
+
+-- =====================================================
+-- splits — owner-only, scoped through the parent run
+-- =====================================================
+
+DROP POLICY IF EXISTS "Users can view their own splits" ON splits;
+CREATE POLICY "Users can view their own splits"
+    ON splits FOR SELECT
+    USING (run_id IN (SELECT id FROM runs WHERE user_id = auth.uid()));
+
+-- =====================================================
+-- goals — owner-only
+-- =====================================================
+
+DROP POLICY IF EXISTS "Users can view their own goals" ON goals;
+CREATE POLICY "Users can view their own goals"
+    ON goals FOR SELECT
+    USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "Users can insert their own goals" ON goals;
+CREATE POLICY "Users can insert their own goals"
+    ON goals FOR INSERT
+    WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "Users can update their own goals" ON goals;
+CREATE POLICY "Users can update their own goals"
+    ON goals FOR UPDATE
+    USING (user_id = auth.uid())
+    WITH CHECK (user_id = auth.uid());
+
+-- =====================================================
+-- user_sources — owner-only. Holds OAuth tokens; nothing anonymous reads this.
+-- =====================================================
+
+DROP POLICY IF EXISTS "Users can view their own user_sources" ON user_sources;
+CREATE POLICY "Users can view their own user_sources"
+    ON user_sources FOR SELECT
+    USING (user_id = auth.uid());

--- a/tests/test_rls_guardrail.py
+++ b/tests/test_rls_guardrail.py
@@ -1,0 +1,67 @@
+"""The RLS anon-leak guardrail, enforced (SB-227, SB-453).
+
+`auth.uid()` is NULL for the anon role, so `OR auth.uid() IS NULL` in a policy
+evaluates TRUE for every unauthenticated caller and the policy degrades to
+"allow everyone". The anon key is public — it ships in the frontend bundle — so
+on Supabase-hosted prod, where anon holds the default SELECT grant, that is a
+full table read for anyone who asks.
+
+This has now been introduced three times: the initial schema, the goals table,
+and again inside `20260704010000_fix_security_advisor.sql` — a migration whose
+stated purpose was fixing security. Hence a test rather than a convention.
+
+Local dev does not reveal it: the anon role there lacks the table grant, so RLS
+is never reached. A clean local database is not evidence.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+MIGRATIONS = Path(__file__).resolve().parent.parent / "supabase" / "migrations"
+
+# The defect, in the forms Postgres accepts: `auth.uid() IS NULL` with any
+# spacing, and the parenthesised form pg_policies echoes back.
+ANON_ESCAPE = re.compile(r"auth\s*\.\s*uid\s*\(\s*\)\s*\)?\s+IS\s+NULL", re.IGNORECASE)
+
+# Lines that merely *talk* about the antipattern — the fix migrations explain it
+# at length, and this file's own name would otherwise trip the scan.
+_COMMENT = re.compile(r"^\s*--")
+
+
+def _offending_lines() -> list[str]:
+    hits: list[str] = []
+    for path in sorted(MIGRATIONS.glob("*.sql")):
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            if _COMMENT.match(line):
+                continue
+            if ANON_ESCAPE.search(line):
+                hits.append(f"{path.name}:{lineno}: {line.strip()}")
+    return hits
+
+
+def test_no_migration_grants_anon_an_rls_escape() -> None:
+    offenders = _offending_lines()
+    assert not offenders, (
+        "`auth.uid() IS NULL` in an RLS policy lets any unauthenticated caller "
+        "read the whole table (SB-227, SB-453). Scope the policy to "
+        "`user_id = auth.uid()` instead:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_the_detector_actually_matches_the_defect() -> None:
+    """A guard that cannot fail guards nothing."""
+    assert ANON_ESCAPE.search("USING (user_id = auth.uid() OR auth.uid() IS NULL);")
+    assert ANON_ESCAPE.search("WHERE user_id = auth.uid() OR auth.uid( ) is null")
+    # the form pg_policies renders
+    assert ANON_ESCAPE.search("((user_id = auth.uid()) OR (auth.uid() IS NULL))")
+    # and does not fire on a correctly scoped policy
+    assert not ANON_ESCAPE.search("USING (user_id = auth.uid());")
+
+
+def test_the_fix_migrations_are_present() -> None:
+    """Both halves of the fix — users/sync_history, then everything else."""
+    names = {p.name for p in MIGRATIONS.glob("*.sql")}
+    assert "20260704020000_rls_owner_only_no_anon_leak.sql" in names
+    assert "20260731120000_rls_owner_only_runs_splits_goals_sources.sql" in names


### PR DESCRIPTION
Fixes SB-453

## The defect

`auth.uid()` is NULL for the anon role, so `USING (user_id = auth.uid() OR auth.uid() IS NULL)` evaluates TRUE for every unauthenticated caller and the policy degrades to "allow everyone". SB-227 established the guardrail; `20260704020000` fixed `users`/`sync_history`. Four tables were left behind.

## Confirmed exploitable in prod

Unauthenticated, using only the public anon key that ships in the frontend bundle:

| table | exposed to anyone |
| --- | --- |
| `runs` | 4,785 rows |
| `splits` | 20,677 rows |
| `goals` | 5 rows |
| `user_sources` | 1 row — **`access_token`, `refresh_token`, `access_token_secret`** |

**`user_sources` was not in the ticket and is the severe one.** Those are live SmashRun OAuth credentials, so this was account takeover, not just a data leak. Token rotation is being handled separately from this PR — the migration closes the hole, it does not undo the exposure.

## Why it survived two prior passes

Local dev shows nothing: the anon role there holds no table `SELECT` grant, so RLS is never reached. On Supabase-hosted prod, anon *does* hold the default grant. A clean local database was never evidence, which is worth remembering the next time this is checked.

## Changes

- **New migration** recreates all eight policies as owner-only (`user_id = auth.uid()`), `splits` scoped through its parent run. Idempotent.
- **The three migrations that introduced the antipattern are corrected in place.** Supabase tracks applied migrations by version, not checksum (`supabase_migrations.schema_migrations` has no hash column), so this is inert for existing databases — and means a freshly provisioned one never creates the leaking policy at all, rather than creating it and patching it moments later.
- **`tests/test_rls_guardrail.py`** fails if it is reintroduced, and asserts the detector itself matches the defect. This has now crept in three times — once inside `20260704010000_fix_security_advisor.sql`, a migration whose stated purpose was fixing security. A convention was evidently not enough.

## Blast radius

None expected. The clause was never load-bearing: the backend uses the service-role key, which bypasses RLS entirely, and authenticated browser sessions resolve `auth.uid()` to the caller so they still see exactly their own rows. Applied locally with the full policy set verified clean; 168 root and 334 backend tests pass.

Merging applies it to prod via the `supabase db push` workflow. I'll re-run the unauthenticated probe afterwards to confirm the hole is shut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)