### PR TITLE
feat(workouts): option groups in templates — pick one of N (SB-448)

### DIFF
--- a/backend/tests/test_workout_repository.py
+++ b/backend/tests/test_workout_repository.py
@@ -231,3 +231,60 @@ def test_session_create_round_trips_with_sets():
     dash = next(s for s in out["sets"] if s["exercise_key"] == "40yd_dash")
     assert dash["time_seconds"] == 5.42
     assert all(s["session_id"] == out["id"] for s in out["sets"])
+
+
+def test_template_item_option_group_round_trips():
+    """Alternatives survive create -> read (SB-448).
+
+    Matthew's in-season aerobic day is run OR bike OR jump rope; without the
+    group the card prescribes all three.
+    """
+    supa = _FakeSupabase()
+    repo = WorkoutTemplatesRepository(supa)
+    out = repo.create(
+        uuid4(),
+        {
+            "name": "In-season aerobic day",
+            "type": "session",
+            "items": [
+                {
+                    "exercise_key": "easy_jog",
+                    "position": 0,
+                    "target_duration_seconds": 1200,
+                    "option_group": "aerobic",
+                    "option_group_label": "Aerobic engine",
+                },
+                {
+                    "exercise_key": "bike",
+                    "position": 1,
+                    "target_duration_seconds": 2400,
+                    "option_group": "aerobic",
+                },
+                {"exercise_key": "plank", "position": 2, "target_duration_seconds": 60},
+            ],
+        },
+    )
+
+    by_key = {i["exercise_key"]: i for i in out["items"]}
+    assert by_key["easy_jog"]["option_group"] == "aerobic"
+    assert by_key["easy_jog"]["option_group_label"] == "Aerobic engine"
+    assert by_key["bike"]["option_group"] == "aerobic"
+    # The label lives on one member; the renderers read it from whichever has it.
+    assert by_key["bike"].get("option_group_label") is None
+    # A mandatory item stays mandatory.
+    assert by_key["plank"].get("option_group") is None
+
+
+def test_template_items_without_option_group_are_unchanged():
+    """Every existing template has NULL groups and must behave exactly as before."""
+    supa = _FakeSupabase()
+    repo = WorkoutTemplatesRepository(supa)
+    out = repo.create(
+        uuid4(),
+        {
+            "name": "Monday Circuit",
+            "type": "circuit",
+            "items": [{"exercise_key": "pushups", "position": 0, "target_reps": 15}],
+        },
+    )
+    assert out["items"][0].get("option_group") is None

--- a/frontend/src/types/workout.ts
+++ b/frontend/src/types/workout.ts
@@ -79,6 +79,8 @@ export interface TemplateItemInput {
   target_distance_m?: number | null
   rest_seconds?: number | null
   variant?: string | null
+  option_group?: string | null
+  option_group_label?: string | null
   notes?: string | null
 }
 
@@ -111,6 +113,10 @@ export interface TemplateItem {
   rest_seconds: number | null
   segments?: SegmentTarget[] | null
   variant: string | null
+  // Alternatives (SB-448): items sharing an option_group are a "pick one of N".
+  // null = mandatory. The label is read from any member of the group.
+  option_group?: string | null
+  option_group_label?: string | null
   notes: string | null
 }
 

