### PR TITLE
fix(workouts): the athlete's card was under-reporting the plan (SB-484)

### DIFF
--- a/frontend/src/components/WorkoutTemplateCard.vue
+++ b/frontend/src/components/WorkoutTemplateCard.vue
@@ -72,17 +72,32 @@
           <span class="text-gray-300 font-medium">· {{ sec.items.length }}</span>
         </h4>
         <ul>
+          <template v-for="(row, ri) in sec.rows" :key="row.kind === 'group' ? row.key : row.item.id">
+            <!-- Alternatives are one choice, not a checklist (SB-448). -->
+            <li
+              v-if="row.kind === 'group'"
+              class="flex items-center gap-2 pt-1.5 pb-0.5 px-2 -mx-2 text-[11px] font-semibold uppercase tracking-wide text-gray-400"
+            >
+              {{ row.label }} · do one
+            </li>
           <li
-            v-for="(item, i) in sec.items"
+            v-for="item in row.kind === 'group' ? row.items : [row.item]"
             :key="item.id"
             class="group flex items-center justify-between gap-3 py-1.5 px-2 -mx-2 rounded-lg hover:bg-gray-50 transition-colors print:hover:bg-transparent"
+            :class="row.kind === 'group' ? 'pl-6' : ''"
           >
             <span class="flex items-center gap-2 min-w-0">
               <span
-                v-if="sec.key === 'main'"
+                v-if="row.kind === 'group'"
+                class="w-5 h-5 shrink-0 grid place-items-center text-gray-300 text-[11px]"
+              >
+                ○
+              </span>
+              <span
+                v-else-if="sec.key === 'main'"
                 class="w-5 h-5 shrink-0 grid place-items-center rounded-full bg-brand-50 text-brand-700 text-[11px] font-semibold tabular-nums"
               >
-                {{ i + 1 }}
+                {{ ri + 1 }}
               </span>
               <span class="text-sm text-gray-900 truncate">{{ nameFor(item.exercise_key) }}</span>
               <span
@@ -96,6 +111,7 @@
               <span v-for="p in pills(item)" :key="p.text" class="pill" :class="p.cls">{{ p.text }}</span>
             </span>
           </li>
+          </template>
         </ul>
       </section>
     </div>
@@ -106,7 +122,9 @@
 import { computed, ref } from 'vue'
 import { Calendar, Check, ClipboardCheck, Pencil, Printer, Repeat, Trash2 } from 'lucide-vue-next'
 import type { Exercise, TemplateItem, WorkoutSectionKey, WorkoutTemplate } from '@/types/workout'
