### PR TITLE
feat: tap an exercise to see what it is

### DIFF
--- a/frontend/src/components/ExerciseDescription.vue
+++ b/frontend/src/components/ExerciseDescription.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="rounded-lg bg-gray-50 px-3 py-2 text-xs text-gray-600" data-testid="exercise-description">
+    <ul v-if="cues.length" class="space-y-0.5">
+      <li v-for="cue in cues" :key="cue" class="flex gap-1.5">
+        <span class="text-gray-300" aria-hidden="true">·</span>
+        <span>{{ cue }}</span>
+      </li>
+    </ul>
+    <p v-if="exercise?.instructions" :class="cues.length ? 'mt-1.5' : ''">
+      {{ exercise.instructions }}
+    </p>
+    <p v-if="isEmpty" class="text-gray-400">No description added for this exercise yet.</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * What an exercise actually is, for an athlete mid-workout (SB-525).
+ *
+ * Gabe hit "Aquaman" and had no way to find out what it was — while the cues
+ * ("Prone: lift opposite arm + leg", "Long through the spine") sat in the
+ * database the whole time. 43 of 57 exercises already have cues; they simply
+ * were not rendered on any athlete-facing screen, only on the printed sheet.
+ *
+ * Presentational only. Each surface owns its own trigger and layout, because
+ * the workout card and the session logger arrange their rows differently — but
+ * the content and, importantly, the empty-state wording live here so they
+ * cannot drift apart.
+ */
+import { computed } from 'vue'
+import type { Exercise } from '@/types/workout'
+
+const props = defineProps<{ exercise?: Exercise | null }>()
+
+const cues = computed(() => props.exercise?.cues ?? [])
+const isEmpty = computed(() => cues.value.length === 0 && !props.exercise?.instructions)
+</script>

--- a/frontend/src/components/WorkoutTemplateCard.vue
+++ b/frontend/src/components/WorkoutTemplateCard.vue
@@ -94,33 +94,49 @@
           <li
             v-for="item in row.kind === 'group' ? row.items : [row.item]"
             :key="item.id"
-            class="group flex items-center justify-between gap-3 py-1.5 px-2 -mx-2 rounded-lg hover:bg-gray-50 transition-colors print:hover:bg-transparent"
+            class="group py-1.5 px-2 -mx-2 rounded-lg hover:bg-gray-50 transition-colors print:hover:bg-transparent"
             :class="row.kind === 'group' ? 'pl-6' : ''"
           >
-            <span class="flex items-center gap-2 min-w-0">
-              <span
-                v-if="row.kind === 'group'"
-                class="w-5 h-5 shrink-0 grid place-items-center text-gray-300 text-[11px]"
+            <div class="flex items-center justify-between gap-3">
+              <!-- The name itself is the tap target (SB-525): a line of text is
+                   a far better target mid-workout than a small icon would be. -->
+              <button
+                type="button"
+                class="flex items-center gap-2 min-w-0 text-left py-1 -my-1 print:pointer-events-none"
+                :aria-expanded="isOpen(item.id)"
+                :data-testid="`describe-${item.exercise_key}`"
+                @click="toggle(item.id)"
               >
-                ○
+                <span
+                  v-if="row.kind === 'group'"
+                  class="w-5 h-5 shrink-0 grid place-items-center text-gray-300 text-[11px]"
+                >
+                  ○
+                </span>
+                <span
+                  v-else-if="sec.key === 'main'"
+                  class="w-5 h-5 shrink-0 grid place-items-center rounded-full bg-brand-50 text-brand-700 text-[11px] font-semibold tabular-nums"
+                >
+                  {{ ri + 1 }}
+                </span>
+                <span class="text-sm text-gray-900 truncate">{{ nameFor(item.exercise_key) }}</span>
+                <span
+                  v-if="item.variant"
+                  class="shrink-0 rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 capitalize"
+                >
+                  {{ item.variant }}
+                </span>
+                <Info class="w-3.5 h-3.5 shrink-0 text-gray-300 print:hidden" aria-hidden="true" />
+              </button>
+              <span class="flex items-center gap-1.5 shrink-0">
+                <span v-for="p in pills(item)" :key="p.text" class="pill" :class="p.cls">{{ p.text }}</span>
               </span>
