### PR TITLE
fix: a readable failure state on the print sheet

### DIFF
--- a/frontend/src/config/__tests__/api.test.ts
+++ b/frontend/src/config/__tests__/api.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../supabase', () => ({
+  supabase: { auth: { getSession: async () => ({ data: { session: null } }) } },
+}))
+
+import { apiCall } from '../api'
+
+const respond = (status: number, body: unknown) => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: false,
+      status,
+      headers: { get: () => null },
+      json: async () => body,
+    })),
+  )
+}
+
+const failure = async (): Promise<Error & { status?: number }> => {
+  try {
+    await apiCall('/whatever')
+  } catch (e) {
+    return e as Error & { status?: number }
+  }
+  throw new Error('expected apiCall to throw')
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('apiCall error messages (SB-523)', () => {
+  it('reads FastAPI 422 validation arrays instead of falling back to the status', async () => {
+    // The shape that produced a bare "HTTP 422" on the print sheet: `detail` is
+    // an ARRAY, so `detail.message` was undefined and every branch missed.
+    respond(422, {
+      detail: [
+        { loc: ['header', 'x-act-as-athlete'], msg: 'value is not a valid uuid' },
+      ],
+    })
+    const err = await failure()
+    expect(err.message).toContain('x-act-as-athlete')
+    expect(err.message).toContain('not a valid uuid')
+    expect(err.message).not.toBe('HTTP 422')
+  })
+
+  it('joins several validation failures', async () => {
+    respond(422, {
+      detail: [
+        { loc: ['body', 'name'], msg: 'field required' },
+        { loc: ['body', 'rounds'], msg: 'must be positive' },
+      ],
+    })
+    const err = await failure()
+    expect(err.message).toBe('name: field required; rounds: must be positive')
+  })
+
+  it('still handles a plain string detail', async () => {
+    respond(404, { detail: 'Template not found' })
+    expect((await failure()).message).toBe('Template not found')
+  })
+
+  it('still handles a structured object detail (SB-349 dup-athlete 409)', async () => {
+    respond(409, { detail: { code: 'dup', message: 'Athlete already exists' } })
+    expect((await failure()).message).toBe('Athlete already exists')
+  })
+
+  it('falls back to the status only when the body says nothing useful', async () => {
+    respond(500, {})
+    const err = await failure()
+    expect(err.message).toBe('HTTP 500')
+    expect(err.status).toBe(500)
+  })
+
+  it('attaches the status so callers can explain the failure', async () => {
+    respond(403, { detail: 'nope' })
+    expect((await failure()).status).toBe(403)
+  })
+})

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -4,6 +4,37 @@ const API_BASE = import.meta.env.VITE_API_BASE || '/api'
 
 export const getApiBase = (): string => API_BASE
 
+/** FastAPI's 422 body: `detail` is an array of per-field validation errors. */
+type ValidationItem = { loc?: unknown[]; msg?: string }
+
+/**
+ * A human message from an error body, or null if it holds nothing readable.
+ *
+ * `detail` arrives in three shapes: a plain string (most 4xx), an object with
+ * `.message` (the structured 409s), and — for 422 — an *array* of validation
+ * items. The array case used to fall through to a bare `HTTP 422`, which is
+ * what an athlete saw when the print sheet failed (SB-523).
+ */
+const readableError = (body: unknown): string | null => {
+  const detail = (body as { detail?: unknown; message?: unknown })?.detail
+  if (typeof detail === 'string' && detail) return detail
+  if (Array.isArray(detail)) {
+    const parts = (detail as ValidationItem[])
+      .map((d) => {
+        const field = Array.isArray(d.loc) ? d.loc[d.loc.length - 1] : undefined
+        return field ? `${String(field)}: ${d.msg ?? 'invalid'}` : d.msg
+      })
+      .filter(Boolean)
+    if (parts.length) return parts.join('; ')
+  }
+  if (detail && typeof detail === 'object') {
+    const msg = (detail as { message?: unknown }).message
+    if (typeof msg === 'string' && msg) return msg
+  }
+  const top = (body as { message?: unknown })?.message
+  return typeof top === 'string' && top ? top : null
+}
+
 export const apiCall = async <T>(
   path: string,
   options: RequestInit = {}
@@ -27,14 +58,9 @@ export const apiCall = async <T>(
 
   if (!response.ok) {
     const body = await response.json().catch(() => ({ message: 'Request failed' }))
-    // `detail` may be a string (most 4xx) or a structured object (e.g. the
-    // dup-athlete 409, SB-349). Keep the human message on .message, and attach
-    // status + parsed body so callers can act on structured errors.
-    const detail = body?.detail
-    const message =
-      (detail && typeof detail === 'object' ? detail.message : detail) ||
-      body?.message ||
-      `HTTP ${response.status}`
+    // Keep the human message on .message, and attach status + parsed body so
+    // callers can act on structured errors. See readableError for the shapes.
+    const message = readableError(body) ?? `HTTP ${response.status}`
     const err = new Error(message) as Error & { status?: number; body?: unknown }
     err.status = response.status
     err.body = body

--- a/frontend/src/views/WorkoutPrintView.vue
+++ b/frontend/src/views/WorkoutPrintView.vue
@@ -26,7 +26,21 @@
     <div v-if="loading" class="max-w-3xl mx-auto p-8">
       <div class="bg-white rounded-xl h-96 animate-pulse" />
     </div>
-    <div v-else-if="error" class="max-w-3xl mx-auto p-8 text-sm text-red-700">{{ error }}</div>
+    <div v-else-if="error" class="max-w-xl mx-auto p-8">
+      <div class="bg-white rounded-xl p-6 text-center" data-testid="print-error">
+        <h2 class="text-lg font-semibold text-gray-900">Couldn't load this workout</h2>
+        <p class="mt-2 text-sm text-gray-600">{{ errorHelp }}</p>
+        <div class="mt-5 flex items-center justify-center gap-3">
+          <button type="button" class="btn-primary text-sm" data-testid="print-retry" @click="load">
+            Try again
+          </button>
+          <RouterLink :to="backTo" class="text-sm text-gray-500 hover:text-brand-600">
+            Back to workouts
+          </RouterLink>
+        </div>
+        <p class="mt-4 text-xs text-gray-400">{{ error }}</p>
+      </div>
+    </div>
 
     <div
       v-else-if="template"
@@ -136,6 +150,7 @@ const athleteName = ref('')
 const exercises = ref<Map<string, Exercise>>(new Map())
 const loading = ref(true)
 const error = ref<string | null>(null)
+const errorStatus = ref<number | null>(null)
 
 type FormatKey = 'full' | 'card'
 const format = ref<FormatKey>('full')
@@ -248,7 +263,28 @@ const timeRows = (item: TemplateItem): TimeRow[] => {
 
 const printSheet = () => window.print()
 
-onMounted(async () => {
+// Plain-English cause, chosen by status. The raw message stays on screen too,
+// small and grey — useful when debugging, not shouted at the athlete (SB-523).
+const errorHelp = computed(() => {
+  switch (errorStatus.value) {
+    case 401:
+    case 403:
+      return 'You may not have access to this workout, or your session expired. Try signing in again.'
+    case 404:
+      return "This workout doesn't exist any more — it may have been deleted."
+    case 422:
+      return 'Something in the request was wrong, so the server turned it down. This is a bug on our side, not something you did.'
+    default:
+      return errorStatus.value && errorStatus.value >= 500
+        ? 'The server had a problem. Trying again usually works.'
+        : 'Check your connection and try again.'
+  }
+})
+
+const load = async () => {
+  loading.value = true
+  error.value = null
+  errorStatus.value = null
   try {
     // Send X-Act-As-Athlete only when a coach is genuinely acting for someone
     // else. The backend types it as UUID | None and already treats an absent
@@ -268,10 +304,13 @@ onMounted(async () => {
     }
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Failed to load workout'
+    errorStatus.value = (e as { status?: number })?.status ?? null
   } finally {
     loading.value = false
   }
-})
+}
+
+onMounted(load)
 </script>
 
 <style scoped>

--- a/frontend/src/views/__tests__/WorkoutPrintView.test.ts
+++ b/frontend/src/views/__tests__/WorkoutPrintView.test.ts
@@ -131,3 +131,70 @@ describe('WorkoutPrintView on /my/workouts/print (SB-522)', () => {
     expect(w.get('a').attributes('href')).toBe('/my/workouts')
   })
 })
+
+describe('WorkoutPrintView failure state (SB-523)', () => {
+  // Gabe's whole experience of the bug was one line of red text reading
+  // "HTTP 422". Whatever fails next, he should get a sentence and a way out.
+
+  const fail = (message: string, status?: number) => {
+    apiCallMock.mockReset()
+    apiCallMock.mockImplementation(() => {
+      const e = new Error(message) as Error & { status?: number }
+      e.status = status
+      return Promise.reject(e)
+    })
+  }
+
+  it('explains the failure instead of printing a bare status', async () => {
+    fail('HTTP 422', 422)
+    const w = mount(WorkoutPrintView)
+    await flushPromises()
+    const panel = w.get('[data-testid="print-error"]')
+    expect(panel.text()).toContain("Couldn't load this workout")
+    expect(panel.text()).toContain('not something you did')
+  })
+
+  it('tailors the explanation to the status', async () => {
+    fail('nope', 404)
+    const w = mount(WorkoutPrintView)
+    await flushPromises()
+    expect(w.get('[data-testid="print-error"]').text()).toContain("doesn't exist any more")
+  })
+
+  it('keeps the raw message available for debugging', async () => {
+    fail('HTTP 500', 500)
+    const w = mount(WorkoutPrintView)
+    await flushPromises()
+    expect(w.get('[data-testid="print-error"]').text()).toContain('HTTP 500')
+  })
+
+  it('offers a retry that actually refetches', async () => {
+    fail('HTTP 500', 500)
+    const w = mount(WorkoutPrintView)
+    await flushPromises()
+    const before = apiCallMock.mock.calls.length
+
+    // Recover, then retry: the sheet should render without a reload.
+    apiCallMock.mockReset()
+    apiCallMock.mockImplementation((path: string) => {
+      if (path.startsWith('/workouts/templates/')) return Promise.resolve(template)
+      if (path.startsWith('/athletes/')) return Promise.resolve({ id: 'a1', display_name: 'Gabe' })
+      if (path === '/workouts/exercises') return Promise.resolve(exercises)
+      return Promise.reject(new Error(`unexpected: ${path}`))
+    })
+    await w.get('[data-testid="print-retry"]').trigger('click')
+    await flushPromises()
+
+    expect(apiCallMock.mock.calls.length).toBeGreaterThan(0)
+    expect(before).toBeGreaterThan(0)
+    expect(w.find('[data-testid="print-error"]').exists()).toBe(false)
+    expect(w.text()).toContain('Track Thursday')
+  })
+
+  it('offers a way out of the dead end', async () => {
+    fail('HTTP 500', 500)
+    const w = mount(WorkoutPrintView)
+    await flushPromises()
+    expect(w.get('[data-testid="print-error"]').text()).toContain('Back to workouts')
+  })
+})


### PR DESCRIPTION
## What Gabe actually saw

One line of red text: `HTTP 422`. No cause, no retry, no way back.

silverbeer/myrunstreak.run#223 removed *that* 422. This fixes the experience around it, which any future failure would have reproduced identically.

## Two defects, one symptom

**1. `apiCall` fell through to the raw status** (`config/api.ts`)

FastAPI returns a 422 `detail` as an **array** of per-field validation items — not a string, not an object with `.message`. Every branch missed it, so the `HTTP ${status}` fallback won. The bare code was never a design choice; it was what was left when nothing parsed.

Now the array shape becomes `field: reason`, so the real cause reaches the UI.

**2. The view rendered `{{ error }}` and stopped** (`WorkoutPrintView.vue`)

Now: a heading, a plain-English cause selected by status, a **Try again** that refetches in place, and a link back to the workout list. The raw message stays — small and grey, useful when debugging, not shouted at a kid.

The 422 copy says outright that it's our bug, not something he did. He's 
the one person who should never have to wonder.

Loading moved into a callable `load()` so retry doesn't need a page reload.

## Testing

`apiCall` had **no test file at all** — it does now, covering every `detail` shape (array, string, structured object, empty) plus the status-only fallback and status attachment. The regression case asserts the exact array that produced Gabe's message no longer yields `HTTP 422`.

View tests cover the panel, per-status copy, retry recovering to a rendered sheet, and the escape route.

`vue-tsc --noEmit` clean. Full suite: **314 tests, 39 files, all passing** (up from 303).

Note: `npm run lint` reports 128 pre-existing errors on clean `main` — a broken eslint config that can't parse TS. Untouched here; CI runs `type-check` and `build`, not lint. Worth its own ticket.

Fixes SB-523

🤖 Generated with [Claude Code](https://claude.com/claude-code)