-import { SECTIONS, fmtDuration, kgToLb, prettifyKey } from '@/utils/workoutPayload'
+import { SECTIONS, prettifyKey } from '@/utils/workoutPayload'
+import { groupOptionItems } from '@/utils/optionGroups'
+import { targetPills } from '@/utils/targets'
 import { formatDayMonth, formatRelativeTime } from '@/utils/format'
 
 const props = defineProps<{
@@ -132,34 +150,39 @@ const ACCENT: Record<WorkoutSectionKey, { rule: string; label: string }> = {
   cooldown: { rule: 'border-sky-300', label: 'text-sky-600' },
 }
 
-const sections = computed(() =>
-  SECTIONS.map((s) => ({
-    key: s.key,
-    title: s.label,
-    ...ACCENT[s.key],
-    items: props.template.items
-      .filter((it) => it.section === s.key)
-      .sort((a, b) => a.position - b.position),
-  })).filter((s) => s.items.length > 0),
-)
+const KNOWN = new Set(SECTIONS.map((s) => s.key as string))
+const FALLBACK_ACCENT = { rule: 'border-gray-200', label: 'text-gray-500' }
 
-interface Pill {
-  text: string
-  cls: string
-}
-const pills = (it: TemplateItem): Pill[] => {
-  const out: Pill[] = []
-  const base = 'bg-gray-100 text-gray-600'
-  if (it.target_reps != null) out.push({ text: `${it.target_reps} reps`, cls: base })
-  if (it.target_duration_seconds != null)
-    out.push({ text: fmtDuration(it.target_duration_seconds), cls: base })
-  if (it.target_load_kg != null)
-    out.push({ text: `${kgToLb(it.target_load_kg)} lb`, cls: 'bg-amber-50 text-amber-700' })
-  if (it.target_distance_m != null) out.push({ text: `${it.target_distance_m} m`, cls: base })
-  if (it.rest_seconds != null)
-    out.push({ text: `rest ${fmtDuration(it.rest_seconds)}`, cls: 'bg-gray-50 text-gray-400' })
-  return out
-}
+/**
+ * Every section the template actually uses (SB-484).
+ *
+ * `section` is free text, but this used to filter against a fixed
+ * warmup/main/cooldown whitelist — so a plan with a `speed_endurance` block
+ * silently rendered without its intervals, and the athlete had no way to know
+ * anything was missing. Known sections keep their order and accent; anything
+ * else follows, in the order the items appear.
+ */
+const sections = computed(() => {
+  const byKey = new Map<string, TemplateItem[]>()
+  for (const it of [...props.template.items].sort((a, b) => a.position - b.position)) {
+    const key = it.section || 'main'
+    if (!byKey.has(key)) byKey.set(key, [])
+    byKey.get(key)!.push(it)
+  }
+  const keys = [
+    ...SECTIONS.map((s) => s.key as string).filter((k) => byKey.has(k)),
+    ...[...byKey.keys()].filter((k) => !KNOWN.has(k)),
+  ]
+  return keys.map((key) => ({
+    key,
+    title: SECTIONS.find((s) => s.key === key)?.label ?? prettifyKey(key),
+    ...(ACCENT[key as WorkoutSectionKey] ?? FALLBACK_ACCENT),
+    rows: groupOptionItems(byKey.get(key)!),
+    items: byKey.get(key)!,
+  }))
+})
+
+const pills = targetPills
 
 const rootEl = ref<HTMLElement | null>(null)
 

--- a/frontend/src/components/__tests__/WorkoutTemplateCard.test.ts
+++ b/frontend/src/components/__tests__/WorkoutTemplateCard.test.ts
@@ -126,3 +126,76 @@ describe('WorkoutTemplateCard', () => {
     expect(w.text()).toContain('Jul 28')
   })
 })