--- a/frontend/src/utils/__tests__/optionGroups.test.ts
+++ b/frontend/src/utils/__tests__/optionGroups.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import { groupOptionItems } from '../optionGroups'
+import type { TemplateItem } from '@/types/workout'
+
+const item = (over: Partial<TemplateItem> & { id: string; position: number }): TemplateItem => ({
+  exercise_key: 'plank',
+  section: 'main',
+  target_reps: null,
+  target_duration_seconds: null,
+  target_load_kg: null,
+  target_distance_m: null,
+  rest_seconds: null,
+  variant: null,
+  notes: null,
+  ...over,
+})
+
+describe('groupOptionItems', () => {
+  it('leaves mandatory items alone', () => {
+    const rows = groupOptionItems([
+      item({ id: 'a', position: 0, exercise_key: 'pushups' }),
+      item({ id: 'b', position: 1, exercise_key: 'plank' }),
+    ])
+    expect(rows.map((r) => r.kind)).toEqual(['item', 'item'])
+  })
+
+  it('folds the aerobic day into one pick-one block', () => {
+    // Matthew's actual prescription: run OR bike OR jump rope.
+    const rows = groupOptionItems([
+      item({ id: 'w', position: 0, exercise_key: 'dynamic_drills' }),
+      item({
+        id: 'r',
+        position: 1,
+        exercise_key: 'easy_jog',
+        option_group: 'aerobic',
+        option_group_label: 'Aerobic engine',
+      }),
+      item({ id: 'b', position: 2, exercise_key: 'bike', option_group: 'aerobic' }),
+      item({ id: 'j', position: 3, exercise_key: 'jump_rope', option_group: 'aerobic' }),
+      item({ id: 'p', position: 4, exercise_key: 'plank' }),
+    ])
+
+    expect(rows.map((r) => r.kind)).toEqual(['item', 'group', 'item'])
+    const group = rows[1]
+    if (group.kind !== 'group') throw new Error('expected a group')
+    expect(group.label).toBe('Aerobic engine')
+    expect(group.items.map((i) => i.exercise_key)).toEqual(['easy_jog', 'bike', 'jump_rope'])
+  })
+
+  it('places the group where its first member sits, not at the end', () => {
+    const rows = groupOptionItems([
+      item({ id: 'a', position: 0, exercise_key: 'bike', option_group: 'aerobic' }),
+      item({ id: 'b', position: 1, exercise_key: 'plank' }),
+    ])
+    expect(rows[0].kind).toBe('group')
+  })
+
+  it('keeps non-contiguous alternatives in one block', () => {
+    // A coach editing a plan can leave the options separated; repeating the
+    // heading would read as two separate choices.
+    const rows = groupOptionItems([
+      item({ id: 'a', position: 0, exercise_key: 'easy_jog', option_group: 'aerobic' }),
+      item({ id: 'b', position: 1, exercise_key: 'plank' }),
+      item({ id: 'c', position: 2, exercise_key: 'bike', option_group: 'aerobic' }),
+    ])
+
+    expect(rows.map((r) => r.kind)).toEqual(['group', 'item'])
+    const group = rows[0]
+    if (group.kind !== 'group') throw new Error('expected a group')
+    expect(group.items).toHaveLength(2)
+  })
+
+  it('falls back to a generic label when the coach did not write one', () => {
+    const rows = groupOptionItems([
+      item({ id: 'a', position: 0, exercise_key: 'bike', option_group: 'aerobic' }),
+    ])
+    const group = rows[0]
+    if (group.kind !== 'group') throw new Error('expected a group')
+    expect(group.label).toBe('Pick one')
+  })
+
+  it('sorts by position regardless of input order', () => {
+    const rows = groupOptionItems([
+      item({ id: 'b', position: 2, exercise_key: 'plank' }),
+      item({ id: 'a', position: 1, exercise_key: 'pushups' }),
+    ])
+    expect(rows.map((r) => (r.kind === 'item' ? r.item.exercise_key : ''))).toEqual([
+      'pushups',
+      'plank',
+    ])
+  })
+
+  it('treats distinct groups separately', () => {
+    const rows = groupOptionItems([
+      item({ id: 'a', position: 0, exercise_key: 'easy_jog', option_group: 'aerobic' }),
+      item({ id: 'b', position: 1, exercise_key: 'pull_up', option_group: 'upper' }),
+    ])
+    expect(rows.map((r) => r.kind)).toEqual(['group', 'group'])
+  })
+})

--- a/frontend/src/utils/optionGroups.ts
+++ b/frontend/src/utils/optionGroups.ts
@@ -1,0 +1,55 @@
+/**
+ * Fold "pick one of N" alternatives into renderable rows (SB-448).
+ *
+ * Matthew's in-season aerobic day is an either/or — "20 minute steady run, 40
+ * minute steady bike, or 5 minute steady jump rope" — not a checklist. Items
+ * sharing an `option_group` are alternatives; a null group is mandatory.
+ *
+ * Every surface that renders a template needs the same fold, so it lives here
+ * rather than inside one view.
+ */
+import type { TemplateItem } from '@/types/workout'
+
+export type TemplateRow =
+  | { kind: 'item'; item: TemplateItem }
+  | { kind: 'group'; key: string; label: string; items: TemplateItem[] }
+
+/**
+ * Group alternatives, preserving order.
+ *
+ * A group lands at the position of its first member, and later members are
+ * absorbed into it — so alternatives listed non-contiguously still render as
+ * one block instead of repeating the heading.
+ */
+export function groupOptionItems(items: TemplateItem[]): TemplateRow[] {
+  const rows: TemplateRow[] = []
+  const groupIndex = new Map<string, number>()
+
+  for (const item of [...items].sort((a, b) => a.position - b.position)) {
+    const key = item.option_group
+    if (!key) {
+      rows.push({ kind: 'item', item })
+      continue
+    }
+    const existing = groupIndex.get(key)
+    if (existing === undefined) {
+      groupIndex.set(key, rows.length)
+      rows.push({
+        kind: 'group',
+        key,
+        // The label is read from whichever member carries it, so a coach only
+        // has to write it once.
+        label: item.option_group_label || 'Pick one',
+        items: [item],
+      })
+      continue
+    }
+    const row = rows[existing]
+    if (row.kind === 'group') {
+      row.items.push(item)
+      if (!row.label && item.option_group_label) row.label = item.option_group_label
+    }
+  }
+
+  return rows
+}

