### PR TITLE
feat(workouts): heart rate, cadence and speed as first-class measures (SB-447)

### DIFF
--- a/frontend/src/types/workout.ts
+++ b/frontend/src/types/workout.ts
@@ -122,6 +122,12 @@ export interface TemplateItem {
   rest_seconds_max?: number | null
   rest_mode?: 'fixed' | 'range' | 'full' | 'autoregulated' | null
   segments?: SegmentTarget[] | null
+  // HR / cadence / speed (SB-447). Speed is canonical kph, shown as mph.
+  // Cadence is a per-minute count whose unit follows the movement.
+  target_hr_min?: number | null
+  target_hr_max?: number | null
+  target_cadence?: number | null
+  target_speed_kph?: number | null
   variant: string | null
   // Alternatives (SB-448): items sharing an option_group are a "pick one of N".
   // null = mandatory. The label is read from any member of the group.

--- a/frontend/src/views/WorkoutPrintView.vue
+++ b/frontend/src/views/WorkoutPrintView.vue
@@ -217,6 +217,17 @@ const targetText = (item: TemplateItem): string => {
         : `${item.target_distance_m} m`,
     )
   }
+  // A prescribed heart-rate zone is the point of the in-season aerobic day.
+  if (item.target_hr_min != null || item.target_hr_max != null) {
+    const lo = item.target_hr_min
+    const hi = item.target_hr_max
+    parts.push(
+      lo != null && hi != null ? `HR ${lo}-${hi}` : lo != null ? `HR ${lo}+` : `HR ≤${hi}`,
+    )
+  }
+  if (item.target_cadence != null) parts.push(`${item.target_cadence}/min`)
+  if (item.target_speed_kph != null)
+    parts.push(`${Math.round(item.target_speed_kph * 0.621371)} mph`)
   const rest = restText(item)
   if (rest) parts.push(rest)
   return parts.join(' · ') || '—'

--- a/src/shared/models/workout.py
+++ b/src/shared/models/workout.py
@@ -184,6 +184,14 @@ class TemplateItemCreate(BaseModel):
     target_distance_m: float | None = Field(default=None, ge=0)
     rest_seconds: float | None = Field(default=None, ge=0)
     rest_seconds_max: float | None = Field(default=None, ge=0)
+    # Heart rate, cadence and speed (SB-447) — the 2026-07-30 plan is the first
+    # to prescribe them ("HR 160-175", "170 rpm or 20 mph"). Speed is canonical
+    # kph, shown as mph at the edge. Cadence is a per-minute count whose unit
+    # follows the movement: crank rpm cycling, steps running, skips on a rope.
+    target_hr_min: int | None = Field(default=None, ge=20, le=250)
+    target_hr_max: int | None = Field(default=None, ge=20, le=250)
+    target_cadence: float | None = Field(default=None, ge=0, le=300)
+    target_speed_kph: float | None = Field(default=None, ge=0, le=100)
     # "Full recovery" and "go off how you feel" are prescriptions, not numbers —
     # storing them as a mode beats inventing a value the coach never gave.
     rest_mode: RestMode | None = None
@@ -208,6 +216,7 @@ class TemplateItemCreate(BaseModel):
             ("target_reps", "target_reps_max"),
             ("target_load_kg", "target_load_max_kg"),
             ("rest_seconds", "rest_seconds_max"),
+            ("target_hr_min", "target_hr_max"),
             ("target_duration_seconds", "target_duration_max_seconds"),
         )
         for lo_name, hi_name in pairs:
@@ -271,11 +280,27 @@ class ExerciseSetCreate(BaseModel):
     load_kg: float | None = Field(default=None, ge=0)
     distance_m: float | None = Field(default=None, ge=0)
     time_seconds: float | None = Field(default=None, ge=0)