+
+// --- SB-484: the card had been under-reporting the plan ----------------------
+
+const sbTemplate = (items: TemplateItem[]): WorkoutTemplate => ({
+  ...template,
+  id: 't2',
+  name: 'Speed Endurance — Track',
+  items,
+})
+
+const render484 = (items: TemplateItem[]) =>
+  mount(WorkoutTemplateCard, { props: { template: sbTemplate(items), readonly: true } })
+
+describe('WorkoutTemplateCard — full prescription (SB-484)', () => {
+  it('shows items in sections outside warmup/main/cooldown', () => {
+    // The worst of the bug, because it was silent: `sections` filtered against
+    // a fixed whitelist while `section` is free text, so a speed_endurance
+    // block rendered without its intervals and nothing said anything was gone.
+    const w = render484([
+      ti({ id: 'a', position: 0, section: 'warmup', exercise_key: 'easy_jog' }),
+      ti({ id: 'b', position: 1, section: 'speed_endurance', exercise_key: 'interval_run' }),
+      ti({ id: 'c', position: 2, section: 'accelerations', exercise_key: 'ground_start_accel' }),
+    ])
+
+    const text = w.text()
+    expect(text).toContain('Interval run')
+    expect(text).toContain('Ground start accel')
+    expect(text).toContain('Speed endurance')
+  })
+
+  it('renders a rep range rather than its lower bound', () => {
+    const w = render484([ti({ position: 0, target_reps: 8, target_reps_max: 12 })])
+    expect(w.text()).toContain('8-12 reps')
+  })
+
+  it('renders a heart-rate zone', () => {
+    const w = render484([ti({ position: 0, target_hr_min: 120, target_hr_max: 145 })])
+    expect(w.text()).toContain('HR 120-145')
+  })
+
+  it('renders alternatives as one choice', () => {
+    const w = render484([
+      ti({
+        position: 0,
+        exercise_key: 'easy_jog',
+        option_group: 'aerobic',
+        option_group_label: 'Aerobic engine',
+      }),
+      ti({ position: 1, exercise_key: 'bike', option_group: 'aerobic' }),
+      ti({ position: 2, exercise_key: 'jump_rope', option_group: 'aerobic' }),
+    ])
+    const text = w.text()
+    expect(text).toContain('Aerobic engine')
+    expect(text).toContain('do one')
+  })
+
+  it('shows full recovery instead of nothing', () => {
+    const w = render484([ti({ position: 0, rest_mode: 'full' })])
+    expect(w.text()).toContain('full recovery')
+  })
+
+  it('shows a load range in lb', () => {
+    const w = render484([ti({ position: 0, target_load_kg: 2.26796, target_load_max_kg: 3.62874 })])
+    expect(w.text()).toContain('5-8 lb')
+  })
+
+  it('renders every item of a twelve-item circuit', () => {
+    const items = Array.from({ length: 12 }, (_, i) =>
+      ti({ id: `i${i}`, position: i, exercise_key: `ex_${i}`, target_duration_seconds: 30 }),
+    )
+    expect(render484(items).findAll('li')).toHaveLength(12)
+  })
+})

--- a/frontend/src/utils/__tests__/targets.test.ts
+++ b/frontend/src/utils/__tests__/targets.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { fmtRange, hrZoneText, restText, durationText, targetPills } from '../targets'
+import type { TemplateItem } from '@/types/workout'
+
+const item = (over: Partial<TemplateItem> = {}): TemplateItem => ({
+  id: 'x',
+  exercise_key: 'plank',
+  section: 'main',
+  position: 0,
+  target_reps: null,
+  target_duration_seconds: null,
+  target_load_kg: null,
+  target_distance_m: null,
+  rest_seconds: null,
+  variant: null,
+  notes: null,
+  ...over,
+})
+
+const texts = (i: TemplateItem) => targetPills(i).map((p) => p.text)
+
+describe('fmtRange', () => {
+  it('renders a range', () => expect(fmtRange(8, 12)).toBe('8-12'))
+  it('renders a lone bound', () => expect(fmtRange(8, null)).toBe('8'))
+  it('collapses equal bounds', () => expect(fmtRange(10, 10)).toBe('10'))
+  it('is empty with nothing set', () => expect(fmtRange(null, null)).toBe(''))
+})
+
+describe('hrZoneText', () => {
+  it('renders a zone', () =>
+    expect(hrZoneText(item({ target_hr_min: 160, target_hr_max: 175 }))).toBe('HR 160-175'))
+  it('renders a floor', () => expect(hrZoneText(item({ target_hr_min: 120 }))).toBe('HR 120+'))
+  it('renders a ceiling', () => expect(hrZoneText(item({ target_hr_max: 145 }))).toBe('HR ≤145'))
+  it('is empty without a zone', () => expect(hrZoneText(item())).toBe(''))
+})
+
+describe('restText', () => {
+  it('says full recovery rather than inventing a number', () =>
+    expect(restText(item({ rest_mode: 'full' }))).toBe('full recovery'))
+  it('full recovery wins over a stored number', () =>
+    expect(restText(item({ rest_mode: 'full', rest_seconds: 60 }))).toBe('full recovery'))
+  it('renders an autoregulated range', () =>
+    expect(restText(item({ rest_seconds: 60, rest_seconds_max: 90, rest_mode: 'autoregulated' })))
+      .toBe('rest 60-90s (by feel)'))
+  it('renders by feel with no numbers', () =>
+    expect(restText(item({ rest_mode: 'autoregulated' }))).toBe('rest by feel'))
+  it('is empty when no rest is prescribed', () => expect(restText(item())).toBe(''))
+})
+
+describe('durationText', () => {
+  it('keeps a range instead of collapsing to the lower bound', () =>
+    expect(durationText(item({ target_duration_seconds: 40, target_duration_max_seconds: 42 })))
+      .toBe('40-42s'))
+  it('formats a single duration', () =>
+    expect(durationText(item({ target_duration_seconds: 1200 }))).toBe('20 min'))
+})
+
+describe('targetPills', () => {
+  it('shows a rep range, not its lower bound', () => {
+    // The bug: 8-12 rendered as "8 reps", which reads as the prescription.
+    expect(texts(item({ target_reps: 8, target_reps_max: 12 }))).toContain('8-12 reps')
+  })
+
+  it('shows a load range in lb', () => {
+    expect(texts(item({ target_load_kg: 2.26796, target_load_max_kg: 3.62874 }))).toContain('5-8 lb')
+  })
+
+  it('carries the whole speed-endurance prescription', () => {
+    const out = texts(
+      item({
+        target_reps: 8,
+        target_reps_max: 12,
+        target_distance_m: 200,
+        target_duration_seconds: 40,
+        target_duration_max_seconds: 42,
+        rest_seconds: 60,
+        rest_seconds_max: 90,
+        rest_mode: 'autoregulated',
+      }),
+    )
+    expect(out).toContain('8-12 reps')
+    expect(out).toContain('40-42s')
+    expect(out).toContain('200 m')
+    expect(out).toContain('rest 60-90s (by feel)')
+  })
+
+  it('shows the heart-rate zone the aerobic day is built on', () => {
+    expect(texts(item({ target_hr_min: 120, target_hr_max: 145 }))).toContain('HR 120-145')
+  })
+
+  it('shows cadence and speed', () => {
+    const out = texts(item({ target_cadence: 170, target_speed_kph: 32.19 }))
+    expect(out).toContain('170/min')
+    expect(out).toContain('20 mph')
+  })
+
+  it('is empty for an item with no targets', () => expect(texts(item())).toEqual([]))
+})