--- a/frontend/src/views/WorkoutPrintView.vue
+++ b/frontend/src/views/WorkoutPrintView.vue
@@ -60,8 +60,17 @@
             </tr>
           </thead>
           <tbody>
-            <tr v-for="item in section.items" :key="item.id">
+            <template v-for="row in section.rows" :key="row.kind === 'group' ? row.key : row.item.id">
+              <tr v-if="row.kind === 'group'" class="option-head">
+                <td colspan="5">{{ row.label }} — do <strong>one</strong>, circle which</td>
+              </tr>
+              <tr
+                v-for="item in row.kind === 'group' ? row.items : [row.item]"
+                :key="item.id"
+                :class="{ 'option-item': row.kind === 'group' }"
+              >
               <td class="col-ex font-bold uppercase">
+                <span v-if="row.kind === 'group'" class="option-mark">○</span>
                 {{ exerciseName(item.exercise_key) }}
                 <span v-if="item.variant" class="variant">({{ item.variant }})</span>
               </td>
@@ -85,6 +94,7 @@
               </td>
               <td class="col-notes"></td>
             </tr>
+            </template>
           </tbody>
         </table>
       </div>
@@ -107,6 +117,7 @@ import { useRoute, RouterLink } from 'vue-router'
 import { apiCall } from '@/config/api'
 import type { Exercise, TemplateItem, WorkoutTemplate } from '@/types/workout'
 import type { Athlete } from '@/types/coach'
+import { groupOptionItems } from '@/utils/optionGroups'
 
 const route = useRoute()
 const athleteId = String(route.params.athleteId)
@@ -147,6 +158,9 @@ const sections = computed(() => {
     key,
     label: SECTION_LABELS[key] ?? key.replace(/_/g, ' '),
     items: by[key],
+    // "Pick one of N" alternatives fold into a single block (SB-448) — printed
+    // flat, the aerobic day told Gabe to do all three.
+    rows: groupOptionItems(by[key]),
   }))
 })
 
