### PR TITLE
feat(workouts): Gabe can build, print and log his own sessions (SB-486)

### DIFF
--- a/backend/admin.py
+++ b/backend/admin.py
@@ -60,3 +60,16 @@ def require_athlete_access(user_id: UUID, athlete_id: UUID) -> None:
     """Raise 403 unless the user may act on this athlete."""
     if not can_access_athlete(user_id, athlete_id):
         raise HTTPException(status_code=_FORBIDDEN, detail="No access to this athlete")
+
+
+def coaches_athlete(user_id: UUID, athlete_id: UUID) -> bool:
+    """True if the user *coaches* this athlete, as opposed to *being* them.
+
+    ``can_access_athlete`` deliberately answers yes to both, which is right for
+    reads. Writes need the distinction: an athlete may edit what they authored
+    themselves, while their coach may edit anything of theirs (SB-486).
+    """
+    supabase = get_supabase_client()
+    if CoachAthletesRepository(supabase).active_link_exists(user_id, athlete_id):
+        return True
+    return is_admin(user_id)

--- a/backend/routes/workouts.py
+++ b/backend/routes/workouts.py
@@ -12,7 +12,7 @@ from datetime import date
 from typing import Any
 from uuid import UUID
 
-from backend.admin import is_admin, require_athlete_access
+from backend.admin import coaches_athlete, is_admin, require_athlete_access
 from backend.auth import authenticate_request
 from backend.cache import invalidate_user
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
@@ -51,6 +51,33 @@ def acting_athlete(
 
 
 # ---------------------------------------------------------------- catalog
+
+
+def _require_may_modify(
+    user_id: UUID, athlete_id: UUID | None, row: dict[str, Any], kind: str
+) -> None:
+    """Enforce who may change an athlete-scoped row (SB-486).
+
+    A coach may modify anything belonging to an athlete they coach. Anyone else
+    with access — which means the athlete themselves — may modify only what
+    they authored. So Matthew's prescription stays authoritative: Gabe can log
+    against it and print it, but not rewrite it.
+
+    Hiding the buttons is not enforcement; without this an athlete could PATCH a
+    coach's template directly. A NULL ``created_by`` predates athlete-authored
+    rows and is treated as the coach's.
+    """
+    if athlete_id is None:
+        return  # self-owned rows: _scope already limits these to the caller
+    if coaches_athlete(user_id, athlete_id):
+        return
+    created_by = row.get("created_by")
+    if created_by and UUID(str(created_by)) == user_id:
+        return
+    raise HTTPException(
+        status.HTTP_403_FORBIDDEN,
+        f"This {kind} was created by your coach — you can use it, but not change it",
+    )
 
 
 @router.get("/exercises", response_model=list[Exercise])
@@ -212,6 +239,11 @@ async def update_template(
     if unknown:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, f"Unknown exercise(s): {sorted(unknown)}")
 
+    existing = WorkoutTemplatesRepository(supabase).get(user_id, template_id, athlete_id=athlete_id)
+    if existing is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Template not found or not yours")
+    _require_may_modify(user_id, athlete_id, existing, "workout")
+
     row = WorkoutTemplatesRepository(supabase).update(
         user_id, template_id, body.model_dump(mode="json", exclude_none=True), athlete_id=athlete_id
     )
@@ -250,9 +282,13 @@ async def delete_template(
     user_id: UUID = Depends(authenticate_request),
     athlete_id: UUID | None = Depends(acting_athlete),
 ) -> None:
-    if not WorkoutTemplatesRepository(get_supabase_client()).delete(
-        user_id, template_id, athlete_id=athlete_id
-    ):
+    repo = WorkoutTemplatesRepository(get_supabase_client())
+    existing = repo.get(user_id, template_id, athlete_id=athlete_id)
+    if existing is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Template not found")
+    _require_may_modify(user_id, athlete_id, existing, "workout")
+
+    if not repo.delete(user_id, template_id, athlete_id=athlete_id):
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Template not found")
     await invalidate_user(user_id)
 
@@ -313,8 +349,15 @@ async def delete_session(
     user_id: UUID = Depends(authenticate_request),
     athlete_id: UUID | None = Depends(acting_athlete),
 ) -> None:
-    if not WorkoutSessionsRepository(get_supabase_client()).delete(
-        user_id, session_id, athlete_id=athlete_id
-    ):
+    repo = WorkoutSessionsRepository(get_supabase_client())
+    existing = repo.get(user_id, session_id, athlete_id=athlete_id)
+    if existing is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
+    # A session is editable by whoever logged it, and by the coach for any of
+    # their athlete's (SB-486) — so Gabe can fix his own typo without being able
+    # to delete a session Matthew recorded.
+    _require_may_modify(user_id, athlete_id, existing, "session")
+
+    if not repo.delete(user_id, session_id, athlete_id=athlete_id):
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
     await invalidate_user(user_id)

--- a/backend/tests/test_workout_author_rights.py
+++ b/backend/tests/test_workout_author_rights.py
@@ -1,0 +1,175 @@
+"""SB-486: who may change an athlete-scoped workout row.
+
+Matthew builds and assigns; Gabe can log against a prescription and print it,
+but not rewrite it. Whatever Gabe authors himself is his to edit, and Matthew as
+coach can edit anything of his athlete's.
+
+Hiding the buttons is not enforcement — without the route guard an athlete could
+PATCH a coach's template straight through the API, so these cover the API rule
+rather than the UI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+
+COACH = uuid4()
+ATHLETE_USER = uuid4()
+ATHLETE_ID = uuid4()
+
+
+def _template(created_by: UUID | None) -> dict[str, Any]:
+    return {
+        "id": str(uuid4()),
+        "name": "Upper Body Day",
+        "type": "circuit",
+        "rounds": 2,
+        "user_id": str(COACH),
+        "athlete_id": str(ATHLETE_ID),
+        "created_by": str(created_by) if created_by else None,
+        "items": [],
+    }
+
+
+def _patch_template(caller: UUID, existing: dict[str, Any], *, is_coach: bool) -> Any:
+    """Call update_template with the repo and coach check stubbed."""
+    repo = MagicMock()
+    repo.get.return_value = existing
+    repo.update.return_value = {**existing, "name": "Edited"}
+    body = MagicMock()
+    body.items = []
+    body.model_dump.return_value = {"name": "Edited"}
+
+    with (
+        patch("backend.routes.workouts.get_supabase_client"),
+        patch("backend.routes.workouts.WorkoutTemplatesRepository", return_value=repo),
+        patch("backend.routes.workouts.ExercisesRepository") as ex,
+        patch("backend.routes.workouts.coaches_athlete", return_value=is_coach),
+        patch("backend.routes.workouts.invalidate_user", new=_noop),
+    ):
+        ex.return_value.keys.return_value = set()
+        from backend.routes.workouts import update_template
+
+        return asyncio.run(
+            update_template(
+                template_id=UUID(existing["id"]),
+                body=body,
+                user_id=caller,
+                athlete_id=ATHLETE_ID,
+            )
+        ), repo
+
+
+async def _noop(*a: Any, **k: Any) -> None:
+    return None
+
+
+def test_coach_may_edit_their_athletes_template() -> None:
+    result, repo = _patch_template(COACH, _template(COACH), is_coach=True)
+    assert result.name == "Edited"
+    repo.update.assert_called_once()
+
+
+def test_athlete_may_not_edit_a_coachs_template() -> None:
+    """The decided rule: Matthew's prescription stays authoritative."""
+    with pytest.raises(HTTPException) as exc:
+        _patch_template(ATHLETE_USER, _template(COACH), is_coach=False)
+
+    assert exc.value.status_code == 403
+    assert "not change it" in str(exc.value.detail)
+
+
+def test_athlete_may_edit_their_own_template() -> None:
+    result, repo = _patch_template(ATHLETE_USER, _template(ATHLETE_USER), is_coach=False)
+    assert result.name == "Edited"
+    repo.update.assert_called_once()
+
+
+def test_null_created_by_is_treated_as_the_coachs() -> None:
+    """Rows predating athlete authorship must not become athlete-editable."""
+    with pytest.raises(HTTPException) as exc:
+        _patch_template(ATHLETE_USER, _template(None), is_coach=False)
+    assert exc.value.status_code == 403
+
+
+def test_missing_template_is_404_not_403() -> None:
+    """Don't leak the existence of another athlete's row through the new check."""
+    repo = MagicMock()
+    repo.get.return_value = None
+    body = MagicMock()
+    body.items = []
+
+    with (
+        patch("backend.routes.workouts.get_supabase_client"),
+        patch("backend.routes.workouts.WorkoutTemplatesRepository", return_value=repo),
+        patch("backend.routes.workouts.ExercisesRepository") as ex,
+        patch("backend.routes.workouts.coaches_athlete", return_value=False),
+    ):
+        ex.return_value.keys.return_value = set()
+        from backend.routes.workouts import update_template
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(
+                update_template(
+                    template_id=uuid4(), body=body, user_id=ATHLETE_USER, athlete_id=ATHLETE_ID
+                )
+            )
+
+    assert exc.value.status_code == 404
+
+
+# --- sessions: editable by their author, and by the coach for any -------------
+
+
+def _delete_session(caller: UUID, existing: dict[str, Any] | None, *, is_coach: bool) -> Any:
+    repo = MagicMock()
+    repo.get.return_value = existing
+    repo.delete.return_value = True
+
+    with (
+        patch("backend.routes.workouts.get_supabase_client"),
+        patch("backend.routes.workouts.WorkoutSessionsRepository", return_value=repo),
+        patch("backend.routes.workouts.coaches_athlete", return_value=is_coach),
+        patch("backend.routes.workouts.invalidate_user", new=_noop),
+    ):
+        from backend.routes.workouts import delete_session
+
+        asyncio.run(delete_session(session_id=uuid4(), user_id=caller, athlete_id=ATHLETE_ID))
+    return repo
+
+
+def _session(created_by: UUID) -> dict[str, Any]:
+    return {"id": str(uuid4()), "athlete_id": str(ATHLETE_ID), "created_by": str(created_by)}
+
+
+def test_athlete_may_delete_the_session_they_logged() -> None:
+    repo = _delete_session(ATHLETE_USER, _session(ATHLETE_USER), is_coach=False)
+    repo.delete.assert_called_once()
+
+
+def test_athlete_may_not_delete_a_session_the_coach_logged() -> None:
+    with pytest.raises(HTTPException) as exc:
+        _delete_session(ATHLETE_USER, _session(COACH), is_coach=False)
+    assert exc.value.status_code == 403
+
+
+def test_coach_may_delete_any_session_of_their_athlete() -> None:
+    repo = _delete_session(COACH, _session(ATHLETE_USER), is_coach=True)
+    repo.delete.assert_called_once()
+
+
+# --- self-owned rows are untouched by any of this -----------------------------
+
+
+def test_self_rows_skip_the_author_check() -> None:
+    """A runner's own workouts have no athlete_id; _scope already limits them to
+    the caller, so the new rule must not apply and must not need created_by."""
+    from backend.routes.workouts import _require_may_modify
+
+    _require_may_modify(ATHLETE_USER, None, {"created_by": None}, "workout")

--- a/frontend/src/components/WorkoutTemplateCard.vue
+++ b/frontend/src/components/WorkoutTemplateCard.vue
@@ -17,6 +17,15 @@
           >
             <Calendar class="w-3 h-3" /> {{ formatDayMonth(template.scheduled_for) }}
           </span>
+          <!-- Who authored it (SB-486). Coaches see at a glance which workouts
+               the athlete added themselves. -->
+          <span
+            v-if="authorLabel"
+            class="inline-flex items-center gap-1 rounded-full bg-violet-50 px-2 py-0.5 text-xs font-semibold text-violet-700"
+            data-testid="author-badge"
+          >
+            {{ authorLabel }}
+          </span>
           <span
             v-if="template.has_session"
             class="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-xs font-semibold text-green-700"
@@ -35,8 +44,9 @@
           Added {{ formatRelativeTime(template.created_at) }}
         </p>
       </div>
-      <div v-if="!readonly" class="flex items-center gap-1 shrink-0 print:hidden">
+      <div v-if="showActions" class="flex items-center gap-1 shrink-0 print:hidden">
         <button
+          v-if="mayLog"
           type="button"
           class="act hover:text-brand-600 hover:bg-brand-50"
           title="Log this"
@@ -46,13 +56,14 @@
         >
           <ClipboardCheck class="w-4 h-4" />
         </button>
-        <button type="button" class="act" title="Print" aria-label="Print workout" @click="$emit('print')">
+        <button v-if="mayPrint" type="button" class="act" title="Print" aria-label="Print workout" @click="$emit('print')">
           <Printer class="w-4 h-4" />
         </button>
-        <button type="button" class="act" title="Edit" aria-label="Edit workout" @click="$emit('edit')">
+        <button v-if="mayEdit" type="button" class="act" title="Edit" aria-label="Edit workout" @click="$emit('edit')">
           <Pencil class="w-4 h-4" />
         </button>
         <button
+          v-if="mayEdit"
           type="button"
           class="act hover:text-red-600 hover:bg-red-50"
           title="Delete"
@@ -127,12 +138,33 @@ import { groupOptionItems } from '@/utils/optionGroups'
 import { targetPills } from '@/utils/targets'
 import { formatDayMonth, formatRelativeTime } from '@/utils/format'
 
-const props = defineProps<{
-  template: WorkoutTemplate
-  exercises?: Exercise[]
-  // Athlete-facing view (SB-332): hide the coach action buttons.
-  readonly?: boolean
-}>()
+const props = withDefaults(
+  defineProps<{
+    template: WorkoutTemplate
+    exercises?: Exercise[]
+    // Athlete-facing view (SB-332): hide the coach action buttons.
+    readonly?: boolean
+    // Finer-grained rights (SB-486). An athlete may log against and print a
+    // workout their coach prescribed, but only edit one they authored — a
+    // single `readonly` boolean could not express that, and it hid Print, which
+    // the paper-first workflow depends on. Undefined = follow `readonly`, so
+    // every existing caller behaves exactly as before.
+    canLog?: boolean
+    canPrint?: boolean
+    canEdit?: boolean
+    // e.g. "Added by Gabe" — the caller knows the names, the card just shows it.
+    authoredBy?: string | null
+  }>(),
+  { canLog: undefined, canPrint: undefined, canEdit: undefined, authoredBy: null },
+)
+
+/** Shown when a caller supplies it — the coach view labels athlete-authored rows. */
+const authorLabel = computed(() => props.authoredBy ?? null)
+
+const mayLog = computed(() => props.canLog ?? !props.readonly)
+const mayPrint = computed(() => props.canPrint ?? !props.readonly)
+const mayEdit = computed(() => props.canEdit ?? !props.readonly)
+const showActions = computed(() => mayLog.value || mayPrint.value || mayEdit.value)
 
 defineEmits<{ (e: 'edit'): void; (e: 'delete'): void; (e: 'log'): void; (e: 'print'): void }>()
 

--- a/frontend/src/composables/useActingAthlete.ts
+++ b/frontend/src/composables/useActingAthlete.ts
@@ -1,0 +1,47 @@
+/**
+ * Which athlete a workout view is acting on (SB-486).
+ *
+ * The builder, logger and print views are already athlete-scoped — they were
+ * just only reachable at `/coach/:athleteId/...`, so the athlete came from the
+ * route. An athlete working on their own workouts has no such param: they are
+ * the subject.
+ *
+ * Both cases resolve to an athlete id, which is all the views and the existing
+ * `actAs()` header need. The API authorises either caller identically —
+ * `can_access_athlete` returns true for the coach *and* for the linked athlete
+ * (backend/admin.py) — so nothing else has to branch on who is asking.
+ */
+import { computed, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import { useMyAthlete } from '@/composables/useCoach'
+
+export function useActingAthlete() {
+  const route = useRoute()
+  const { myAthlete, loadMyAthlete } = useMyAthlete()
+  const resolved = ref(false)
+
+  /** True when the caller is working on their own workouts, not an athlete's. */
+  const isSelf = computed(() => !route.params.athleteId)
+
+  const athleteId = computed<string | null>(() => {
+    const param = route.params.athleteId as string | undefined
+    return param ?? myAthlete.value?.id ?? null
+  })
+
+  /** Where this view's back-link and post-save redirect should go. */
+  const homePath = computed(() =>
+    isSelf.value ? '/my/workouts' : `/coach/${route.params.athleteId as string}`,
+  )
+
+  /**
+   * Resolve the athlete. Only fetches `/me/athlete` when there is no route
+   * param, so the coach path costs nothing extra.
+   */
+  async function resolveAthlete(): Promise<string | null> {
+    if (!route.params.athleteId) await loadMyAthlete()
+    resolved.value = true
+    return athleteId.value
+  }
+
+  return { athleteId, isSelf, homePath, resolved, resolveAthlete }
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -122,6 +122,40 @@ const router = createRouter({
       component: () => import('@/views/MyWorkoutsView.vue'),
       meta: { requiresAuth: true },
     },
+    // An athlete works on their own workouts through the same three views the
+    // coach uses (SB-486). No :athleteId — they are the subject, resolved from
+    // /me/athlete. requiresAuth only: the API authorises the linked athlete
+    // exactly as it does their coach.
+    {
+      path: '/my/workouts/build',
+      name: 'my-workout-builder',
+      component: () => import('@/views/WorkoutBuilderView.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/my/workouts/build/:templateId',
+      name: 'my-workout-editor',
+      component: () => import('@/views/WorkoutBuilderView.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/my/workouts/log',
+      name: 'my-workout-logger',
+      component: () => import('@/views/WorkoutSessionLoggerView.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/my/workouts/log/:templateId',
+      name: 'my-workout-logger-template',
+      component: () => import('@/views/WorkoutSessionLoggerView.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/my/workouts/print/:templateId',
+      name: 'my-workout-print',
+      component: () => import('@/views/WorkoutPrintView.vue'),
+      meta: { requiresAuth: true },
+    },
   ],
   scrollBehavior(_to, _from, savedPosition) {
     return savedPosition ?? { top: 0 }

--- a/frontend/src/types/workout.ts
+++ b/frontend/src/types/workout.ts
@@ -138,6 +138,10 @@ export interface TemplateItem {
 
 export interface WorkoutTemplate {
   id: string
+  // Who authored it (SB-486): the coach who prescribed it, or the athlete
+  // themselves. Drives who may edit it, and the "added by" badge.
+  created_by?: string | null
+  athlete_id?: string | null
   name: string
   type: WorkoutType
   rounds: number
@@ -173,6 +177,11 @@ export interface BuilderItem {
 /** One logged set in the API payload. Only the used dimensions are filled. */
 export interface SessionSetInput {
   exercise_key: string
+  // Measured HR / cadence / speed (SB-447). Speed is canonical kph.
+  hr_bpm_avg?: number | null
+  hr_bpm_max?: number | null
+  cadence?: number | null
+  speed_kph?: number | null
   round_number?: number | null
   set_index?: number | null
   variant?: string | null
@@ -206,6 +215,11 @@ export interface LoggerAttempt {
   load_lb: number | null
   distance_m: number | null
   time_seconds: number | null
+  // Entered in the units a US athlete reads off a watch; converted on the way
+  // out (SB-486). Cadence has no unit of its own — it follows the movement.
+  hr_bpm: number | null
+  cadence: number | null
+  speed_mph: number | null
   rpe: number | null
 }
 

--- a/frontend/src/utils/__tests__/sessionPayload.test.ts
+++ b/frontend/src/utils/__tests__/sessionPayload.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@/utils/sessionPayload'
 import type { Exercise, LoggerAttempt, LoggerRow, WorkoutTemplate } from '@/types/workout'
 
-const ex = (key: string, measures: string[] = []): Exercise => ({
+const ex = (key: string, measures: string[] = ['reps']): Exercise => ({
   key,
   display_name: key,
   category: 'strength',
@@ -102,6 +102,27 @@ describe('buildSessionPayload', () => {
     expect(p.sets).toHaveLength(1)
     expect(p.sets[0].exercise_key).toBe('pushups')
     expect(p.sets[0].set_index).toBeNull() // only one non-empty attempt survived
+  })
+
+  it('keeps a movement that has nothing to measure (SB-486)', () => {
+    // A tick-box exercise carries no `measures`, so there is nothing for the
+    // athlete to type — the row's presence is the record. Dropping it as
+    // "empty" would make a completed workout read as half-done.
+    const p = buildSessionPayload(meta, [
+      row('pushups', { attempts: [attempt({ reps: 8 })] }),
+      { ...row('skywalker'), exercise: ex('skywalker', []) },
+    ])
+
+    expect(p.sets).toHaveLength(2)
+    const tick = p.sets.find((s) => s.exercise_key === 'skywalker')
+    expect(tick).toBeDefined()
+    expect(tick?.reps ?? null).toBeNull()
+  })
+
+  it('still drops a measurable exercise the athlete left blank', () => {
+    // The distinction: nothing *could* be entered vs nothing *was*.
+    const p = buildSessionPayload(meta, [row('plank', { attempts: [attempt()] })])
+    expect(p.sets).toHaveLength(0)
   })
 
   it('carries round_number + trims variant, notes on first set only', () => {

--- a/frontend/src/utils/sessionPayload.ts
+++ b/frontend/src/utils/sessionPayload.ts
@@ -29,6 +29,9 @@ export function blankAttempt(): LoggerAttempt {
     load_lb: null,
     distance_m: null,
     time_seconds: null,
+    hr_bpm: null,
+    cadence: null,
+    speed_mph: null,
     rpe: null,
   }
 }
@@ -41,6 +44,9 @@ function isEmptyAttempt(a: LoggerAttempt): boolean {
     a.load_lb == null &&
     a.distance_m == null &&
     a.time_seconds == null &&
+    a.hr_bpm == null &&
+    a.cadence == null &&
+    a.speed_mph == null &&
     a.rpe == null
   )
 }
@@ -63,6 +69,22 @@ export function buildSessionPayload(meta: SessionMeta, rows: LoggerRow[]): Worko
   const sets: SessionSetInput[] = []
   for (const row of rows) {
     const filled = row.attempts.filter((a) => !isEmptyAttempt(a))
+
+    // Some movements have nothing to measure — a plank variation the coach just
+    // wants ticked off. The catalog says so by carrying no `measures`, and
+    // there is nothing for the athlete to type, so the row's presence IS the
+    // record. Without this it would be dropped as "empty" and the workout would
+    // read as half-done.
+    if (filled.length === 0 && row.exercise.measures.length === 0) {
+      sets.push({
+        exercise_key: row.exercise.key,
+        round_number: row.round_number,
+        set_index: null,
+        variant: row.variant?.trim() || null,
+        notes: row.notes?.trim() || null,
+      })
+      continue
+    }
     const multi = filled.length > 1
     filled.forEach((a, i) => {
       sets.push({
@@ -75,6 +97,9 @@ export function buildSessionPayload(meta: SessionMeta, rows: LoggerRow[]): Worko
         load_kg: lbToKg(a.load_lb),
         distance_m: a.distance_m,
         time_seconds: a.time_seconds,
+        hr_bpm_avg: a.hr_bpm,
+        cadence: a.cadence,
+        speed_kph: a.speed_mph == null ? null : Math.round(a.speed_mph * 1.609344 * 100) / 100,
         rpe: a.rpe,
         notes: i === 0 ? row.notes?.trim() || null : null,
       })

--- a/frontend/src/views/AthleteDetailView.vue
+++ b/frontend/src/views/AthleteDetailView.vue
@@ -58,6 +58,7 @@
           :key="t.id"
           :template="t"
           :exercises="exercises"
+          :authored-by="authoredBy(t)"
           @edit="router.push(`/coach/${athleteId}/build/${t.id}`)"
           @log="router.push(`/coach/${athleteId}/log/${t.id}`)"
           @print="router.push(`/coach/${athleteId}/print/${t.id}`)"
@@ -102,6 +103,7 @@ import { useExercises } from '@/composables/useExercises'
 import AthleteProfileForm from '@/components/AthleteProfileForm.vue'
 import AthleteAccessPanel from '@/components/AthleteAccessPanel.vue'
 import WorkoutTemplateCard from '@/components/WorkoutTemplateCard.vue'
+import type { WorkoutTemplate } from '@/types/workout'
 import { deleteTemplate } from '@/composables/useWorkoutTemplates'
 import type { Athlete } from '@/types/coach'
 
@@ -109,6 +111,17 @@ const route = useRoute()
 const router = useRouter()
 const athleteId = route.params.athleteId as string
 const { athlete, sessions, templates, loading, error, load } = useAthleteDetail(athleteId)
+
+/**
+ * Label a workout the athlete built for themselves (SB-486). A template created
+ * by the linked athlete's own user carries their user id in `created_by`;
+ * anything else came from a coach and needs no badge.
+ */
+const authoredBy = (t: WorkoutTemplate): string | null => {
+  const linked = athlete.value?.linked_user_id
+  if (!linked || !t.created_by || t.created_by !== linked) return null
+  return `Added by ${athlete.value?.display_name ?? 'athlete'}`
+}
 const { exercises, load: loadExercises } = useExercises()
 
 const editing = ref(false)

--- a/frontend/src/views/MyWorkoutsView.vue
+++ b/frontend/src/views/MyWorkoutsView.vue
@@ -1,7 +1,19 @@
 <template>
   <div class="container-app py-8 max-w-2xl">
-    <h1 class="text-2xl font-bold text-gray-900 mb-1">My workouts</h1>
-    <p class="text-sm text-gray-500 mb-6">Workouts your coach has assigned to you.</p>
+    <div class="flex items-start justify-between gap-4 mb-6">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900 mb-1">My workouts</h1>
+        <p class="text-sm text-gray-500">
+          Workouts your coach has assigned, plus any you build yourself.
+        </p>
+      </div>
+      <RouterLink
+        to="/my/workouts/build"
+        class="shrink-0 rounded-lg bg-brand-600 px-3 py-2 text-sm font-medium text-white hover:bg-brand-700"
+      >
+        + New workout
+      </RouterLink>
+    </div>
 
     <div v-if="loading" class="space-y-3">
       <div
@@ -22,7 +34,7 @@
       v-else-if="templates.length === 0"
       class="bg-white rounded-xl border border-gray-100 shadow-sm p-8 text-center text-gray-500"
     >
-      <p>No workouts assigned yet.</p>
+      <p>No workouts yet.</p>
     </div>
 
     <div v-else class="space-y-4">
@@ -31,22 +43,49 @@
         :key="t.id"
         :template="t"
         :exercises="exercises"
-        readonly
+        can-log
+        can-print
+        :can-edit="isMine(t)"
+        @log="router.push(`/my/workouts/log/${t.id}`)"
+        @print="router.push(`/my/workouts/print/${t.id}`)"
+        @edit="router.push(`/my/workouts/build/${t.id}`)"
+        @delete="remove(t)"
       />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { onMounted } from 'vue'
+import { useRouter, RouterLink } from 'vue-router'
 import { useMyAthlete } from '@/composables/useCoach'
 import { useMyWorkouts } from '@/composables/useMyWorkouts'
+import { deleteTemplate } from '@/composables/useWorkoutTemplates'
 import WorkoutTemplateCard from '@/components/WorkoutTemplateCard.vue'
+import type { WorkoutTemplate } from '@/types/workout'
 
 const router = useRouter()
 const { myAthlete, loadMyAthlete } = useMyAthlete()
 const { templates, exercises, loading, error, load } = useMyWorkouts()
+
+/**
+ * Mine to change (SB-486). A workout the coach prescribed can be logged and
+ * printed but not edited — the API enforces that too, this only keeps the
+ * buttons honest.
+ *
+ * Compared against the athlete's own `linked_user_id` rather than the auth
+ * store: it is the same user id, already loaded here, and keeps this view free
+ * of a Pinia dependency it otherwise would not need.
+ */
+const isMine = (t: WorkoutTemplate): boolean =>
+  !!t.created_by && t.created_by === myAthlete.value?.linked_user_id
+
+const remove = async (t: WorkoutTemplate): Promise<void> => {
+  if (!myAthlete.value) return
+  if (!window.confirm(`Delete "${t.name}"?`)) return
+  await deleteTemplate(t.id, myAthlete.value.id)
+  await load()
+}
 
 onMounted(async () => {
   await loadMyAthlete(true)

--- a/frontend/src/views/WorkoutBuilderView.vue
+++ b/frontend/src/views/WorkoutBuilderView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container-app py-8">
-    <RouterLink :to="`/coach/${athleteId}`" class="text-sm text-brand-600 hover:text-brand-700">
+    <RouterLink :to="homePath" class="text-sm text-brand-600 hover:text-brand-700">
       ← Back
     </RouterLink>
 
@@ -124,17 +124,16 @@ import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import ExercisePicker from '@/components/ExercisePicker.vue'
 import { useExercises } from '@/composables/useExercises'
-import { useRoles } from '@/composables/useCoach'
 import { createTemplate, getTemplate, updateTemplate } from '@/composables/useWorkoutTemplates'
+import { useActingAthlete } from '@/composables/useActingAthlete'
 import { SECTIONS, buildTemplatePayload, kgToLb } from '@/utils/workoutPayload'
 import type { BuilderItem, Exercise, WorkoutSectionKey, WorkoutType } from '@/types/workout'
 
 const route = useRoute()
 const router = useRouter()
-const athleteId = route.params.athleteId as string
+const { athleteId, homePath, resolveAthlete } = useActingAthlete()
 const editingId = (route.params.templateId as string | undefined) || null
 
-const { isCoach, loadRoles } = useRoles()
 const { exercises, load } = useExercises()
 
 const name = ref('')
@@ -203,9 +202,9 @@ const save = async (): Promise<void> => {
       items.value,
       scheduledFor.value,
     )
-    if (editingId) await updateTemplate(editingId, payload, athleteId)
-    else await createTemplate(payload, athleteId)
-    router.push(`/coach/${athleteId}`)
+    if (editingId) await updateTemplate(editingId, payload, athleteId.value!)
+    else await createTemplate(payload, athleteId.value!)
+    router.push(homePath.value)
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Failed to save workout'
   } finally {
@@ -215,7 +214,7 @@ const save = async (): Promise<void> => {
 
 // Load an existing template into the builder state (kg → lb, key → Exercise).
 const prefillFrom = (templateId: string): Promise<void> =>
-  getTemplate(templateId, athleteId).then((tpl) => {
+  getTemplate(templateId, athleteId.value!).then((tpl) => {
     name.value = tpl.name
     type.value = tpl.type
     rounds.value = tpl.rounds
@@ -239,8 +238,10 @@ const prefillFrom = (templateId: string): Promise<void> =>
   })
 
 onMounted(async () => {
-  await loadRoles()
-  if (!isCoach.value) {
+  // Coach or athlete — the gate is having an athlete to build for, not a role.
+  // Athletes author their own workouts too (SB-486).
+  await resolveAthlete()
+  if (!athleteId.value) {
     router.replace('/dashboard')
     return
   }

--- a/frontend/src/views/WorkoutSessionLoggerView.vue
+++ b/frontend/src/views/WorkoutSessionLoggerView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container-app py-8">
-    <RouterLink :to="`/coach/${athleteId}`" class="text-sm text-brand-600 hover:text-brand-700">
+    <RouterLink :to="homePath" class="text-sm text-brand-600 hover:text-brand-700">
       ← Back
     </RouterLink>
 
@@ -86,9 +86,19 @@
         </label>
       </div>
 
+      <!-- Nothing to measure: having it on the list is the record (SB-486). -->
+      <p
+        v-if="isCheckbox(row)"
+        class="mt-2 text-xs text-gray-400"
+        :data-testid="`checkbox-${row.exercise.key}`"
+      >
+        Nothing to measure — listing it here records that it was done.
+      </p>
+
       <!-- Attempts (sets) -->
       <div
         v-for="(a, i) in row.attempts"
+        v-else
         :key="i"
         class="mt-2 flex flex-wrap items-center gap-2 text-xs"
         :data-testid="`attempt-${row.exercise.key}-${i}`"
@@ -123,6 +133,7 @@
       </div>
 
       <button
+        v-if="!isCheckbox(row)"
         type="button"
         class="btn-secondary text-xs mt-2"
         :data-testid="`add-set-${row.exercise.key}`"
@@ -173,7 +184,6 @@ import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import ExercisePicker from '@/components/ExercisePicker.vue'
 import { useExercises } from '@/composables/useExercises'
-import { useRoles } from '@/composables/useCoach'
 import { getTemplate } from '@/composables/useWorkoutTemplates'
 import { createSession } from '@/composables/useWorkoutSessions'
 import {
@@ -184,13 +194,13 @@ import {
   todayISO,
 } from '@/utils/sessionPayload'
 import type { Exercise, LoggerRow, WorkoutType } from '@/types/workout'
+import { useActingAthlete } from '@/composables/useActingAthlete'
 
 const route = useRoute()
 const router = useRouter()
-const athleteId = route.params.athleteId as string
+const { athleteId, homePath, resolveAthlete } = useActingAthlete()
 const templateId = (route.params.templateId as string | undefined) || null
 
-const { isCoach, loadRoles } = useRoles()
 const { exercises, load } = useExercises()
 
 const sessionDate = ref(todayISO())
@@ -213,7 +223,7 @@ const rowKeys = computed(() => rows.value.map((r) => r.exercise.key))
 interface FieldDef {
   measure: string
   label: string
-  model: 'reps' | 'duration_s' | 'load_lb' | 'distance_m' | 'time_seconds'
+  model: 'reps' | 'duration_s' | 'load_lb' | 'distance_m' | 'time_seconds' | 'hr_bpm' | 'cadence' | 'speed_mph'
 }
 const FIELD_DEFS: FieldDef[] = [
   { measure: 'reps', label: 'Reps', model: 'reps' },
@@ -221,13 +231,22 @@ const FIELD_DEFS: FieldDef[] = [
   { measure: 'load_kg', label: 'Load(lb)', model: 'load_lb' },
   { measure: 'distance_m', label: 'Dist(m)', model: 'distance_m' },
   { measure: 'time_s', label: 'Time(s)', model: 'time_seconds' },
+  // SB-447 added these measures to the catalog; the logger never learned them,
+  // so the bike session — which Matthew prescribes by heart rate — could not be
+  // recorded at all.
+  { measure: 'hr_bpm', label: 'HR', model: 'hr_bpm' },
+  { measure: 'cadence', label: '/min', model: 'cadence' },
+  { measure: 'speed_kph', label: 'mph', model: 'speed_mph' },
 ]
-const FALLBACK: FieldDef[] = [FIELD_DEFS[0], FIELD_DEFS[4]] // reps + time
 
-const fieldsFor = (row: LoggerRow): FieldDef[] => {
-  const shown = FIELD_DEFS.filter((f) => row.exercise.measures.includes(f.measure))
-  return shown.length ? shown : FALLBACK
-}
+const fieldsFor = (row: LoggerRow): FieldDef[] =>
+  FIELD_DEFS.filter((f) => row.exercise.measures.includes(f.measure))
+
+/**
+ * A movement with nothing to measure is a tick-box: the coach wants it done,
+ * not quantified. Logging the row at all is the record (see buildSessionPayload).
+ */
+const isCheckbox = (row: LoggerRow): boolean => row.exercise.measures.length === 0
 
 const onPick = (ex: Exercise): void => {
   const existing = rows.value.find((r) => r.exercise.key === ex.key)
@@ -274,8 +293,8 @@ const save = async (): Promise<void> => {
   saving.value = true
   error.value = null
   try {
-    await createSession(payload.value, athleteId)
-    router.push(`/coach/${athleteId}`)
+    await createSession(payload.value, athleteId.value!)
+    router.push(homePath.value)
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Failed to save session'
   } finally {
@@ -284,7 +303,7 @@ const save = async (): Promise<void> => {
 }
 
 const prefillFrom = (id: string): Promise<void> =>
-  getTemplate(id, athleteId).then((tpl) => {
+  getTemplate(id, athleteId.value!).then((tpl) => {
     templateName.value = tpl.name
     sessionType.value = tpl.type
     const byKey = new Map(exercises.value.map((e) => [e.key, e]))
@@ -293,8 +312,10 @@ const prefillFrom = (id: string): Promise<void> =>
   })
 
 onMounted(async () => {
-  await loadRoles()
-  if (!isCoach.value) {
+  // Coach or athlete — the gate is having an athlete to act on, not a role.
+  // A user who is neither has nothing to log here (SB-486).
+  await resolveAthlete()
+  if (!athleteId.value) {
     router.replace('/dashboard')
     return
   }

--- a/frontend/src/views/__tests__/MyWorkoutsView.test.ts
+++ b/frontend/src/views/__tests__/MyWorkoutsView.test.ts
@@ -11,7 +11,13 @@ vi.mock('@/composables/useCoach', () => ({
 }))
 
 const replaceMock = vi.fn()
-vi.mock('vue-router', () => ({ useRouter: () => ({ replace: replaceMock }) }))
+const pushMock = vi.fn()
+// The view now links to the build/log/print surfaces (SB-486), so the mock has
+// to provide RouterLink as well as the router itself.
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ replace: replaceMock, push: pushMock }),
+  RouterLink: { template: '<a><slot /></a>' },
+}))
 
 import MyWorkoutsView from '../MyWorkoutsView.vue'
 
@@ -68,6 +74,6 @@ describe('MyWorkoutsView (SB-332)', () => {
     })
     const w = mount(MyWorkoutsView)
     await flushPromises()
-    expect(w.text()).toContain('No workouts assigned yet')
+    expect(w.text()).toContain('No workouts yet')
   })
 })

--- a/frontend/src/views/__tests__/WorkoutBuilderView.test.ts
+++ b/frontend/src/views/__tests__/WorkoutBuilderView.test.ts
@@ -9,6 +9,9 @@ const h = vi.hoisted(() => ({
   replace: vi.fn(),
   isCoach: { value: true },
   loadRoles: vi.fn().mockResolvedValue(undefined),
+  // The athlete the caller IS, for the self-service path (SB-486).
+  myAthlete: { value: null as { id: string } | null },
+  loadMyAthlete: vi.fn().mockResolvedValue(undefined),
   load: vi.fn().mockResolvedValue(undefined),
   params: { athleteId: 'ath1' } as Record<string, string>,
 }))
@@ -34,6 +37,7 @@ vi.mock('@/composables/useExercises', async () => {
 })
 vi.mock('@/composables/useCoach', () => ({
   useRoles: () => ({ isCoach: h.isCoach, loadRoles: h.loadRoles }),
+  useMyAthlete: () => ({ myAthlete: h.myAthlete, loadMyAthlete: h.loadMyAthlete }),
 }))
 vi.mock('@/composables/useWorkoutTemplates', () => ({
   createTemplate: (...a: unknown[]) => h.createTemplate(...a),
@@ -49,6 +53,7 @@ vi.mock('vue-router', () => ({
 beforeEach(() => {
   vi.clearAllMocks()
   h.isCoach.value = true
+  h.myAthlete.value = null
   h.params = { athleteId: 'ath1' }
 })
 
@@ -60,8 +65,12 @@ async function mountBuilder() {
 }
 
 describe('WorkoutBuilderView', () => {
-  it('redirects non-coaches', async () => {
+  it('redirects when there is no athlete to act on', async () => {
+    // Since SB-486 the gate is "do we have an athlete", not "are you a coach" —
+    // an athlete opens this view for themselves with no route param.
     h.isCoach.value = false
+    h.params = {}
+    h.myAthlete.value = null
     await mountBuilder()
     expect(h.replace).toHaveBeenCalledWith('/dashboard')
   })

--- a/frontend/src/views/__tests__/WorkoutSessionLoggerView.test.ts
+++ b/frontend/src/views/__tests__/WorkoutSessionLoggerView.test.ts
@@ -8,6 +8,9 @@ const h = vi.hoisted(() => ({
   replace: vi.fn(),
   isCoach: { value: true },
   loadRoles: vi.fn().mockResolvedValue(undefined),
+  // The athlete the caller IS, for the self-service path (SB-486).
+  myAthlete: { value: null as { id: string } | null },
+  loadMyAthlete: vi.fn().mockResolvedValue(undefined),
   load: vi.fn().mockResolvedValue(undefined),
   params: { athleteId: 'ath1' } as Record<string, string>,
 }))
@@ -39,6 +42,7 @@ vi.mock('@/composables/useExercises', async () => {
 })
 vi.mock('@/composables/useCoach', () => ({
   useRoles: () => ({ isCoach: h.isCoach, loadRoles: h.loadRoles }),
+  useMyAthlete: () => ({ myAthlete: h.myAthlete, loadMyAthlete: h.loadMyAthlete }),
 }))
 vi.mock('@/composables/useWorkoutTemplates', () => ({
   getTemplate: (...a: unknown[]) => h.getTemplate(...a),
@@ -55,6 +59,7 @@ vi.mock('vue-router', () => ({
 beforeEach(() => {
   vi.clearAllMocks()
   h.isCoach.value = true
+  h.myAthlete.value = null
   h.params = { athleteId: 'ath1' }
 })
 
@@ -66,8 +71,33 @@ async function mountLogger() {
 }
 
 describe('WorkoutSessionLoggerView', () => {
-  it('redirects non-coaches', async () => {
+  it('an athlete logs for themselves with no route param (SB-486)', async () => {
+    // The whole point: Gabe opens /my/workouts/log, the view resolves *him* as
+    // the subject, and the API call carries his own athlete id.
     h.isCoach.value = false
+    h.params = {}
+    h.myAthlete.value = { id: 'ath1' }
+    h.createSession.mockResolvedValue({ id: 's1' })
+
+    const w = await mountLogger()
+
+    expect(h.replace).not.toHaveBeenCalled()
+    await w.find('[data-testid="add-exercise"]').trigger('click')
+    await w.find('[data-testid="ex-pushups"]').trigger('click')
+    await w.find('[data-testid="reps-pushups-0"]').setValue(10)
+    await w.find('[data-testid="save"]').trigger('click')
+    await flushPromises()
+
+    expect(h.createSession).toHaveBeenCalled()
+    expect(h.createSession.mock.calls[0][1]).toBe('ath1')
+  })
+
+  it('redirects when there is no athlete to act on', async () => {
+    // Since SB-486 the gate is "do we have an athlete", not "are you a coach" —
+    // an athlete opens this view for themselves with no route param.
+    h.isCoach.value = false
+    h.params = {}
+    h.myAthlete.value = null
     await mountLogger()
     expect(h.replace).toHaveBeenCalledWith('/dashboard')
   })


### PR DESCRIPTION
Fixes SB-486

## Why

Gabe could see his six templates and do nothing with them — no log, no print, no build. Only Matthew could record work. That's why **zero sessions have ever been logged**, and why *"when the runs get easy, increase speed… adjust, assess"* has nothing to act on.

## The finding that shaped this

**The backend already allowed it.** `require_coach` appears nowhere in `backend/routes/workouts.py`; every write authorises through `can_access_athlete`, which returns true for the linked athlete as well as the coach (`backend/admin.py:52`). Gabe was blocked entirely client-side: four `requiresCoach` routes, an `isCoach` bail in the logger, and a `readonly` flag that hid **Print** — the one thing a paper-first workflow needs.

So this is mostly frontend, plus one authorisation gap that mattered.

## Changes

**`useActingAthlete`** resolves the subject from the route param when a coach is acting, else from `/me/athlete`. The builder, logger and print views are reused unchanged behind `/my/workouts/*`; both callers already share the same act-as header.

**Per-action rights on the card.** The single `readonly` boolean becomes `canLog` / `canPrint` / `canEdit` — a coach's prescription can be logged and printed but not edited, while what Gabe authors is his to change. Defaults preserve every existing caller.

**Enforced server-side, because hiding buttons is not enforcement.** On template and session mutations, a caller who isn't a coach of the athlete must be the row's `created_by`. Without this Gabe could `PATCH` Matthew's template straight through the API. A `NULL` `created_by` predates athlete authorship and stays coach-only.

**The logger learns `hr_bpm`, `cadence`, `speed`.** `FIELD_DEFS` predated SB-447, so the bike — which Matthew prescribes by heart rate — couldn't be logged at all.

**Tick-box movements.** An exercise carrying no `measures` has nothing to type, so the row's presence is the record rather than an empty attempt to discard. No catalog row is measureless today (0 of 57), so this is the shape *"some exercises might just be a checkbox"* needs when one exists.

**Coach signal.** An "Added by Gabe" badge on athlete-authored work.

## Tests I changed deliberately

Three encoded the old rule, so I updated rather than worked around them:

- builder + logger `redirects non-coaches` → `redirects when there is no athlete to act on`, since the gate is now having a subject, not holding a role
- the empty state is no longer `No workouts assigned yet` now that he can add his own
- `sessionPayload` used `measures: []` as a brevity default, which since this change means "nothing to measure" — the fixture now carries a real measure, and both semantics have their own test

New coverage includes the path the feature exists for: an athlete mounting the logger with no route param, saving, and the API call carrying **his own** athlete id.

## Verification

186 root · 347 backend · 127 stk · 298 frontend, all passing. `vue-tsc` clean.

Ready for end-to-end once deployed: Gabe logs a session, Matthew sees it; Gabe builds a template, Matthew sees it badged; `PUT` on a coach template as the athlete → 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)