-              <span
-                v-else-if="sec.key === 'main'"
-                class="w-5 h-5 shrink-0 grid place-items-center rounded-full bg-brand-50 text-brand-700 text-[11px] font-semibold tabular-nums"
-              >
-                {{ ri + 1 }}
-              </span>
-              <span class="text-sm text-gray-900 truncate">{{ nameFor(item.exercise_key) }}</span>
-              <span
-                v-if="item.variant"
-                class="shrink-0 rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 capitalize"
-              >
-                {{ item.variant }}
-              </span>
-            </span>
-            <span class="flex items-center gap-1.5 shrink-0">
-              <span v-for="p in pills(item)" :key="p.text" class="pill" :class="p.cls">{{ p.text }}</span>
-            </span>
+            </div>
+            <ExerciseDescription
+              v-if="isOpen(item.id)"
+              class="mt-1.5 ml-7 print:hidden"
+              :exercise="byKey[item.exercise_key]"
+            />
           </li>
           </template>
         </ul>
@@ -131,8 +147,9 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { Calendar, Check, ClipboardCheck, Pencil, Printer, Repeat, Trash2 } from 'lucide-vue-next'
+import { Calendar, Check, ClipboardCheck, Info, Pencil, Printer, Repeat, Trash2 } from 'lucide-vue-next'
 import type { Exercise, TemplateItem, WorkoutSectionKey, WorkoutTemplate } from '@/types/workout'
+import ExerciseDescription from '@/components/ExerciseDescription.vue'
 import { SECTIONS, prettifyKey } from '@/utils/workoutPayload'
 import { groupOptionItems } from '@/utils/optionGroups'
 import { targetPills } from '@/utils/targets'
@@ -215,6 +232,17 @@ const sections = computed(() => {
 })
 
 const pills = targetPills
+
+// Which exercises have their description open. Per-item rather than one at a
+// time: an athlete comparing "Side plank (L)" with "(R)" should be able to see
+// both, and closing one to read another is friction mid-workout (SB-525).
+const openItems = ref(new Set<string>())
+const isOpen = (id: string) => openItems.value.has(id)
+const toggle = (id: string) => {
+  const next = new Set(openItems.value)
+  next.has(id) ? next.delete(id) : next.add(id)
+  openItems.value = next
+}
 
 const rootEl = ref<HTMLElement | null>(null)
 

--- a/frontend/src/components/__tests__/ExerciseDescription.test.ts
+++ b/frontend/src/components/__tests__/ExerciseDescription.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ExerciseDescription from '../ExerciseDescription.vue'
+import type { Exercise } from '@/types/workout'
+
+const make = (over: Partial<Exercise> = {}): Exercise =>
+  ({
+    key: 'aquaman',
+    display_name: 'Aquaman',
+    category: 'strength',
+    measures: ['duration_s'],
+    is_benchmark: false,
+    owner_id: null,
+    visibility: 'public',
+    created_by: null,
+    forked_from: null,
+    aliases: [],
+    movement_pattern: null,
+    equipment: [],
+    body_region: [],
+    laterality: null,
+    difficulty: null,
+    tags: [],
+    media_url: null,
+    thumbnail_url: null,
+    // The real cues from the catalog — the ones Gabe could not see (SB-525).
+    cues: ['Prone: lift opposite arm + leg', 'Long through the spine'],
+    instructions: null,
+    ...over,
+  }) as Exercise
+
+describe('ExerciseDescription (SB-525)', () => {
+  it('answers "what is Aquaman" from the cues already in the catalog', () => {
+    const w = mount(ExerciseDescription, { props: { exercise: make() } })
+    expect(w.text()).toContain('Prone: lift opposite arm + leg')
+    expect(w.text()).toContain('Long through the spine')
+  })
+
+  it('shows instructions alongside cues when both exist', () => {
+    const w = mount(ExerciseDescription, {
+      props: { exercise: make({ instructions: 'Hold two seconds at the top.' }) },
+    })
+    expect(w.text()).toContain('Long through the spine')
+    expect(w.text()).toContain('Hold two seconds at the top.')
+  })
+
+  it('shows instructions on their own when there are no cues', () => {
+    const w = mount(ExerciseDescription, {
+      props: { exercise: make({ cues: [], instructions: 'Ten metres, walking.' }) },
+    })
+    expect(w.text()).toContain('Ten metres, walking.')
+    expect(w.text()).not.toContain('No description')
+  })
+
+  it('says so honestly rather than showing an empty panel', () => {
+    // 14 of 57 exercises have neither cues nor instructions. Silence would read
+    // as a bug; the athlete should know there is simply nothing written yet.
+    const w = mount(ExerciseDescription, {
+      props: { exercise: make({ cues: [], instructions: null }) },
+    })
+    expect(w.text()).toContain('No description added for this exercise yet.')
+  })
+
+  it('does not blow up when the exercise is missing from the catalog', () => {
+    const w = mount(ExerciseDescription, { props: { exercise: null } })
+    expect(w.text()).toContain('No description added for this exercise yet.')
+  })
+})

