### PR TITLE
fix(frontend): never cache index.html, and recover from a mid-session deploy (SB-485)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -13,9 +13,28 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
+    # Hashed filenames change every build, so these are safe to keep forever.
+    # NOTE: add_header is NOT inherited into a location that declares its own,
+    # so the server-level security headers are repeated here deliberately.
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+    }
+
+    # index.html is the one file that must NEVER be cached (SB-485). It names
+    # the hashed chunks, and every build renames them — so a stale copy asks
+    # for files that no longer exist and the app dies with "Failed to fetch
+    # dynamically imported module". With no Cache-Control at all, browsers fall
+    # back to heuristic caching and do exactly that. ETag keeps the revalidation
+    # a cheap 304.
+    location = /index.html {
+        add_header Cache-Control "no-cache" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
     }
 
     # SPA fallback

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -163,4 +163,36 @@ router.beforeEach(async (to) => {
   }
 })
 
+/**
+ * Recover when a deploy lands mid-session (SB-485).
+ *
+ * Route components are lazy chunks with hashed names. If the app is rebuilt
+ * while someone has the page open, their next navigation asks for a filename
+ * that no longer exists and Vue Router raises "Failed to fetch dynamically
+ * imported module" — a dead screen with nothing to click.
+ *
+ * Reloading fetches the current index.html and its live chunk names. The
+ * sessionStorage flag means a genuinely broken build reloads once and then
+ * surfaces the error, rather than looping forever.
+ */
+const RELOAD_FLAG = 'stk:chunk-reload'
+
+router.onError((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error)
+  const isStaleChunk =
+    /Failed to fetch dynamically imported module|Importing a module script failed|error loading dynamically imported module/i.test(
+      message,
+    )
+  if (!isStaleChunk) return
+  if (sessionStorage.getItem(RELOAD_FLAG)) return
+  sessionStorage.setItem(RELOAD_FLAG, '1')
+  window.location.reload()
+})
+
+// A completed navigation means the running bundle is current — clear the guard
+// so a later deploy can trigger its own single reload.
+router.afterEach(() => {
+  sessionStorage.removeItem(RELOAD_FLAG)
+})
+
 export default router


### PR DESCRIPTION
Fixes SB-485

## What Gabe saw

Logged in, and the app was broken:

```
TypeError: Failed to fetch dynamically imported module:
https://myrunstreak.run/assets/MyWorkoutsView-BrPZqAZn….js
```

plus he landed on `/coach` showing "Coach privileges required".

## One cause, both symptoms

His browser was running `index-B3EKlNwy.js`; the server serves `index-CErKnvxx.js`.

- the lazy chunk his old bundle asks for **404s** — today's deploys renamed every hashed file
- landing a non-coach on `/coach` is what the bundle did *before* SB-331 taught `resolveLanding` to ignore a `coach` preference for non-coaches

So he wasn't hitting two bugs; he was running last week's app.

## Why his index.html went stale

It was served with **no `Cache-Control` at all** — only `ETag` and `Last-Modified`. With no explicit directive, browsers fall back to *heuristic* caching (commonly ~10% of the time since `Last-Modified`) and can serve a stale copy without revalidating.

`nginx.conf` had the SPA rule exactly backwards:

| file | was | should be |
| --- | --- | --- |
| hashed assets (names change every build) | `immutable`, 1 year | ✅ correct |
| `index.html` (names those chunks) | nothing — cached by guess | ❌ must revalidate |

## Changes

1. **`index.html` → `Cache-Control: no-cache`.** `ETag` keeps it a 304, so the cost is one conditional request per load.
2. **Security headers repeated in the new block.** `add_header` is not inherited once a location declares its own — the assets block had already been silently losing `X-Frame-Options` and friends this way, so it gets them back too.
3. **`router.onError` reloads once on a chunk-import failure.** No cache policy helps someone already holding the page when a deploy lands, so the app heals itself instead of showing a dead screen. Guarded by a `sessionStorage` flag and cleared after any successful navigation, so a genuinely broken build surfaces its error instead of looping.

## Verification

Built the real image and curled it:

```
index.html      Cache-Control: no-cache          + security headers
assets/index-*  max-age=31536000, immutable      + security headers
/my/workouts    200, Cache-Control: no-cache     (SPA fallback inherits it)
```

`nginx -t` passes in the image. Frontend suite green.

## Note

This stops it recurring. **Anyone already holding a stale `index.html` — Gabe right now — needs one hard refresh** (⌘⇧R), because his cached copy predates this header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)