### PR TITLE
fix: scope athlete print to the athlete row, not an absent header

### DIFF
--- a/frontend/src/views/WorkoutPrintView.vue
+++ b/frontend/src/views/WorkoutPrintView.vue
@@ -133,17 +133,30 @@ import type { Exercise, TemplateItem, WorkoutTemplate } from '@/types/workout'
 import type { Athlete } from '@/types/coach'
 import { groupOptionItems } from '@/utils/optionGroups'
 import { fmtRange, hrZoneText, restText } from '@/utils/targets'
+import { useMyAthlete } from '@/composables/useCoach'
 
 const route = useRoute()
 const templateId = String(route.params.templateId)
 
-// This view serves two routes: /coach/:athleteId/print/:templateId and
-// /my/workouts/print/:templateId. Only the coach one carries an athleteId, so
-// it must stay nullable — String(undefined) yields the string "undefined",
-// which the API then rejects as an invalid UUID with a bare 422 (SB-522).
-const athleteId = route.params.athleteId ? String(route.params.athleteId) : null
-const actingAsAthlete = athleteId !== null
-const backTo = actingAsAthlete ? `/coach/${athleteId}` : '/my/workouts'
+// This view serves two routes:
+//   /coach/:athleteId/print/:templateId   — a coach printing for an athlete
+//   /my/workouts/print/:templateId        — the athlete printing their own
+//
+// Only the coach route carries an athleteId, so it must stay nullable:
+// String(undefined) yields the string "undefined", which the API rejects as an
+// invalid UUID with a bare 422 (SB-522).
+const coachRouteAthleteId = route.params.athleteId ? String(route.params.athleteId) : null
+const isCoachRoute = coachRouteAthleteId !== null
+const backTo = isCoachRoute ? `/coach/${coachRouteAthleteId}` : '/my/workouts'
+
+// Every workout request is scoped by athlete id, and a coach-assigned template
+// belongs to the ATHLETE row — not to the athlete's user account. Omitting the
+// header sends the query down the "my own self-authored rows" branch
+// (athlete_id IS NULL), which can never match it, so the athlete got a 404
+// (SB-524). Resolve the caller's athlete row and scope by its id, exactly as
+// MyWorkoutsView already does.
+const { myAthlete, loadMyAthlete } = useMyAthlete()
+const scopeAthleteId = ref<string | null>(coachRouteAthleteId)
 
 const template = ref<WorkoutTemplate | null>(null)
 const athleteName = ref('')
