### PR TITLE
fix: athlete can print their own workout (HTTP 422)

### DIFF
--- a/frontend/src/views/WorkoutPrintView.vue
+++ b/frontend/src/views/WorkoutPrintView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="min-h-screen bg-gray-100 print:bg-white">
     <div class="no-print sticky top-0 z-10 bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between">
-      <RouterLink :to="`/coach/${athleteId}`" class="text-sm text-gray-500 hover:text-brand-600">
+      <RouterLink :to="backTo" class="text-sm text-gray-500 hover:text-brand-600">
         ← Back
       </RouterLink>
       <div class="flex items-center gap-3">
@@ -33,7 +33,7 @@
       class="sheet mx-auto bg-white text-black"
       :class="format === 'card' ? 'sheet-card' : 'sheet-full'"
     >
-      <h1 class="sheet-title">{{ athleteName }} — {{ template.name }}</h1>
+      <h1 class="sheet-title">{{ athleteName ? `${athleteName} — ${template.name}` : template.name }}</h1>
 
       <div class="sheet-meta">
         <span>Date: <span class="blank w-32" /></span>
@@ -121,8 +121,15 @@ import { groupOptionItems } from '@/utils/optionGroups'
 import { fmtRange, hrZoneText, restText } from '@/utils/targets'
 
 const route = useRoute()
-const athleteId = String(route.params.athleteId)
 const templateId = String(route.params.templateId)
+
+// This view serves two routes: /coach/:athleteId/print/:templateId and
+// /my/workouts/print/:templateId. Only the coach one carries an athleteId, so
+// it must stay nullable — String(undefined) yields the string "undefined",
+// which the API then rejects as an invalid UUID with a bare 422 (SB-522).
+const athleteId = route.params.athleteId ? String(route.params.athleteId) : null
+const actingAsAthlete = athleteId !== null
+const backTo = actingAsAthlete ? `/coach/${athleteId}` : '/my/workouts'
 
 const template = ref<WorkoutTemplate | null>(null)
 const athleteName = ref('')