--- a/frontend/src/utils/targets.ts
+++ b/frontend/src/utils/targets.ts
@@ -1,0 +1,103 @@
+/**
+ * How a prescribed target reads (SB-484).
+ *
+ * The CLI card, the printable sheet and the athlete's in-app card each format
+ * the same fields, and they had drifted: the sheet learned ranges, heart-rate
+ * zones and rest modes in SB-446/447, the athlete's card did not — so Gabe's
+ * app showed "8 reps" for a prescribed 8-12 and no heart-rate zone at all.
+ * One implementation, so a future dimension lands everywhere at once.
+ */
+import type { TemplateItem } from '@/types/workout'
+import { fmtDuration, kgToLb } from '@/utils/workoutPayload'
+
+/** A target that may be a range: (8, 12) → "8-12"; (8, null) → "8". */
+export function fmtRange(
+  lo?: number | null,
+  hi?: number | null,
+  unit = '',
+): string {
+  if (lo != null && hi != null && hi !== lo) return `${lo}-${hi}${unit}`
+  const value = lo ?? hi
+  return value != null ? `${value}${unit}` : ''
+}
+
+/** A prescribed heart-rate zone: "HR 160-175", "HR 120+", "HR ≤145". */
+export function hrZoneText(item: TemplateItem): string {
+  const { target_hr_min: lo, target_hr_max: hi } = item
+  if (lo == null && hi == null) return ''
+  if (lo != null && hi != null) return hi === lo ? `HR ${lo}` : `HR ${lo}-${hi}`
+  return lo != null ? `HR ${lo}+` : `HR ≤${hi}`
+}
+
+/**
+ * Rest as prescribed — which is not always a number.
+ *
+ * "Full recovery" and "go off how you feel" are conditions the athlete
+ * resolves; showing an invented duration would misreport the plan.
+ */
+export function restText(item: TemplateItem): string {
+  if (item.rest_mode === 'full') return 'full recovery'
+  if (item.rest_seconds == null && item.rest_seconds_max == null) {
+    return item.rest_mode === 'autoregulated' ? 'rest by feel' : ''
+  }
+  const lo = item.rest_seconds
+  const hi = item.rest_seconds_max
+  const range =
+    lo != null && hi != null && hi !== lo
+      ? `${lo}-${hi}s`
+      : fmtDuration((lo ?? hi) as number)
+  return item.rest_mode === 'autoregulated' ? `rest ${range} (by feel)` : `rest ${range}`
+}
+
+/** Duration, honouring a range: 40-42s rather than the lower bound alone. */
+export function durationText(item: TemplateItem): string {
+  const lo = item.target_duration_seconds
+  const hi = item.target_duration_max_seconds
+  if (lo == null && hi == null) return ''
+  if (lo != null && hi != null && hi !== lo) return `${lo}-${hi}s`
+  return fmtDuration((lo ?? hi) as number)
+}
+
+export interface TargetPill {
+  text: string
+  cls: string
+}
+
+const BASE = 'bg-gray-100 text-gray-600'
+const LOAD = 'bg-amber-50 text-amber-700'
+const ZONE = 'bg-rose-50 text-rose-700'
+const REST = 'bg-gray-50 text-gray-400'
+
+/** Every prescribed dimension of one item, as display pills. */
+export function targetPills(item: TemplateItem): TargetPill[] {
+  const out: TargetPill[] = []
+
+  const reps = fmtRange(item.target_reps, item.target_reps_max)
+  if (reps) out.push({ text: `${reps} reps`, cls: BASE })
+
+  const duration = durationText(item)
+  if (duration) out.push({ text: duration, cls: BASE })
+
+  if (item.target_load_kg != null || item.target_load_max_kg != null) {
+    // Prescribed in lb, stored canonical kg — round each bound so 5-8 lb
+    // survives the round-trip instead of becoming 5-8.0000001.
+    const load = fmtRange(kgToLb(item.target_load_kg), kgToLb(item.target_load_max_kg))
+    if (load) out.push({ text: `${load} lb`, cls: LOAD })
+  }
+
+  if (item.target_distance_m != null) out.push({ text: `${item.target_distance_m} m`, cls: BASE })
+
+  const zone = hrZoneText(item)
+  if (zone) out.push({ text: zone, cls: ZONE })
+
+  // Cadence carries no unit of its own: rpm on a bike, steps running, skips on
+  // a rope — it follows the movement (SB-447).
+  if (item.target_cadence != null) out.push({ text: `${item.target_cadence}/min`, cls: BASE })
+  if (item.target_speed_kph != null)
+    out.push({ text: `${Math.round(item.target_speed_kph * 0.621371)} mph`, cls: BASE })
+
+  const rest = restText(item)
+  if (rest) out.push({ text: rest, cls: REST })
+
+  return out
+}