--- a/frontend/src/components/__tests__/WorkoutTemplateCard.test.ts
+++ b/frontend/src/components/__tests__/WorkoutTemplateCard.test.ts
@@ -199,3 +199,87 @@ describe('WorkoutTemplateCard — full prescription (SB-484)', () => {
     expect(render484(items).findAll('li')).toHaveLength(12)
   })
 })
+
+describe('WorkoutTemplateCard — exercise descriptions (SB-525)', () => {
+  // Gabe hit "Aquaman" mid-workout with no way to find out what it was, while
+  // its cues sat in the catalog. The card now reveals them in place.
+  const aquaman = {
+    key: 'aquaman',
+    display_name: 'Aquaman',
+    measures: [],
+    cues: ['Prone: lift opposite arm + leg', 'Long through the spine'],
+    instructions: null,
+  } as unknown as Exercise
+
+  const withAquaman = {
+    ...template,
+    items: [ti({ id: 'a1', exercise_key: 'aquaman', position: 0, target_duration_seconds: 60 })],
+  }
+
+  const render = () =>
+    mount(WorkoutTemplateCard, {
+      props: { template: withAquaman, exercises: [aquaman] },
+    })
+
+  it('hides the description until asked — the list stays scannable', () => {
+    const w = render()
+    expect(w.text()).toContain('Aquaman')
+    expect(w.find('[data-testid="exercise-description"]').exists()).toBe(false)
+  })
+
+  it('reveals the cues when the exercise name is tapped', async () => {
+    const w = render()
+    await w.get('[data-testid="describe-aquaman"]').trigger('click')
+    const panel = w.get('[data-testid="exercise-description"]')
+    expect(panel.text()).toContain('Prone: lift opposite arm + leg')
+    expect(panel.text()).toContain('Long through the spine')
+  })
+
+  it('closes again on a second tap', async () => {
+    const w = render()
+    const trigger = w.get('[data-testid="describe-aquaman"]')
+    await trigger.trigger('click')
+    await trigger.trigger('click')
+    expect(w.find('[data-testid="exercise-description"]').exists()).toBe(false)
+  })
+
+  it('exposes the open state to screen readers', async () => {
+    const w = render()
+    const trigger = w.get('[data-testid="describe-aquaman"]')
+    expect(trigger.attributes('aria-expanded')).toBe('false')
+    await trigger.trigger('click')
+    expect(trigger.attributes('aria-expanded')).toBe('true')
+  })
+
+  it('opens each item independently, so L and R can be compared', async () => {
+    // Closing one to read the other is friction mid-workout.
+    const w = mount(WorkoutTemplateCard, {
+      props: {
+        template: {
+          ...template,
+          items: [
+            ti({ id: 'l', exercise_key: 'side_plank', position: 0, variant: 'left' }),
+            ti({ id: 'r', exercise_key: 'side_plank', position: 1, variant: 'right' }),
+          ],
+        },
+        exercises: [{ key: 'side_plank', display_name: 'Side plank', measures: [], cues: ['Stack the hips'], instructions: null } as unknown as Exercise],
+      },
+    })
+    const triggers = w.findAll('[data-testid="describe-side_plank"]')
+    expect(triggers).toHaveLength(2)
+    await triggers[0].trigger('click')
+    await triggers[1].trigger('click')
+    expect(w.findAll('[data-testid="exercise-description"]')).toHaveLength(2)
+  })
+
+  it('is honest when an exercise has no description yet', async () => {
+    const w = mount(WorkoutTemplateCard, {
+      props: {
+        template: withAquaman,
+        exercises: [{ ...aquaman, cues: [], instructions: null } as unknown as Exercise],
+      },
+    })
+    await w.get('[data-testid="describe-aquaman"]').trigger('click')
+    expect(w.get('[data-testid="exercise-description"]').text()).toContain('No description added')
+  })
+})