+    # Measured HR / cadence / speed (SB-447). Bounds catch a transposed 610 bpm,
+    # not implausible coaching — judging whether a value is realistic stays with
+    # the log-workout skill, which flags outliers to a human.
+    hr_bpm_avg: int | None = Field(default=None, ge=20, le=250)
+    hr_bpm_max: int | None = Field(default=None, ge=20, le=250)
+    cadence: float | None = Field(default=None, ge=0, le=300)
+    speed_kph: float | None = Field(default=None, ge=0, le=100)
     rpe: int | None = Field(default=None, ge=1, le=10)
     started_at: datetime | None = None
     ended_at: datetime | None = None
     notes: str | None = None
     extra: dict[str, Any] | None = None
+
+    @model_validator(mode="after")
+    def _hr_max_not_below_avg(self) -> ExerciseSetCreate:
+        if self.hr_bpm_avg is not None and self.hr_bpm_max is not None:
+            if self.hr_bpm_max < self.hr_bpm_avg:
+                raise ValueError(
+                    f"hr_bpm_max ({self.hr_bpm_max}) is below hr_bpm_avg ({self.hr_bpm_avg})"
+                )
+        return self
 
 
 class ExerciseSet(ExerciseSetCreate):

--- a/stk/src/cli/commands/workout.py
+++ b/stk/src/cli/commands/workout.py
@@ -136,6 +136,15 @@ def _fmt_rest(item: dict[str, Any]) -> str:
     return text
 
 
+def _fmt_hr_zone(lo: int | None, hi: int | None) -> str:
+    """A prescribed heart-rate zone: "HR 160-175", "HR 120+", "HR ≤145" (SB-447)."""
+    if lo is None and hi is None:
+        return ""
+    if lo is not None and hi is not None:
+        return f"HR {lo:g}-{hi:g}" if hi != lo else f"HR {lo:g}"
+    return f"HR {lo:g}+" if lo is not None else f"HR ≤{hi:g}"
+
+
 def _fmt_target(item: dict[str, Any]) -> str:
     parts = []
     reps = _fmt_range(item.get("target_reps"), item.get("target_reps_max"))
@@ -155,6 +164,14 @@ def _fmt_target(item: dict[str, Any]) -> str:
         parts.append(f"{_fmt_range(lo_lb, hi_lb)}lb")
     if item.get("target_distance_m") is not None:
         parts.append(_fmt_distance(item["target_distance_m"]))
+    zone = _fmt_hr_zone(item.get("target_hr_min"), item.get("target_hr_max"))
+    if zone:
+        parts.append(zone)
+    if item.get("target_cadence") is not None:
+        # Unit follows the movement — rpm on a bike, spm running, skips on a rope.
+        parts.append(f"{item['target_cadence']:g}/min")
+    if item.get("target_speed_kph") is not None:
+        parts.append(f"{item['target_speed_kph'] * 0.621371:.0f}mph")
     rest = _fmt_rest(item)
     if rest:
         parts.append(rest)
@@ -295,6 +312,23 @@ def _range_status(actual: float, lo: float | None, hi: float | None) -> str:
     return "[green]hit[/green]"
 
 