--- a/frontend/src/views/WorkoutPrintView.vue
+++ b/frontend/src/views/WorkoutPrintView.vue
@@ -118,6 +118,7 @@ import { apiCall } from '@/config/api'
 import type { Exercise, TemplateItem, WorkoutTemplate } from '@/types/workout'
 import type { Athlete } from '@/types/coach'
 import { groupOptionItems } from '@/utils/optionGroups'
+import { fmtRange, hrZoneText, restText } from '@/utils/targets'
 
 const route = useRoute()
 const athleteId = String(route.params.athleteId)
@@ -174,25 +175,6 @@ const fmtSecs = (s: number) => {
   return `${s} sec`
 }
 
-// A target may be a range (SB-446): "8-12", "5-8 lb", "60-90 sec".
-const fmtRange = (lo?: number | null, hi?: number | null, unit = ''): string => {
-  if (lo != null && hi != null && hi !== lo) return `${lo}-${hi}${unit}`
-  const value = lo ?? hi
-  return value != null ? `${value}${unit}` : ''
-}
-
-// Rest is not always a number: "full recovery" and "go off how you feel" are
-// conditions the athlete resolves, and printing an invented number would
-// misreport what the coach wrote.
-const restText = (item: TemplateItem): string => {
-  if (item.rest_mode === 'full') return 'rest: full recovery'
-  if (item.rest_seconds == null && item.rest_seconds_max == null) {
-    return item.rest_mode === 'autoregulated' ? 'rest: by feel' : ''
-  }
-  const range = fmtRange(item.rest_seconds, item.rest_seconds_max, ' sec')
-  return item.rest_mode === 'autoregulated' ? `rest ${range} (by feel)` : `rest ${range}`
-}
-
 const targetText = (item: TemplateItem): string => {
   const parts: string[] = []
   const reps = fmtRange(item.target_reps, item.target_reps_max)
@@ -218,13 +200,8 @@ const targetText = (item: TemplateItem): string => {
     )
   }
   // A prescribed heart-rate zone is the point of the in-season aerobic day.