@@ -286,20 +299,27 @@ const load = async () => {
   error.value = null
   errorStatus.value = null
   try {
-    // Send X-Act-As-Athlete only when a coach is genuinely acting for someone
-    // else. The backend types it as UUID | None and already treats an absent
-    // header as "me", so omitting it is correct — sending "undefined" is a 422.
-    const headers = actingAsAthlete ? { 'X-Act-As-Athlete': athleteId as string } : undefined
+    // On the athlete route the scope id is not in the URL — resolve it first.
+    if (!isCoachRoute && scopeAthleteId.value === null) {
+      await loadMyAthlete(true)
+      if (!myAthlete.value) {
+        throw Object.assign(new Error('No athlete profile is linked to this account.'), {
+          status: 404,
+        })
+      }
+      scopeAthleteId.value = myAthlete.value.id
+    }
+    const headers = { 'X-Act-As-Athlete': scopeAthleteId.value as string }
     const [tpl, catalog] = await Promise.all([
       apiCall<WorkoutTemplate>(`/workouts/templates/${templateId}`, { headers }),
       apiCall<Exercise[]>('/workouts/exercises'),
     ])
     template.value = tpl
     exercises.value = new Map(catalog.map((e) => [e.key, e]))
-    // Only a coach needs the athlete's name in the heading; printing your own
-    // sheet does not, so skip the lookup rather than fetch /athletes/me.
-    if (actingAsAthlete) {
-      const athlete = await apiCall<Athlete>(`/athletes/${athleteId}`)
+    // Only a coach needs the athlete's name in the heading — printing your own
+    // sheet does not, so skip the extra request.
+    if (isCoachRoute) {
+      const athlete = await apiCall<Athlete>(`/athletes/${coachRouteAthleteId}`)
       athleteName.value = athlete.display_name
     }
   } catch (e) {

--- a/frontend/src/views/__tests__/WorkoutPrintView.test.ts
+++ b/frontend/src/views/__tests__/WorkoutPrintView.test.ts
@@ -15,6 +15,13 @@ vi.mock('vue-router', () => ({
   RouterLink: { props: ['to'], template: '<a :href="to"><slot /></a>' },
 }))
 
+// The athlete route has to resolve its own athletes-table row (SB-524).
+const myAthlete: { value: { id: string } | null } = { value: { id: 'my-athlete-row' } }
+const loadMyAthlete = vi.fn(async () => {})
+vi.mock('@/composables/useCoach', () => ({
+  useMyAthlete: () => ({ myAthlete, loadMyAthlete }),
+}))
+
 import WorkoutPrintView from '../WorkoutPrintView.vue'
 
 const template = {
@@ -42,6 +49,8 @@ const exercises = [
 
 beforeEach(() => {
   routeParams = { ...COACH_ROUTE }
+  myAthlete.value = { id: 'my-athlete-row' }
+  loadMyAthlete.mockClear()
   apiCallMock.mockReset()
   apiCallMock.mockImplementation((path: string) => {
     if (path.startsWith('/workouts/templates/')) return Promise.resolve(template)
@@ -99,12 +108,27 @@ describe('WorkoutPrintView on /my/workouts/print (SB-522)', () => {
   // /athletes/undefined. The backend types that header as UUID and rejects the
   // request before any handler runs.
 
-  it('sends no X-Act-As-Athlete header when printing your own workout', async () => {
+  it('scopes to the caller\'s own athlete row (SB-524)', async () => {
+    // Not "no header": a coach-assigned template belongs to the ATHLETE row, so
+    // an absent header queries `athlete_id IS NULL` and 404s. The scope id is
+    // the athletes-table id, which is not the user id and is not in the URL.
     routeParams = { ...OWN_ROUTE }
     mount(WorkoutPrintView)
     await flushPromises()
     const call = apiCallMock.mock.calls.find((c) => c[0] === '/workouts/templates/t1')
-    expect(call?.[1]?.headers).toBeUndefined()
+    expect(call?.[1]?.headers).toEqual({ 'X-Act-As-Athlete': 'my-athlete-row' })
+  })
+
+  it('says so when the account has no linked athlete row', async () => {
+    routeParams = { ...OWN_ROUTE }
+    myAthlete.value = null
+    const w = mount(WorkoutPrintView)
+    await flushPromises()
+    expect(w.get('[data-testid="print-error"]').text()).toContain('No athlete profile')
+    // Nothing athlete-scoped should have been attempted.
+    expect(apiCallMock.mock.calls.some((c) => String(c[0]).includes('/workouts/templates/'))).toBe(
+      false,
+    )
   })
 
   it('never sends the string "undefined" anywhere', async () => {


### PR DESCRIPTION
## My SB-522 fix was wrong

It removed the bogus `X-Act-As-Athlete: "undefined"` by omitting the header, reasoning that absence means "me". Absence *does* mean "me" — but "me" is the wrong scope for a coach-assigned workout. Gabe's `HTTP 422` became `Template not found`.

## Cause

`workout_repository.py:38`:

```python
if athlete_id is not None:
    return query.eq("athlete_id", str(athlete_id))
return query.eq("user_id", str(user_id)).is_("athlete_id", "null")
```

The template belongs to the athlete **row**, not the athlete's account:

```
id          b84f5a43-…   "Monday At-Home (Matthew)"
user_id     16eb502d-…   the coach
athlete_id  b06c0c96-…   Gabe's athletes-table row
```

No header → the `athlete_id IS NULL` branch → cannot match → 404.

**`athlete_id` is an athletes-table id, not a user id.** `can_access_athlete` matches on `athlete.linked_user_id == user_id`, so an athlete does have access to their own row — the header just has to carry the right id, and it is not in the URL.

## Verified against restored prod data

```
old (no header)   → 0 rows    ← the 404
new (athlete id)  → 1 row     ← found
linked_user_id    → t         ← access granted, no 403
```

Not reasoning this time — the actual row, queried directly.

## Fix

Resolve the caller's athlete row via `useMyAthlete()` and scope by its id — exactly what `MyWorkoutsView` already does, which is precisely why the list worked and print didn't. An account with no linked athlete row now says so instead of 404ing.

## The tests were part of the problem

SB-522's tests asserted the header was **absent** on this route. They encoded the wrong behaviour and passed confidently, because they asserted what the code did rather than what the athlete needed. A frontend-only mock could never have caught this — the truth lives in the backend's scoping rule.

Replaced with an assertion that the athlete row id is sent, plus coverage of the no-linked-athlete case.

## Testing

`vue-tsc --noEmit` clean. **315 tests, 39 files, all passing.**

Fixes SB-524

🤖 Generated with [Claude Code](https://claude.com/claude-code)