+def _zone_status(actual: float, lo: float | None, hi: float | None) -> str:
+    """Grade a heart rate against its prescribed zone (SB-447).
+
+    Deliberately not `_range_status`: exceeding a rep range is over-delivery,
+    but exceeding a heart-rate ceiling is the opposite of the prescription. On
+    Matthew's in-season aerobic day the whole point of "keep HR 120-145" is
+    *not* going harder, so above-zone reads as a warning, not a win.
+    """
+    if lo is None and hi is None:
+        return ""
+    if lo is not None and actual < lo:
+        return "[yellow]below zone[/yellow]"
+    if hi is not None and actual > hi:
+        return "[red]above zone[/red]"
+    return "[green]in zone[/green]"
+
+
 def review(
     session_id: str = typer.Argument(
         ..., help="Session id (full or 8-char prefix from `sessions`)"
@@ -343,6 +377,15 @@ def review(
             line += f" {_fmt_distance(st['distance_m']):<7}"
         if actual:
             line += f" {actual}"
+        hr = st.get("hr_bpm_avg")
+        if hr is not None:
+            goal = items_by_key.get(st["exercise_key"], {})
+            zone = _zone_status(hr, goal.get("target_hr_min"), goal.get("target_hr_max"))
+            line += f" {hr}bpm" + (f"  {zone}" if zone else "")
+        if st.get("cadence") is not None:
+            line += f" {st['cadence']:g}/min"
+        if st.get("speed_kph") is not None:
+            line += f" {st['speed_kph'] * 0.621371:.1f}mph"
         if st.get("reps") is not None:
             line += f" {st['reps']} reps"
             goal = items_by_key.get(st["exercise_key"], {})

--- a/stk/tests/test_workout_hr_zone.py
+++ b/stk/tests/test_workout_hr_zone.py
@@ -1,0 +1,86 @@
+"""SB-447: heart rate, cadence and speed on the card and in review.
+
+The 2026-07-30 plan is the first to prescribe them — bike intervals at HR
+160-175, the in-season aerobic day at HR 120-145 — and the coach asked for the
+instrumentation directly: "insert as many metrics as you can".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cli.commands.workout import _fmt_hr_zone, _fmt_target, _range_status, _zone_status
+
+MPH = 1.609344
+
+
+def _item(**over: Any) -> dict[str, Any]:
+    return {"exercise_key": "bike", "position": 0, **over}
+
+
+class TestHrZoneFormatting:
+    def test_a_zone(self) -> None:
+        assert _fmt_hr_zone(160, 175) == "HR 160-175"
+
+    def test_floor_only(self) -> None:
+        assert _fmt_hr_zone(120, None) == "HR 120+"
+
+    def test_ceiling_only(self) -> None:
+        assert _fmt_hr_zone(None, 145) == "HR ≤145"
+
+    def test_equal_bounds_are_a_single_number(self) -> None:
+        assert _fmt_hr_zone(150, 150) == "HR 150"
+
+    def test_no_zone(self) -> None:
+        assert _fmt_hr_zone(None, None) == ""
+
+
+class TestTargetLine:
+    def test_the_bike_interval_prescription(self) -> None:
+        """2 min on at HR 160-175, fallback 170/min or 20 mph."""
+        out = _fmt_target(
+            _item(
+                target_duration_seconds=120,
+                target_hr_min=160,
+                target_hr_max=175,
+                target_cadence=170,
+                target_speed_kph=20 * MPH,
+            )
+        )
+        assert "HR 160-175" in out
+        assert "170/min" in out
+        assert "20mph" in out
+
+    def test_the_aerobic_day_ceiling(self) -> None:
+        out = _fmt_target(_item(target_duration_seconds=1200, target_hr_min=120, target_hr_max=145))
+        assert "HR 120-145" in out
+
+    def test_items_without_hr_are_unchanged(self) -> None:
+        assert _fmt_target(_item(exercise_key="pushups", target_reps=15)) == "15 reps"
+
+
+class TestZoneStatus:
+    def test_inside_the_zone(self) -> None:
+        assert "in zone" in _zone_status(168, 160, 175)
+
+    def test_bounds_are_inclusive(self) -> None:
+        assert "in zone" in _zone_status(160, 160, 175)
+        assert "in zone" in _zone_status(175, 160, 175)
+
+    def test_below_the_zone_is_a_warning_not_a_failure(self) -> None:
+        assert "below zone" in _zone_status(140, 160, 175)
+
+    def test_above_the_zone_is_red(self) -> None:
+        """The point of "keep HR 120-145" is not going harder — unlike reps,
+        exceeding a heart-rate ceiling is the opposite of the prescription."""
+        assert "above zone" in _zone_status(165, 120, 145)
+        assert "red" in _zone_status(165, 120, 145)
+
+    def test_hr_does_not_reuse_the_rep_grader(self) -> None:
+        """Guard against a refactor collapsing the two: over a rep range is
+        over-delivery (green), over an HR ceiling is not."""
+        assert "green" in _range_status(14, 8, 12)  # reps: over is good
+        assert "red" in _zone_status(165, 120, 145)  # HR: over is not
+
+    def test_no_zone_grades_nothing(self) -> None:
+        assert _zone_status(150, None, None) == ""

--- a/supabase/migrations/20260731180000_workout_hr_cadence_speed.sql
+++ b/supabase/migrations/20260731180000_workout_hr_cadence_speed.sql
@@ -1,0 +1,82 @@
+-- Heart rate, cadence and speed as first-class workout measures (SB-447).
+--
+-- The 2026-07-30 plan is the first to prescribe them, and the coach asked for
+-- instrumentation directly: "insert as many metrics as you can ---> adjust,
+-- assess. I'll be there for it."
+--
+--   Bike intervals: 2 min on / 1 min recovery, "on" pace = HR 160-175
+--   No HR monitor:  170 rpm or 20 mph
+--   Aerobic day:    keep HR 120-145
+--
+-- None of it existed anywhere. Putting it in `extra` JSONB would mean no
+-- trending, no review, no charts — which defeats the instruction.
+--
+-- Speed is stored canonical kph and displayed as mph at the edge, the same
+-- convention as kg/lb.
+--
+-- CADENCE IS DELIBERATELY UNIT-AGNOSTIC. The ticket proposed `cadence_rpm`, but
+-- the prescribed 170 is not sustainable bike cadence (elite is ~100-120) — it
+-- is textbook *running* cadence in steps per minute. Rather than bake in a unit
+-- that is wrong for half the movements, the column is a per-minute count whose
+-- unit follows the exercise: crank revolutions on a bike, steps running, skips
+-- on a rope. Open question for Matthew either way.
+
+ALTER TABLE exercise_sets
+    ADD COLUMN hr_bpm_avg INTEGER,
+    ADD COLUMN hr_bpm_max INTEGER,
+    ADD COLUMN cadence NUMERIC(5, 1),
+    ADD COLUMN speed_kph NUMERIC(5, 2);
+
+ALTER TABLE template_items
+    ADD COLUMN target_hr_min INTEGER,
+    ADD COLUMN target_hr_max INTEGER,
+    ADD COLUMN target_cadence NUMERIC(5, 1),
+    ADD COLUMN target_speed_kph NUMERIC(5, 2);
+
+-- Bounds catch data-entry accidents (a transposed 610 bpm), not implausible
+-- coaching. The "is 170 cadence realistic" judgement stays advisory in the
+-- log-workout skill, which already flags outliers to a human — a hard limit
+-- there would reject every one of Matthew's sessions before he confirms.
+ALTER TABLE exercise_sets
+    ADD CONSTRAINT exercise_sets_hr_avg_check
+    CHECK (hr_bpm_avg IS NULL OR hr_bpm_avg BETWEEN 20 AND 250),
+    ADD CONSTRAINT exercise_sets_hr_max_check
+    CHECK (hr_bpm_max IS NULL OR hr_bpm_max BETWEEN 20 AND 250),
+    ADD CONSTRAINT exercise_sets_hr_order_check
+    CHECK (hr_bpm_max IS NULL OR hr_bpm_avg IS NULL OR hr_bpm_max >= hr_bpm_avg),
+    ADD CONSTRAINT exercise_sets_cadence_check
+    CHECK (cadence IS NULL OR cadence BETWEEN 0 AND 300),
+    ADD CONSTRAINT exercise_sets_speed_check
+    CHECK (speed_kph IS NULL OR speed_kph BETWEEN 0 AND 100);
+
+ALTER TABLE template_items
+    ADD CONSTRAINT template_items_hr_min_check
+    CHECK (target_hr_min IS NULL OR target_hr_min BETWEEN 20 AND 250),
+    ADD CONSTRAINT template_items_hr_max_check
+    CHECK (target_hr_max IS NULL OR target_hr_max BETWEEN 20 AND 250),
+    ADD CONSTRAINT template_items_hr_range_check
+    CHECK (target_hr_max IS NULL OR target_hr_min IS NULL OR target_hr_max >= target_hr_min),
+    ADD CONSTRAINT template_items_cadence_check
+    CHECK (target_cadence IS NULL OR target_cadence BETWEEN 0 AND 300),
+    ADD CONSTRAINT template_items_speed_check
+    CHECK (target_speed_kph IS NULL OR target_speed_kph BETWEEN 0 AND 100);
+
+COMMENT ON COLUMN exercise_sets.cadence IS
+    'Per-minute count; unit follows the movement — crank rpm cycling, steps running, skips on a rope.';
+COMMENT ON COLUMN exercise_sets.speed_kph IS 'Canonical kph; displayed as mph at the edge.';
+COMMENT ON COLUMN template_items.target_hr_min IS 'Lower bound of a prescribed HR zone ("HR 160-175").';
+COMMENT ON COLUMN template_items.target_cadence IS
+    'Per-minute count; unit follows the movement, as for exercise_sets.cadence.';
+
+-- The bike was seeded (SB-445) with only duration/distance because these
+-- measures did not exist. It is the movement the whole aerobic day is
+-- prescribed by heart rate on, so give it the full set now.
+UPDATE exercises
+SET measures = ARRAY['duration_s', 'distance_m', 'hr_bpm', 'cadence', 'speed_kph']
+WHERE key = 'bike';
+
+-- The other movements the 2026-07-30 plan drives by heart rate.
+UPDATE exercises
+SET measures = array_append(measures, 'hr_bpm')
+WHERE key IN ('easy_jog', 'interval_run', 'jump_rope')
+  AND NOT ('hr_bpm' = ANY (measures));

--- a/tests/test_workout_range_validation.py
+++ b/tests/test_workout_range_validation.py
@@ -8,7 +8,7 @@ it is caught in the model rather than surfacing as a database CHECK violation.
 import pytest
 from pydantic import ValidationError
 
-from src.shared.models.workout import RestMode, TemplateItemCreate
+from src.shared.models.workout import ExerciseSetCreate, RestMode, TemplateItemCreate
 
 
 def test_ordered_ranges_are_accepted() -> None:
@@ -71,3 +71,60 @@ def test_existing_items_are_unaffected() -> None:
     item = TemplateItemCreate(exercise_key="pushups", target_reps=15)
     assert item.target_reps_max is None
     assert item.rest_mode is None
+
+
+# --- HR / cadence / speed (SB-447) -------------------------------------------
+
+
+def test_hr_zone_round_trips() -> None:
+    item = TemplateItemCreate(
+        exercise_key="bike",
+        target_hr_min=160,
+        target_hr_max=175,
+        target_cadence=170,
+        target_speed_kph=32.19,
+    )
+    assert (item.target_hr_min, item.target_hr_max) == (160, 175)
+    assert item.target_cadence == 170
+
+
+def test_inverted_hr_zone_is_rejected() -> None:
+    with pytest.raises(ValidationError) as exc:
+        TemplateItemCreate(exercise_key="bike", target_hr_min=175, target_hr_max=160)
+    assert "target_hr_max" in str(exc.value)
+
+
+@pytest.mark.parametrize("bpm", [10, 610])
+def test_impossible_heart_rates_are_rejected(bpm: int) -> None:
+    """Bounds catch a transposed digit, not implausible coaching."""
+    with pytest.raises(ValidationError):
+        TemplateItemCreate(exercise_key="bike", target_hr_min=bpm)
+
+
+def test_matthews_170_cadence_is_allowed() -> None:
+    """170 is not sustainable bike cadence and is probably running cadence in
+    steps/min — but it is what the coach wrote, and rejecting it in the model
+    would block his plan before he has been asked. The judgement stays advisory
+    in the log-workout skill.
+    """
+    assert TemplateItemCreate(exercise_key="bike", target_cadence=170).target_cadence == 170
+
+
+def test_logged_set_carries_hr_cadence_speed() -> None:
+    st = ExerciseSetCreate(
+        exercise_key="bike", hr_bpm_avg=168, hr_bpm_max=181, cadence=95, speed_kph=32.19
+    )
+    assert st.hr_bpm_avg == 168
+    assert st.speed_kph == 32.19
+
+
+def test_logged_hr_max_below_average_is_rejected() -> None:
+    with pytest.raises(ValidationError) as exc:
+        ExerciseSetCreate(exercise_key="bike", hr_bpm_avg=180, hr_bpm_max=150)
+    assert "hr_bpm_max" in str(exc.value)
+
+
+def test_sets_without_the_new_measures_are_unchanged() -> None:
+    st = ExerciseSetCreate(exercise_key="pushups", reps=15)
+    assert st.hr_bpm_avg is None
+    assert st.cadence is None


### PR DESCRIPTION
Fixes SB-447 — the last of the three that block representing Matthew's 2026-07-30 plan (after SB-448 and SB-446).

## Why

The plan is the first to prescribe HR, cadence and speed, and the ask was explicit:

> *"insert as many metrics as you can ---> adjust, assess. I'll be there for it."*

> Bike intervals: 2 min on / 1 min recovery, "on" pace = **HR 160-175**
> No HR monitor: **170 rpm** or **20 mph**
> Aerobic day: keep **HR 120-145**

None of it existed anywhere. `extra` JSONB would have meant no trending, no review, no charts — defeating the instruction.

## What

`exercise_sets` gains `hr_bpm_avg`, `hr_bpm_max`, `cadence`, `speed_kph`; `template_items` gains `target_hr_min/max`, `target_cadence`, `target_speed_kph`. Speed is canonical kph shown as mph, matching the kg/lb convention.

The **bike** — seeded yesterday with only duration and distance because these measures didn't exist — now carries the full set. `easy_jog`, `interval_run` and `jump_rope` gain `hr_bpm`, since the aerobic day is prescribed by heart rate on all of them.

```
  1. bike    2:00 · HR 160-175 · 170/min · 20mph · rest 60s
```

## Two judgement calls worth your eyes

**Cadence is unit-agnostic, not `cadence_rpm` as the ticket proposed.** 170 is not sustainable bike cadence (elite is ~100-120) — but it *is* textbook running cadence in steps/min. Baking "rpm" into the column name would be wrong for half the movements, so it's a per-minute count whose unit follows the exercise: crank revolutions cycling, steps running, skips on a rope. Still worth asking Matthew what he meant, but the schema no longer depends on the answer.

**An HR zone is not a rep range.** Exceeding a rep range is over-delivery, so SB-446's grader shows it green. Exceeding a heart-rate ceiling is the *opposite* of the prescription — the whole point of "keep HR 120-145" is not going harder. So `_zone_status` grades below / in / above with above in red, and there's a test guarding against a future refactor collapsing it back into `_range_status`.

**Bounds reject a transposed 610 bpm but allow 170 cadence.** Judging whether a value is plausible stays advisory in the log-workout skill, where a human sees it. A hard limit would reject every one of Matthew's sessions before he's been asked.

## Verification

Migration applied and verified against local Supabase (Docker is working again):

```
bike|{duration_s,distance_m,hr_bpm,cadence,speed_kph}
violates check constraint "template_items_hr_range_check"   # HR 175-160
violates check constraint "exercise_sets_hr_avg_check"      # 610 bpm
170 cadence -> allowed
```

Suites: 186 root, 338 backend, 122 stk, 267 frontend. Typecheck clean.

## Open for Matthew

What 170 refers to, and whether the jump rope is 3x3 min (conditioning block) or 5 min steady (aerobic day) — both appear in the same plan. Recorded on the tickets, not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)