-  if (item.target_hr_min != null || item.target_hr_max != null) {
-    const lo = item.target_hr_min
-    const hi = item.target_hr_max
-    parts.push(
-      lo != null && hi != null ? `HR ${lo}-${hi}` : lo != null ? `HR ${lo}+` : `HR ≤${hi}`,
-    )
-  }
+  const zone = hrZoneText(item)
+  if (zone) parts.push(zone)
   if (item.target_cadence != null) parts.push(`${item.target_cadence}/min`)
   if (item.target_speed_kph != null)
     parts.push(`${Math.round(item.target_speed_kph * 0.621371)} mph`)


### PR DESCRIPTION
Fixes SB-484

Found answering "what should Gabe expect when he logs in" after building Matthew's plan. `WorkoutTemplateCard` is what he sees at `/my/workouts`; it predates SB-446/447/448 and was never updated with them, so it disagreed with the printable sheet those tickets *did* update.

## The worst of it was silent

`sections` filtered against a fixed `warmup | main | cooldown` whitelist while `template_items.section` is free text. Speed Endurance — Track rendered with **only its warm-up** — all three interval sets and the ground-to-sprint work were simply absent, with nothing indicating anything was missing.

An athlete can't notice what he was never shown. That's the part that made this worth fixing today rather than ticketing.

## The rest was wrong rather than absent

| shown | prescribed |
| --- | --- |
| `8 reps` | 8-12 |
| `40s` | 40-42s |
| `5 lb` | 5-8 lb |
| `rest 60s` | 60-90s, by feel |
| three separate items | run **or** bike **or** rope |
| *nothing* | HR 120-145 |
| *nothing* | full recovery |

A lower bound presenting as the target is worse than showing nothing.

## Changes

- Sections render whatever the template uses: known ones keep their order and accent, anything else follows with a prettified heading.
- `groupOptionItems` reused, so alternatives render as one "do one" block.
- Target formatting extracted to `src/utils/targets.ts`; the print view drops its private copies. Three surfaces were formatting the same fields and this ticket exists because one drifted — a fourth dimension shouldn't need remembering in three places.

## Note on the tests

While writing the new component tests I overwrote the existing `WorkoutTemplateCard.test.ts`, destroying 12 tests covering SB-332/333/334/335 (readonly mode, created date, completed badge, scheduled date, edit/delete emits, catalog name fallback, section ordering). I caught it from the `M` in `git status` — an added file shouldn't show as modified — and restored them from `HEAD~1` before amending. The file now has all 19, and the originals passing against the rewritten component is independent evidence the refactor didn't regress existing behaviour.

Frontend suite: 295 passing. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)