@@ -243,15 +250,22 @@ const printSheet = () => window.print()
 
 onMounted(async () => {
   try {
-    const actAs = { 'X-Act-As-Athlete': athleteId }
-    const [tpl, athlete, catalog] = await Promise.all([
-      apiCall<WorkoutTemplate>(`/workouts/templates/${templateId}`, { headers: actAs }),
-      apiCall<Athlete>(`/athletes/${athleteId}`),
+    // Send X-Act-As-Athlete only when a coach is genuinely acting for someone
+    // else. The backend types it as UUID | None and already treats an absent
+    // header as "me", so omitting it is correct — sending "undefined" is a 422.
+    const headers = actingAsAthlete ? { 'X-Act-As-Athlete': athleteId as string } : undefined
+    const [tpl, catalog] = await Promise.all([
+      apiCall<WorkoutTemplate>(`/workouts/templates/${templateId}`, { headers }),
       apiCall<Exercise[]>('/workouts/exercises'),
     ])
     template.value = tpl
-    athleteName.value = athlete.display_name
     exercises.value = new Map(catalog.map((e) => [e.key, e]))
+    // Only a coach needs the athlete's name in the heading; printing your own
+    // sheet does not, so skip the lookup rather than fetch /athletes/me.
+    if (actingAsAthlete) {
+      const athlete = await apiCall<Athlete>(`/athletes/${athleteId}`)
+      athleteName.value = athlete.display_name
+    }
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Failed to load workout'
   } finally {

--- a/frontend/src/views/__tests__/WorkoutPrintView.test.ts
+++ b/frontend/src/views/__tests__/WorkoutPrintView.test.ts
@@ -5,9 +5,14 @@ const apiCallMock = vi.fn()
 vi.mock('@/config/api', () => ({
   apiCall: (...args: unknown[]) => apiCallMock(...args),
 }))
+// Mutable, because this view serves BOTH routes and only the coach one carries
+// an athleteId. Hardcoding the coach params is what let SB-522 ship unnoticed.
+const COACH_ROUTE = { athleteId: 'a1', templateId: 't1' }
+const OWN_ROUTE = { templateId: 't1' }
+let routeParams: Record<string, string> = { ...COACH_ROUTE }
 vi.mock('vue-router', () => ({
-  useRoute: () => ({ params: { athleteId: 'a1', templateId: 't1' } }),
-  RouterLink: { template: '<a><slot /></a>' },
+  useRoute: () => ({ params: routeParams }),
+  RouterLink: { props: ['to'], template: '<a :href="to"><slot /></a>' },
 }))
 
 import WorkoutPrintView from '../WorkoutPrintView.vue'
@@ -36,6 +41,7 @@ const exercises = [
 ]
 
 beforeEach(() => {
+  routeParams = { ...COACH_ROUTE }
   apiCallMock.mockReset()
   apiCallMock.mockImplementation((path: string) => {
     if (path.startsWith('/workouts/templates/')) return Promise.resolve(template)
@@ -77,5 +83,51 @@ describe('WorkoutPrintView (SB-231)', () => {
       '/workouts/templates/t1',
       expect.objectContaining({ headers: { 'X-Act-As-Athlete': 'a1' } }),
     )
+  })
+
+  it('links back to the athlete when a coach is printing', async () => {
+    const w = mount(WorkoutPrintView)
+    await flushPromises()
+    expect(w.get('a').attributes('href')).toBe('/coach/a1')
+  })
+})
+
+describe('WorkoutPrintView on /my/workouts/print (SB-522)', () => {
+  // Gabe printing his own workout got a bare HTTP 422: the view did
+  // String(route.params.athleteId) on a route that has no athleteId, so the
+  // literal string "undefined" went out as X-Act-As-Athlete and as
+  // /athletes/undefined. The backend types that header as UUID and rejects the
+  // request before any handler runs.
+
+  it('sends no X-Act-As-Athlete header when printing your own workout', async () => {
+    routeParams = { ...OWN_ROUTE }
+    mount(WorkoutPrintView)
+    await flushPromises()
+    const call = apiCallMock.mock.calls.find((c) => c[0] === '/workouts/templates/t1')
+    expect(call?.[1]?.headers).toBeUndefined()
+  })
+
+  it('never sends the string "undefined" anywhere', async () => {
+    routeParams = { ...OWN_ROUTE }
+    mount(WorkoutPrintView)
+    await flushPromises()
+    const flat = JSON.stringify(apiCallMock.mock.calls)
+    expect(flat).not.toContain('undefined')
+  })
+
+  it('skips the athlete lookup and titles the sheet with the workout alone', async () => {
+    routeParams = { ...OWN_ROUTE }
+    const w = mount(WorkoutPrintView)
+    await flushPromises()
+    expect(apiCallMock.mock.calls.some((c) => String(c[0]).startsWith('/athletes/'))).toBe(false)
+    // Title is the workout alone — no dangling "— " where a name would go.
+    expect(w.get('h1.sheet-title').text()).toBe('Track Thursday')
+  })
+
+  it('links back to /my/workouts, not a coach page', async () => {
+    routeParams = { ...OWN_ROUTE }
+    const w = mount(WorkoutPrintView)
+    await flushPromises()
+    expect(w.get('a').attributes('href')).toBe('/my/workouts')
   })
 })


### PR DESCRIPTION
## Reported by Gabe

Printing his own workout showed a bare red `HTTP 422`:

`myrunstreak.run/my/workouts/print/b84f5a43-42c7-47b2-ab24-b936482213fd`

## Cause

`WorkoutPrintView` backs **two** routes, but only accounted for one:

```
/coach/:athleteId/print/:templateId    coach prints for an athlete
/my/workouts/print/:templateId         athlete prints their own
```

```js
const athleteId = String(route.params.athleteId)
```

On the athlete route there is no `athleteId`, so `String(undefined)` produces the **literal string `"undefined"`**, which then went out as:

```js
{ 'X-Act-As-Athlete': 'undefined' }
apiCall('/athletes/undefined')
```

The backend types that header as a UUID (`backend/routes/workouts.py:40`):

```python
x_act_as_athlete: UUID | None = Header(default=None, alias="X-Act-As-Athlete")
```

`"undefined"` is not a valid UUID, so FastAPI rejected the request with 422 before any handler ran.

The header is already `| None` and absence already means "me" — so the bug was inventing a value where omitting it was correct.

## Fix

- `athleteId` is nullable; never `String()` an optional route param
- send `X-Act-As-Athlete` only when genuinely acting for someone else
- skip the `/athletes/{id}` lookup when printing your own sheet, and title it with the workout name alone rather than a dangling `— `
- Back link goes to `/my/workouts`, not `/coach/undefined`

## Why it shipped

The coach path always worked, and the test file hardcoded the coach params:

```js
useRoute: () => ({ params: { athleteId: 'a1', templateId: 't1' } })
```

So the athlete route had **no coverage at all**. Route params are now switchable and both routes are tested, including an explicit assertion that the string `"undefined"` never reaches the API — the failure mode, not just the symptom.

## Testing

`vue-tsc --noEmit` clean. Full frontend suite: **303 tests, 38 files, all passing**, including 4 new ones for the athlete route.

Fixes SB-522

🤖 Generated with [Claude Code](https://claude.com/claude-code)