@@ -318,6 +332,16 @@ onMounted(async () => {
 .col-times { width: 22%; }
 .col-notes { width: 19%; }
 .variant { font-weight: 400; text-transform: none; }
+/* "Pick one of N" (SB-448): the heading has to survive black-and-white
+   photocopying, so it leans on weight and a rule rather than colour. */
+.option-head td {
+  font-size: 0.92em;
+  font-style: italic;
+  padding-top: 0.35em;
+  border-bottom: 1px solid #000;
+}
+.option-item td { background: #f4f4f4; }
+.option-mark { font-style: normal; margin-right: 0.35em; }
 .cue { color: #444; font-size: 0.9em; margin-top: 0.15em; }
 .checkbox {
   display: inline-block;

--- a/src/shared/models/workout.py
+++ b/src/shared/models/workout.py
@@ -169,6 +169,11 @@ class TemplateItemCreate(BaseModel):
     # Per-segment goals for a broken rep (SB-264); None for ordinary items.
     segments: list[SegmentTarget] | None = None
     variant: str | None = None
+    # Alternatives (SB-448): items sharing an option_group are a "pick one of N"
+    # — the aerobic day is run OR bike OR jump rope, not all three. None =
+    # mandatory. The label is read from any member of the group.
+    option_group: str | None = None
+    option_group_label: str | None = None
     notes: str | None = None
 
 

--- a/stk/src/cli/commands/workout.py
+++ b/stk/src/cli/commands/workout.py
@@ -28,6 +28,40 @@ def _dump(data: Any) -> None:
     print(json.dumps(data, indent=2, default=str))
 
 
+def _group_options(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Fold "pick one of N" alternatives into single rows (SB-448).
+
+    Items sharing an ``option_group`` are alternatives — the aerobic day is run
+    OR bike OR jump rope, and printed flat it read as all three. A group lands
+    at the position of its first member, so alternatives listed non-contiguously
+    still render as one block rather than repeating the heading.
+    """
+    rows: list[dict[str, Any]] = []
+    index: dict[str, int] = {}
+    for item in sorted(items, key=lambda i: i.get("position", 0)):
+        key = item.get("option_group")
+        if not key:
+            rows.append({"kind": "item", "item": item})
+            continue
+        if key not in index:
+            index[key] = len(rows)
+            rows.append(
+                {
+                    "kind": "group",
+                    "key": key,
+                    # Read from whichever member carries it — a coach writes it once.
+                    "label": item.get("option_group_label") or "Pick one",
+                    "items": [item],
+                }
+            )
+            continue
+        row = rows[index[key]]
+        row["items"].append(item)
+        if row["label"] == "Pick one" and item.get("option_group_label"):
+            row["label"] = item["option_group_label"]
+    return rows
+
+
 def exercises(
     json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
 ) -> None:
@@ -119,17 +153,29 @@ def show(
     display.console.print(
         f"\n[bold]{t['name']}[/bold]  ({t['type']}, x{t['rounds']} rounds)  — {t['source']}"
     )
-    for item in sorted(t.get("items", []), key=lambda i: i["position"]):
-        display.console.print(
-            f"  {item['position'] + 1}. {item['exercise_key']:<16} {_fmt_target(item)}"
-        )
+
+    def _segments(item: dict[str, Any], indent: str) -> None:
         # Broken rep (SB-264): one rep split into segments with per-segment goals.
         for seg in item.get("segments") or []:
             label = seg.get("label") or f"{seg['distance_m']:g}m"
             display.console.print(
-                f"       [dim]{label:<10}[/dim] "
+                f"{indent}[dim]{label:<10}[/dim] "
                 f"{_fmt_goal(seg.get('target_s_min'), seg.get('target_s_max'))}"
             )
+
+    n = 0
+    for row in _group_options(t.get("items", [])):
+        if row["kind"] == "group":
+            n += 1
+            display.console.print(f"  {n}. [bold]{row['label']}[/bold] [dim]— do one[/dim]")
+            for item in row["items"]:
+                display.console.print(f"       ○ {item['exercise_key']:<14} {_fmt_target(item)}")
+                _segments(item, "           ")
+            continue
+        item = row["item"]
+        n += 1
+        display.console.print(f"  {n}. {item['exercise_key']:<16} {_fmt_target(item)}")
+        _segments(item, "       ")
     if t.get("notes"):
         display.console.print(f"  [dim]{t['notes']}[/dim]")
     display.console.print("")

--- a/stk/tests/test_workout_option_groups.py
+++ b/stk/tests/test_workout_option_groups.py
@@ -1,0 +1,86 @@
+"""SB-448: "pick one of N" alternatives fold into a single block on the card.
+
+Matthew's in-season aerobic day is run OR bike OR jump rope. Rendered flat, the
+card told Gabe to do all three.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cli.commands.workout import _group_options
+
+
+def _item(key: str, position: int, **over: Any) -> dict[str, Any]:
+    return {"exercise_key": key, "position": position, "section": "main", **over}
+
+
+def test_mandatory_items_are_untouched() -> None:
+    rows = _group_options([_item("pushups", 0), _item("plank", 1)])
+    assert [r["kind"] for r in rows] == ["item", "item"]
+
+
+def test_the_aerobic_day_folds_into_one_choice() -> None:
+    rows = _group_options(
+        [
+            _item("dynamic_drills", 0),
+            _item("easy_jog", 1, option_group="aerobic", option_group_label="Aerobic engine"),
+            _item("bike", 2, option_group="aerobic"),
+            _item("jump_rope", 3, option_group="aerobic"),
+            _item("plank", 4),
+        ]
+    )
+
+    assert [r["kind"] for r in rows] == ["item", "group", "item"]
+    group = rows[1]
+    assert group["label"] == "Aerobic engine"
+    assert [i["exercise_key"] for i in group["items"]] == ["easy_jog", "bike", "jump_rope"]
+
+
+def test_group_lands_at_its_first_member() -> None:
+    rows = _group_options([_item("bike", 0, option_group="aerobic"), _item("plank", 1)])
+    assert rows[0]["kind"] == "group"
+
+
+def test_non_contiguous_alternatives_stay_one_block() -> None:
+    """Repeating the heading would read as two separate choices."""
+    rows = _group_options(
+        [
+            _item("easy_jog", 0, option_group="aerobic"),
+            _item("plank", 1),
+            _item("bike", 2, option_group="aerobic"),
+        ]
+    )
+
+    assert [r["kind"] for r in rows] == ["group", "item"]
+    assert len(rows[0]["items"]) == 2
+
+
+def test_label_defaults_when_the_coach_did_not_write_one() -> None:
+    rows = _group_options([_item("bike", 0, option_group="aerobic")])
+    assert rows[0]["label"] == "Pick one"
+
+
+def test_label_is_picked_up_from_a_later_member() -> None:
+    rows = _group_options(
+        [
+            _item("bike", 0, option_group="aerobic"),
+            _item("easy_jog", 1, option_group="aerobic", option_group_label="Aerobic engine"),
+        ]
+    )
+    assert rows[0]["label"] == "Aerobic engine"
+
+
+def test_distinct_groups_stay_distinct() -> None:
+    rows = _group_options(
+        [
+            _item("easy_jog", 0, option_group="aerobic"),
+            _item("pull_up", 1, option_group="upper"),
+        ]
+    )
+    assert [r["kind"] for r in rows] == ["group", "group"]
+
+
+def test_items_are_sorted_by_position() -> None:
+    rows = _group_options([_item("plank", 2), _item("pushups", 1)])
+    assert [r["item"]["exercise_key"] for r in rows] == ["pushups", "plank"]

--- a/supabase/migrations/20260731140000_template_item_option_group.sql
+++ b/supabase/migrations/20260731140000_template_item_option_group.sql
@@ -1,0 +1,30 @@
+-- Option groups on template_items (SB-448): "pick one of N".
+--
+-- Matthew's in-season aerobic day is an either/or, not a list:
+--
+--   "20 minute steady run, 40 minute steady bike, or 5 minute steady jump rope
+--    keeping your heart rate between 120 and 145"
+--
+-- `section` groups items and `position` orders them, but nothing expressed
+-- alternatives — so the printed sheet told Gabe to do all three.
+--
+-- Items sharing an `option_group` value within a template are alternatives;
+-- NULL means mandatory, which is every existing row and today's behaviour.
+-- Choose-1 is the only cardinality any plan has needed, so there is no
+-- choose_n column until one asks for it.
+
+ALTER TABLE template_items
+    ADD COLUMN option_group TEXT,
+    ADD COLUMN option_group_label TEXT;
+
+COMMENT ON COLUMN template_items.option_group IS
+    'Items sharing this value within a template are alternatives — do one of them. NULL = mandatory.';
+COMMENT ON COLUMN template_items.option_group_label IS
+    'Heading shown above the alternatives, e.g. "Aerobic engine — pick one". Read from any member of the group.';
+
+-- Rendering and logging both walk a template's items grouped by option_group;
+-- the partial index keeps that lookup off a full scan without carrying the
+-- overwhelming majority of rows, which are NULL.
+CREATE INDEX idx_template_items_option_group
+    ON template_items (template_id, option_group)
+    WHERE option_group IS NOT NULL;


### PR DESCRIPTION
Fixes SB-448

## Why

Matthew's in-season aerobic day is an either/or, not a checklist:

> *"20 minute steady run, 40 minute steady bike, or 5 minute steady jump rope keeping your heart rate between 120 and 145"*

`section` grouped items and `position` ordered them, but nothing expressed alternatives — so Gabe's printed sheet told him to do **all three**.

## What

**Schema** — `template_items` gains `option_group` + `option_group_label`. Items sharing a group within a template are alternatives; `NULL` is mandatory, which is every existing row and today's behaviour. Choose-1 is the only cardinality any plan has asked for, so there's no `choose_n` until one does. Partial index on the non-null groups.

**Rendering** — both the card (`stk workout show`) and the printable sheet fold a group into one block:

```
  3. Aerobic engine — do one
       ○ easy_jog       20 min
       ○ bike           40 min
       ○ jump_rope       5 min
```

On the sheet it's a labelled band with a circle per option for Gabe to ring what he did.

## Two behaviours worth knowing

**A group renders at its first member's position and absorbs later ones.** A coach editing a plan can leave alternatives non-contiguous; repeating the heading would read as two separate choices rather than one.

**The label is read from whichever member carries it**, so it's written once rather than on every option.

## Logging and review needed no change

The ticket asked that an unchosen alternative not be reported as a miss. `stk workout review` walks the *logged sets* and has no completeness check at all, so this was already true — verified rather than assumed, and worth noting since it means "which option did he pick" is answered by what got logged.

## Verification

Suites: 168 root, 336 backend, 84 stk, 267 frontend — all passing. Frontend typecheck clean.

The migration was **not** applied locally (local Supabase is stopped); the `db push --dry-run` on this PR validates it against prod, and I'll read that before merging.

## Follow-up for Matthew

Are the three genuinely interchangeable (20 min run ≈ 40 min bike ≈ 5 min jump rope)? If so we could store the equivalence and let him prescribe "one aerobic unit" instead of restating the menu. He also prescribes jump rope as 3x3 min in the conditioning block but 5 min steady here — worth confirming both are intentional. Left on the ticket, not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)