### PR TITLE
docs: CLAUDE.md documents the prod→local restore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,9 +247,13 @@ runs), restore prod into local. **This is one command — do not write a new
 script for it.**
 
 ```bash
-source ~/.config/janitor/stk.env        # secrets, via 1Password/varlock
+jt secrets pull stk                     # 1Password → ~/.config/janitor/stk.env
+source ~/.config/janitor/stk.env
 jt supabase restore-from-prod stk
 ```
+
+`jt secrets pull stk` writes the env file from the `stk-prod` 1Password item, so
+no secret is ever typed into a shell. Skip it if the file is already current.
 
 `jt` is [janitor](https://github.com/silverbeer/janitor), configured for STK in
 `~/.config/janitor/config.toml` under the key **`stk`** (the config key, not the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,52 @@ from ..models import Activity           # Relative imports
 from shared.models import Activity      # Missing src prefix
 ```
 
+## 🗄️ Local Database: restoring prod data
+
+Local Supabase starts empty. To develop or analyse against real history (4,700+
+runs), restore prod into local. **This is one command — do not write a new
+script for it.**
+
+```bash
+source ~/.config/janitor/stk.env        # secrets, via 1Password/varlock
+jt supabase restore-from-prod stk
+```
+
+`jt` is [janitor](https://github.com/silverbeer/janitor), configured for STK in
+`~/.config/janitor/config.toml` under the key **`stk`** (the config key, not the
+folder name `myrunstreak.run`). One command does all of it:
+
+1. Resets local to `supabase/migrations`
+2. Loads prod `public` data
+3. Runs this project's `post_restore_cmd` — `jt supabase sync-users stk`, then
+   `scripts/seed_local_users.py` to reseed coach/athlete fixtures
+
+So you end up with prod data, a working login, and the test users. **A loopback
+guard refuses to run unless the target is local**, so it cannot touch prod.
+
+### Connection gotcha
+
+Use the **pooler** URL for `STK_PROD_DATABASE_URL`, not the direct host.
+`db.<ref>.supabase.co` publishes only an AAAA record and is unreachable on an
+IPv4-only network (`pg_dump` → "No route to host"). Pooler username is
+`postgres.<ref>`, port `6543`.
+
+### REST fallback
+
+If the pooler rejects the tenant, `scripts/restore_prod_to_local.sh` does the
+same job over the Supabase REST API — plain HTTPS, works anywhere (SB-224). It
+excludes auth users, OAuth tokens and invites by design. **Prefer the `jt`
+command**; this exists only for when the Postgres path is blocked.
+
+### For agents
+
+Both paths read secrets from 1Password via `op`, which needs biometric auth and
+**will not work in a non-interactive agent shell**. Ask the user to run the
+restore, then work against local. Never point analysis scripts at prod
+credentials to get around it.
+
+Full guide: `~/gitrepos/janitor/docs/supabase-guide.md`.
+
 ## 🧪 Testing Requirements
 
 ### Coverage Requirements


### PR DESCRIPTION
## Problem

`CLAUDE.md` had **zero** mentions of restore, backup, prod→local, or `jt`. An agent working in this repo could not discover that a one-command restore exists.

That is not hypothetical — it happened today. Local Supabase was empty, so a session went looking for prod credentials directly instead of restoring prod into local, which is the supported path and was already built.

## Change

New "Local Database: restoring prod data" section covering:

- **`jt supabase restore-from-prod stk`** as the single command, and that it chains `sync-users` + `seed_local_users.py` via `post_restore_cmd` — so you get data, a working login, and the coach/athlete fixtures in one step
- The **connection gotcha**: use the pooler URL, not `db.<ref>.supabase.co`, which publishes only an AAAA record and is unreachable on an IPv4-only network
- `scripts/restore_prod_to_local.sh` as a **named fallback** (REST, works anywhere HTTPS works) rather than an equal alternative
- An explicit **note for agents**: both paths need 1Password biometric auth and cannot run in a non-interactive shell, so the restore is a task to hand back to the user — not a reason to point analysis scripts at prod credentials

Cross-links to `janitor/docs/supabase-guide.md`, which gets the matching update in silverbeer/janitor#15.

## Testing

Documentation only.

Refs SB-516

🤖 Generated with [Claude Code](https://claude.com/claude-code)