--- a/frontend/src/views/WorkoutSessionLoggerView.vue
+++ b/frontend/src/views/WorkoutSessionLoggerView.vue
@@ -61,7 +61,17 @@
       :data-testid="`row-${row.exercise.key}`"
     >
       <div class="flex items-start justify-between gap-2">
-        <span class="text-sm font-medium text-gray-900">{{ row.exercise.display_name }}</span>
+        <!-- Tap the name to see what the movement is (SB-525). -->
+        <button
+          type="button"
+          class="flex items-center gap-1.5 text-left text-sm font-medium text-gray-900"
+          :aria-expanded="isOpen(row.uid)"
+          :data-testid="`describe-${row.exercise.key}`"
+          @click="toggleInfo(row.uid)"
+        >
+          {{ row.exercise.display_name }}
+          <Info class="w-3.5 h-3.5 shrink-0 text-gray-300" aria-hidden="true" />
+        </button>
         <button
           type="button"
           class="icon-btn text-red-500"
@@ -72,6 +82,7 @@
           ✕
         </button>
       </div>
+      <ExerciseDescription v-if="isOpen(row.uid)" class="mt-2" :exercise="row.exercise" />
 
       <div class="mt-2 flex flex-wrap gap-2 text-xs">
         <label class="field">
@@ -182,7 +193,9 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { Info } from 'lucide-vue-next'
 import ExercisePicker from '@/components/ExercisePicker.vue'
+import ExerciseDescription from '@/components/ExerciseDescription.vue'
 import { useExercises } from '@/composables/useExercises'
 import { getTemplate } from '@/composables/useWorkoutTemplates'
 import { createSession } from '@/composables/useWorkoutSessions'
@@ -266,6 +279,16 @@ const onPick = (ex: Exercise): void => {
 
 const removeRow = (row: LoggerRow): void => {
   rows.value = rows.value.filter((r) => r.uid !== row.uid)
+}
+
+// Which rows have their description showing (SB-525). Keyed by row uid, not
+// exercise key, so the same movement logged twice expands independently.
+const openInfo = ref(new Set<number>())
+const isOpen = (uid: number): boolean => openInfo.value.has(uid)
+const toggleInfo = (uid: number): void => {
+  const next = new Set(openInfo.value)
+  next.has(uid) ? next.delete(uid) : next.add(uid)
+  openInfo.value = next
 }
 
 const removeAttempt = (row: LoggerRow, i: number): void => {


### PR DESCRIPTION
## The problem

Gabe hit "Aquaman" mid-workout and had no way to find out what it was.

The answer was already in the database:

```
aquaman | cues = {"Prone: lift opposite arm + leg", "Long through the spine"}
```

**43 of 57 exercises already carry cues.** They rendered on the printed sheet and in the coach-facing pickers — and on **neither athlete screen**. So the only surface with descriptions was the one that was broken (#223, #225), which is exactly why he was reading off the screen when he got stuck.

No new content needed. Three quarters of the library becomes self-explanatory by rendering what is already there.

## The change

Tapping an exercise name reveals its cues and instructions in place, on the workout card and in the session logger.

**The name is the tap target, not an icon.** A line of text is far easier to hit mid-workout, and it avoids a hover-only affordance that does not exist on a phone at all. A small ⓘ sits alongside as the signal that there is something to tap.

**Descriptions open per item, not one at a time.** "Side plank (L)" and "(R)" can be read side by side — closing one to see the other is friction when you are between rounds.

**Exercises with nothing written say so.** 14 of 57 have neither cues nor instructions; silence there reads as a bug rather than an absence.

Hidden in print — the sheet already renders cues its own way.

## Shared, deliberately

The panel is one component used by both surfaces, so the wording — especially the empty state — cannot drift. That is the lesson `groupOptionItems` already taught this codebase after SB-448.

Each view keeps its own trigger and layout, because the card and the logger arrange rows differently.

## Testing

11 new tests. `ExerciseDescription` covers all four content shapes (cues, instructions, both, neither) plus a missing catalog entry. The card covers hidden-by-default, reveal, collapse, `aria-expanded`, independent expansion of L/R, and the honest empty state — using Aquaman's real cues as the fixture.

`vue-tsc --noEmit` clean. **326 tests, 40 files, all passing** (up from 315).

Fixes SB-525

🤖 Generated with [Claude Code](https://claude.com/claude-code)