### PR TITLE
feat: circuits as data, and sets that can name what they answer

### DIFF
--- a/backend/tests/test_template_blocks.py
+++ b/backend/tests/test_template_blocks.py
@@ -1,0 +1,209 @@
+"""Circuits as data, and sets that can name what they answer (SB-527).
+
+Both halves of the same gap: the prescription was not structured enough to be
+referred back to. Rounds lived on the template as one number (Gabe's said 1
+while Circuit A was genuinely two), circuit membership was retyped into every
+item's notes, and `exercise_sets` pointed at an exercise rather than at the
+prescribed item — so with `lunge` appearing five times in one template, a
+logged set was unattributable.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import ValidationError
+from src.shared.models.workout import (
+    ExerciseSetCreate,
+    TemplateBlockCreate,
+    TemplateItemCreate,
+    WorkoutTemplateCreate,
+)
+from src.shared.supabase_ops.workout_repository import WorkoutTemplatesRepository
+
+# --------------------------------------------------------------- recording fake
+
+
+class _Query:
+    def __init__(self, store: dict[str, list[dict[str, Any]]], table: str):
+        self.store, self.table = store, table
+        self._mode = "select"
+        self._payload: Any = None
+        self._preds: list[Any] = []
+
+    def select(self, *a: Any, **k: Any) -> _Query:
+        return self
+
+    def eq(self, col: str, val: Any) -> _Query:
+        self._preds.append(lambda r: str(r.get(col)) == str(val))
+        return self
+
+    def is_(self, col: str, val: Any) -> _Query:
+        if str(val).lower() == "null":
+            self._preds.append(lambda r: r.get(col) is None)
+        return self
+
+    def in_(self, col: str, vals: Any) -> _Query:
+        wanted = {str(v) for v in vals}
+        self._preds.append(lambda r: str(r.get(col)) in wanted)
+        return self
+
+    def order(self, *a: Any, **k: Any) -> _Query:
+        return self
+
+    def insert(self, payload: Any) -> _Query:
+        self._mode, self._payload = "insert", payload
+        return self
+
+    def update(self, payload: Any) -> _Query:
+        self._mode, self._payload = "update", payload
+        return self
+
+    def delete(self) -> _Query:
+        self._mode = "delete"
+        return self
+
+    def execute(self) -> SimpleNamespace:
+        rows = self.store.setdefault(self.table, [])
+        if self._mode == "insert":
+            payload = self._payload if isinstance(self._payload, list) else [self._payload]
+            out = [{"id": str(uuid4()), **r} for r in payload]
+            rows.extend(out)
+            return SimpleNamespace(data=out)
+        matched = [r for r in rows if all(p(r) for p in self._preds)]
+        if self._mode == "update":
+            for r in matched:
+                r.update(self._payload)
+            return SimpleNamespace(data=matched)
+        if self._mode == "delete":
+            self.store[self.table] = [r for r in rows if r not in matched]
+            return SimpleNamespace(data=matched)
+        return SimpleNamespace(data=matched)
+
+
+class _Client:
+    def __init__(self) -> None:
+        self.store: dict[str, list[dict[str, Any]]] = {}
+
+    def table(self, name: str) -> _Query:
+        return _Query(self.store, name)
+
+
+USER = uuid4()
+
+
+def _monday() -> dict[str, Any]:
+    """Gabe's Monday shape: two circuits, the first run twice with rest after."""
+    return WorkoutTemplateCreate(
+        name="Monday At-Home",
+        rounds=1,
+        blocks=[
+            TemplateBlockCreate(label="Circuit A", position=0, rounds=2, rest_after_seconds=240),
+            TemplateBlockCreate(label="Circuit B", position=1, rounds=1),
+        ],
+        items=[
+            TemplateItemCreate(exercise_key="lunge", position=0, block_index=0),
+            TemplateItemCreate(exercise_key="aquaman", position=1, block_index=0),
+            TemplateItemCreate(exercise_key="bird_dog", position=2, block_index=1),
+            TemplateItemCreate(exercise_key="warmup", position=3, section="warmup"),
+        ],
+    ).model_dump(mode="json")
+
+
+# --------------------------------------------------------------- the model
+
+
+def test_rounds_belong_to_the_circuit_not_the_template() -> None:
+    t = WorkoutTemplateCreate(**{**_monday(), "rounds": 1})
+    assert t.rounds == 1, "the template-level number stays 1..."
+    assert [b.rounds for b in t.blocks] == [2, 1], "...while the circuits carry the real counts"
+
+
+def test_a_dangling_block_index_is_rejected() -> None:
+    """Silently orphaning the item would be worse than failing."""
+    with pytest.raises(ValidationError, match="block_index 5 has no matching block"):
+        WorkoutTemplateCreate(
+            name="Bad",
+            blocks=[TemplateBlockCreate(label="Circuit A")],
+            items=[TemplateItemCreate(exercise_key="lunge", block_index=5)],
+        )
+
+
+def test_a_set_can_name_the_prescribed_item() -> None:
+    item_id = uuid4()
+    s = ExerciseSetCreate(exercise_key="lunge", template_item_id=item_id, round_number=2, reps=10)
+    assert s.template_item_id == item_id
+
+
+def test_an_ad_hoc_set_still_needs_no_prescription() -> None:
+    assert ExerciseSetCreate(exercise_key="pushups", reps=20).template_item_id is None
+
+
+# --------------------------------------------------------------- the repository
+
+
+def test_create_resolves_block_index_to_real_ids() -> None:
+    client = _Client()
+    repo = WorkoutTemplatesRepository(client)  # type: ignore[arg-type]
+    got = repo.create(USER, _monday())
+
+    blocks = {b["label"]: b for b in got["blocks"]}
+    assert set(blocks) == {"Circuit A", "Circuit B"}
+    assert blocks["Circuit A"]["rounds"] == 2
+    assert blocks["Circuit A"]["rest_after_seconds"] == 240
+
+    by_ex = {i["exercise_key"]: i for i in got["items"]}
+    assert by_ex["lunge"]["block_id"] == blocks["Circuit A"]["id"]
+    assert by_ex["aquaman"]["block_id"] == blocks["Circuit A"]["id"]
+    assert by_ex["bird_dog"]["block_id"] == blocks["Circuit B"]["id"]
+
+
+def test_items_outside_a_circuit_keep_no_block() -> None:
+    """The warm-up is not part of any circuit and must not be swept into one."""
+    repo = WorkoutTemplatesRepository(_Client())  # type: ignore[arg-type]
+    got = repo.create(USER, _monday())
+    warmup = next(i for i in got["items"] if i["exercise_key"] == "warmup")
+    assert warmup.get("block_id") is None
+
+
+def test_block_index_never_reaches_the_database() -> None:
+    """It is a payload convenience — persisting it would be the string-key
+    pattern this table exists to escape."""
+    client = _Client()
+    WorkoutTemplatesRepository(client).create(USER, _monday())  # type: ignore[arg-type]
+    assert all("block_index" not in row for row in client.store["template_items"])
+
+
+def test_update_replaces_circuits_with_the_items() -> None:
+    client = _Client()
+    repo = WorkoutTemplatesRepository(client)  # type: ignore[arg-type]
+    created = repo.create(USER, _monday())
+
+    changed = WorkoutTemplateCreate(
+        name="Monday At-Home",
+        blocks=[TemplateBlockCreate(label="Circuit A", rounds=3)],
+        items=[TemplateItemCreate(exercise_key="lunge", block_index=0)],
+    ).model_dump(mode="json")
+    out = repo.update(USER, UUID(created["id"]), changed)
+
+    assert out is not None
+    assert [b["label"] for b in out["blocks"]] == ["Circuit A"]
+    assert out["blocks"][0]["rounds"] == 3
+    assert out["items"][0]["block_id"] == out["blocks"][0]["id"]
+    # No orphans left behind from the previous shape.
+    assert len(client.store["template_blocks"]) == 1
+
+
+def test_a_template_with_no_circuits_still_works() -> None:
+    """Blocks are optional — most templates are a flat list."""
+    repo = WorkoutTemplatesRepository(_Client())  # type: ignore[arg-type]
+    payload = WorkoutTemplateCreate(
+        name="Simple",
+        items=[TemplateItemCreate(exercise_key="pushups")],
+    ).model_dump(mode="json")
+    got = repo.create(USER, payload)
+    assert got["blocks"] == []
+    assert got["items"][0].get("block_id") is None

--- a/frontend/src/types/workout.ts
+++ b/frontend/src/types/workout.ts
@@ -17,6 +17,16 @@ export type MovementPattern =
 
 export type ExerciseCategory = 'strength' | 'speed' | 'power' | 'mobility' | 'cardio' | 'test'
 
+/** A circuit within a template: its own rounds and trailing rest (SB-527). */
+export interface TemplateBlock {
+  id: string
+  template_id: string
+  label: string
+  position: number
+  rounds: number
+  rest_after_seconds: number | null
+}
+
 export interface Exercise {
   key: string
   display_name: string
@@ -133,7 +143,8 @@ export interface TemplateItem {
   // null = mandatory. The label is read from any member of the group.
   option_group?: string | null
   option_group_label?: string | null
-  notes: string | null
+  notes: string | null  /** Circuit membership (SB-527); null when outside any circuit. */
+  block_id?: string | null
 }
 
 export interface WorkoutTemplate {
@@ -153,7 +164,8 @@ export interface WorkoutTemplate {
   scheduled_for?: string | null
   // Completion (SB-334): a logged session references this template.
   has_session?: boolean
-  last_session_date?: string | null
+  last_session_date?: string | null  /** Circuits, in position order (SB-527). Empty for simple templates. */
+  blocks?: TemplateBlock[]
 }
 
 /** One row while building — loads are entered in lb (US coach), stored as kg. */

--- a/src/shared/models/workout.py
+++ b/src/shared/models/workout.py
@@ -203,6 +203,11 @@ class TemplateItemCreate(BaseModel):
     # mandatory. The label is read from any member of the group.
     option_group: str | None = None
     option_group_label: str | None = None
+    # Which circuit this item belongs to (SB-527). On CREATE the blocks do not
+    # have ids yet, so the payload references them by index into `blocks` and
+    # the repository resolves it to a real block_id. Deliberately transient —
+    # persisting another string key is the pattern this table is escaping.
+    block_index: int | None = Field(default=None, ge=0)
     notes: str | None = None
 
     @model_validator(mode="after")
@@ -230,6 +235,29 @@ class TemplateItem(TemplateItemCreate):
     id: UUID
     user_id: UUID
     template_id: UUID
+    # Resolved circuit membership (SB-527); None for items outside any circuit.
+    block_id: UUID | None = None
+
+
+class TemplateBlockCreate(BaseModel):
+    """A circuit within a template (SB-527).
+
+    Rounds belong here, not on the template. Gabe's Monday workout is "Circuit A
+    twice, then four minutes water, then Circuit B once" — one number on the
+    template could not say that, so the real prescription lived in prose and
+    nothing could render or track it.
+    """
+
+    label: str
+    position: int = 0
+    rounds: int = Field(default=1, ge=1)
+    rest_after_seconds: float | None = Field(default=None, ge=0)
+
+
+class TemplateBlock(TemplateBlockCreate):
+    id: UUID
+    user_id: UUID
+    template_id: UUID
 
 
 class WorkoutTemplateCreate(BaseModel):
@@ -241,7 +269,20 @@ class WorkoutTemplateCreate(BaseModel):
     source: str | None = None
     notes: str | None = None
     scheduled_for: date | None = None  # optional date the workout is for (SB-335)
+    # Circuits, in order. Items reference them by `block_index` (SB-527).
+    blocks: list[TemplateBlockCreate] = Field(default_factory=list)
     items: list[TemplateItemCreate] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _block_index_in_range(self) -> WorkoutTemplateCreate:
+        """A dangling block_index would silently orphan the item."""
+        for it in self.items:
+            if it.block_index is not None and it.block_index >= len(self.blocks):
+                raise ValueError(
+                    f"block_index {it.block_index} has no matching block "
+                    f"(there {'is' if len(self.blocks) == 1 else 'are'} {len(self.blocks)})"
+                )
+        return self
 
 
 class WorkoutTemplate(BaseModel):
@@ -257,6 +298,7 @@ class WorkoutTemplate(BaseModel):
     source: str | None = None
     notes: str | None = None
     scheduled_for: date | None = None  # optional date the workout is for (SB-335)
+    blocks: list[TemplateBlock] = Field(default_factory=list)
     items: list[TemplateItem] = Field(default_factory=list)
     created_at: datetime | None = None
     # Completion (SB-334), populated by the list query: a template is "done"
@@ -272,6 +314,10 @@ class ExerciseSetCreate(BaseModel):
     """One logged set. Fills only the dimensions the exercise uses."""
 
     exercise_key: str
+    # Which prescribed item this set answers (SB-527). None for ad-hoc sets with
+    # no prescription behind them. Without it "lunge, round 1, 45s" cannot be
+    # attributed — `lunge` appears five times in one of Matthew's templates.
+    template_item_id: UUID | None = None
     round_number: int | None = Field(default=None, ge=1)
     set_index: int | None = Field(default=None, ge=1)
     variant: str | None = None

--- a/src/shared/supabase_ops/workout_repository.py
+++ b/src/shared/supabase_ops/workout_repository.py
@@ -178,21 +178,53 @@ class ExercisesRepository:
 
 
 class WorkoutTemplatesRepository:
-    """Per-user workout templates (the coach's plan) + their items."""
+    """Per-user workout templates (the coach's plan) + their blocks and items."""
 
     def __init__(self, supabase: Client):
         self.supabase = supabase
+
+    def _write_blocks_and_items(
+        self,
+        template_id: str,
+        blocks: Sequence[dict[str, Any]],
+        items: Sequence[dict[str, Any]],
+        owner: dict[str, Any],
+    ) -> None:
+        """Insert a template's circuits, then its items pointing at them.
+
+        Items arrive referencing blocks by `block_index` because on create the
+        blocks have no ids yet (SB-527). Resolve that here — the index is a
+        payload convenience and must never reach the database.
+        """
+        block_ids: list[str] = []
+        if blocks:
+            rows = [
+                {**b, **owner, "template_id": template_id, "position": b.get("position", i)}
+                for i, b in enumerate(blocks)
+            ]
+            created = self.supabase.table("template_blocks").insert(rows).execute()
+            block_ids = [b["id"] for b in cast(list[dict[str, Any]], created.data)]
+
+        if not items:
+            return
+        item_rows = []
+        for it in items:
+            row = {**it, **owner, "template_id": template_id}
+            idx = row.pop("block_index", None)
+            if idx is not None and idx < len(block_ids):
+                row["block_id"] = block_ids[idx]
+            item_rows.append(row)
+        self.supabase.table("template_items").insert(item_rows).execute()
 
     def create(
         self, user_id: UUID, payload: dict[str, Any], athlete_id: UUID | None = None
     ) -> dict[str, Any]:
         items: Sequence[dict[str, Any]] = payload.pop("items", []) or []
+        blocks: Sequence[dict[str, Any]] = payload.pop("blocks", []) or []
         owner = _owner_fields(user_id, athlete_id)
         row = self.supabase.table("workout_templates").insert({**payload, **owner}).execute()
         template = cast(list[dict[str, Any]], row.data)[0]
-        if items:
-            item_rows = [{**it, **owner, "template_id": template["id"]} for it in items]
-            self.supabase.table("template_items").insert(item_rows).execute()
+        self._write_blocks_and_items(template["id"], blocks, items, owner)
         got = self.get(user_id, UUID(template["id"]), athlete_id)
         assert got is not None
         return got
@@ -210,20 +242,25 @@ class WorkoutTemplatesRepository:
             return None
 
         items: Sequence[dict[str, Any]] | None = payload.pop("items", None)
+        blocks: Sequence[dict[str, Any]] | None = payload.pop("blocks", None)
         if payload:
             self.supabase.table("workout_templates").update(payload).eq(
                 "id", str(template_id)
             ).execute()
 
         if items is not None:
-            # Replace the item set wholesale (simplest correct edit).
+            # Replace items and circuits together (simplest correct edit).
+            # Blocks go after items so the FK from template_items is clear
+            # first; ON DELETE SET NULL would otherwise strand memberships.
             self.supabase.table("template_items").delete().eq(
                 "template_id", str(template_id)
             ).execute()
-            if items:
-                owner = _owner_fields(user_id, athlete_id)
-                item_rows = [{**it, **owner, "template_id": str(template_id)} for it in items]
-                self.supabase.table("template_items").insert(item_rows).execute()
+            self.supabase.table("template_blocks").delete().eq(
+                "template_id", str(template_id)
+            ).execute()
+            self._write_blocks_and_items(
+                str(template_id), blocks or [], items, _owner_fields(user_id, athlete_id)
+            )
 
         return self.get(user_id, template_id, athlete_id)
 
@@ -248,6 +285,19 @@ class WorkoutTemplatesRepository:
             by_template.setdefault(it["template_id"], []).append(it)
         for t in templates:
             t["items"] = by_template.get(t["id"], [])
+
+        blocks = (
+            self.supabase.table("template_blocks")
+            .select("*")
+            .in_("template_id", ids)
+            .order("position")
+            .execute()
+        )
+        blocks_by_template: dict[str, list[dict[str, Any]]] = {}
+        for b in cast(list[dict[str, Any]], blocks.data):
+            blocks_by_template.setdefault(b["template_id"], []).append(b)
+        for t in templates:
+            t["blocks"] = blocks_by_template.get(t["id"], [])
 
         # Attach completion state (SB-334): a template is "done" when a logged
         # session references it. One batched query; keep the latest session_date
@@ -304,6 +354,14 @@ class WorkoutTemplatesRepository:
             .execute()
         )
         template["items"] = cast(list[dict[str, Any]], items.data)
+        blocks = (
+            self.supabase.table("template_blocks")
+            .select("*")
+            .eq("template_id", str(template_id))
+            .order("position")
+            .execute()
+        )
+        template["blocks"] = cast(list[dict[str, Any]], blocks.data)
         return template
 
     def delete(self, user_id: UUID, template_id: UUID, athlete_id: UUID | None = None) -> bool:

--- a/supabase/migrations/20260802000000_template_blocks.sql
+++ b/supabase/migrations/20260802000000_template_blocks.sql
@@ -1,0 +1,187 @@
+-- =====================================================
+-- Circuits as data, and a logged set that can name what it was (SB-527).
+--
+-- Two gaps, one migration, because both need to touch exercise_sets and doing
+-- them separately would migrate that table twice.
+--
+-- 1. CIRCUITS AND ROUNDS WERE PROSE.
+--
+--    Gabe's Monday template carried its real structure in free text:
+--
+--      template.rounds = 1
+--      template.notes  = "Circuit A = 2 cycles x 1 min each; then 4-min water
+--                         rest; Circuit B = 1 cycle, timing not prescribed."
+--      item 4  notes = "Circuit A x2 - 1 min"
+--      item 15 notes = "Circuit B - alternate sides each extension"
+--
+--    Circuit membership was retyped into every item, the round count lived in
+--    one item's note, and the rest between circuits was tacked onto the last
+--    item of the first. Meanwhile workout_templates.rounds is a single number
+--    for the whole template and said 1, so nothing could render "2 rounds".
+--
+--    Note the asymmetry this fixes: exercise_sets.round_number already existed,
+--    so the performance side modelled rounds while the prescription side did
+--    not. You could record round 2; you could not prescribe it.
+--
+--    A real table rather than a `circuit TEXT` column: `section` and
+--    `option_group` are already string groupings resolved client-side, and a
+--    third would mean every rendering surface re-implements the fold — which is
+--    exactly why groupOptionItems had to be extracted after SB-448.
+--
+-- 2. A LOGGED SET COULD NOT NAME THE PRESCRIBED ITEM.
+--
+--    exercise_sets referenced exercise_key, not template_items.id. `lunge`
+--    appears five times in one template (side-step L/R, Circuit B single-leg
+--    L/R, plain), so "lunge, round 1, 45s" was unattributable. "Did he do what
+--    was prescribed?" was not answerable by query.
+-- =====================================================
+
+-- =====================================================
+-- template_blocks — a circuit within a template
+-- =====================================================
+CREATE TABLE template_blocks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,   -- denormalized for RLS
+    template_id UUID NOT NULL REFERENCES workout_templates(id) ON DELETE CASCADE,
+    athlete_id UUID REFERENCES athletes(id) ON DELETE CASCADE,
+    created_by UUID REFERENCES users(user_id) ON DELETE SET NULL,
+    label TEXT NOT NULL,                                    -- "Circuit A"
+    position INTEGER NOT NULL DEFAULT 0,                    -- order within the template
+    rounds INTEGER NOT NULL DEFAULT 1 CHECK (rounds >= 1),  -- the grain that was missing
+    rest_after_seconds NUMERIC(8, 2),                       -- the 4-minute water break
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_template_blocks_template ON template_blocks (template_id, position);
+CREATE INDEX idx_template_blocks_athlete ON template_blocks (athlete_id);
+
+COMMENT ON TABLE template_blocks IS
+    'A circuit within a template: its own round count and trailing rest (SB-527)';
+COMMENT ON COLUMN template_blocks.rounds IS
+    'Rounds for THIS circuit. workout_templates.rounds stays for blockless templates.';
+
+-- Nullable: a simple template needs no blocks, and every existing row has none.
+ALTER TABLE template_items
+    ADD COLUMN block_id UUID REFERENCES template_blocks(id) ON DELETE SET NULL;
+CREATE INDEX idx_template_items_block ON template_items (block_id, position);
+
+COMMENT ON COLUMN template_items.block_id IS
+    'The circuit this item belongs to; NULL for items outside any circuit (SB-527)';
+
+-- Nullable: logging an ad-hoc set with no prescription behind it is legitimate.
+ALTER TABLE exercise_sets
+    ADD COLUMN template_item_id UUID REFERENCES template_items(id) ON DELETE SET NULL;
+CREATE INDEX idx_exercise_sets_template_item ON exercise_sets (template_item_id);
+
+COMMENT ON COLUMN exercise_sets.template_item_id IS
+    'The prescribed item this set answers; NULL for ad-hoc sets (SB-527)';
+
+-- =====================================================
+-- RLS — mirrors template_items exactly
+-- =====================================================
+ALTER TABLE template_blocks ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "own template_blocks select" ON template_blocks FOR SELECT
+    USING (user_id = auth.uid());
+CREATE POLICY "own template_blocks insert" ON template_blocks FOR INSERT
+    WITH CHECK (user_id = auth.uid());
+CREATE POLICY "own template_blocks update" ON template_blocks FOR UPDATE
+    USING (user_id = auth.uid());
+CREATE POLICY "own template_blocks delete" ON template_blocks FOR DELETE
+    USING (user_id = auth.uid());
+
+CREATE POLICY "coach template_blocks select" ON template_blocks FOR SELECT
+    USING (can_coach_athlete(athlete_id));
+CREATE POLICY "coach template_blocks insert" ON template_blocks FOR INSERT
+    WITH CHECK (can_coach_athlete(athlete_id));
+CREATE POLICY "coach template_blocks update" ON template_blocks FOR UPDATE
+    USING (can_coach_athlete(athlete_id));
+CREATE POLICY "coach template_blocks delete" ON template_blocks FOR DELETE
+    USING (can_coach_athlete(athlete_id));
+
+-- =====================================================
+-- Backfill: lift circuits out of the notes prose
+-- =====================================================
+-- Existing templates encode circuit membership as a "Circuit X" prefix in an
+-- item's notes — but only on SOME items. Gabe's Monday template labels items
+-- 4-9 and 15-20, and leaves 10-14 unlabelled even though they are plainly the
+-- back half of Circuit A ("Side-step lunge", "Side plank"...).
+--
+-- So a label starts a circuit and every following item in the same section
+-- belongs to it until the next label. That is how a person reads the list, and
+-- a purely per-item match would strand five of Gabe's eleven Circuit A items.
+--
+-- Conservative at the edges: items BEFORE the first label (the warm-up) stay
+-- NULL, and the carry-forward resets at a section boundary so the cool-down is
+-- never swept into the last circuit.
+DO $$
+DECLARE
+    t RECORD;
+    it RECORD;
+    current_block UUID;
+    current_label TEXT;
+    current_section TEXT;
+    found_label TEXT;
+    next_pos INTEGER;
+    n_rounds INTEGER;
+BEGIN
+    FOR t IN
+        SELECT DISTINCT template_id FROM template_items WHERE notes ~* '^\s*Circuit\s+[A-Za-z0-9]+'
+    LOOP
+        current_block := NULL;
+        current_label := NULL;
+        current_section := NULL;
+        next_pos := 0;
+
+        FOR it IN
+            SELECT id, position, section, notes, user_id, athlete_id, created_by
+            FROM template_items WHERE template_id = t.template_id ORDER BY position
+        LOOP
+            -- A new section ends whatever circuit was running.
+            IF current_section IS DISTINCT FROM it.section THEN
+                current_section := it.section;
+                current_block := NULL;
+                current_label := NULL;
+            END IF;
+
+            found_label := substring(it.notes from '^\s*[Cc]ircuit\s+([A-Za-z0-9]+)');
+
+            IF found_label IS NOT NULL AND ('Circuit ' || upper(found_label)) IS DISTINCT FROM current_label THEN
+                current_label := 'Circuit ' || upper(found_label);
+                -- "x2" / "×2" anywhere in this circuit's run of items.
+                n_rounds := COALESCE((
+                    SELECT MAX(NULLIF(substring(notes from '[×xX]\s*(\d+)'), '')::INTEGER)
+                    FROM template_items
+                    WHERE template_id = t.template_id
+                      AND substring(notes from '^\s*[Cc]ircuit\s+([A-Za-z0-9]+)') = found_label
+                ), 1);
+
+                INSERT INTO template_blocks
+                    (user_id, template_id, athlete_id, created_by, label, position, rounds)
+                VALUES
+                    (it.user_id, t.template_id, it.athlete_id, it.created_by,
+                     current_label, next_pos, n_rounds)
+                RETURNING id INTO current_block;
+                next_pos := next_pos + 1;
+            END IF;
+
+            IF current_block IS NOT NULL THEN
+                UPDATE template_items SET block_id = current_block WHERE id = it.id;
+            END IF;
+        END LOOP;
+    END LOOP;
+END $$;
+
+-- The rest between circuits was tacked onto the last item of the preceding one
+-- ("...; then 4-min rest"). Lift it onto the block that owns that item.
+UPDATE template_blocks b
+SET rest_after_seconds = 60 * sub.mins
+FROM (
+    SELECT ti.block_id,
+           MAX(NULLIF(substring(ti.notes from '(\d+)\s*-?\s*min[a-z]*\s+rest'), '')::NUMERIC) AS mins
+    FROM template_items ti
+    WHERE ti.block_id IS NOT NULL AND ti.notes ~* '\d+\s*-?\s*min[a-z]*\s+rest'
+    GROUP BY ti.block_id
+) sub
+WHERE b.id = sub.block_id AND sub.mins IS NOT NULL;


### PR DESCRIPTION
Two gaps, one migration — both touch `exercise_sets`, and separately would migrate that table twice.

## 1. Circuits and rounds were prose

Gabe's Monday template carried its real structure in free text:

```
template.rounds = 1
template.notes  = "Circuit A = 2 cycles × 1 min each; then 4-min water rest;
                   Circuit B = 1 cycle, timing not prescribed."
item 4  notes = "Circuit A ×2 · 1 min"
item 15 notes = "Circuit B · alternate sides each extension"
```

Circuit membership was retyped into every item, the round count lived in one item's note, and the inter-circuit rest was tacked onto the last item of the first. `workout_templates.rounds` is one number for the whole template and said `1`, so nothing could render "2 rounds".

**The asymmetry this closes:** `exercise_sets.round_number` already existed, so the *performance* side modelled rounds while the *prescription* side did not. You could record round 2; you could not prescribe it.

New `template_blocks` (label, position, rounds, rest_after_seconds); `template_items.block_id` references it, nullable so flat templates and every existing row are unaffected.

**A real table, not a `circuit TEXT` column.** `section` and `option_group` are already string groupings resolved client-side. A third would mean every rendering surface re-implements the fold — exactly why `groupOptionItems` had to be extracted after SB-448.

## 2. A logged set could not name the prescribed item

`exercise_sets` referenced `exercise_key`, not `template_items.id`. `lunge` appears **five times** in this one template (side-step L/R, Circuit B single-leg L/R, plain), so "lunge, round 1, 45s" was unattributable and *"did he do what was prescribed?"* was not answerable by query.

Adds `exercise_sets.template_item_id`, nullable — ad-hoc sets with no prescription behind them are legitimate.

## Block references on create

Items cannot carry a `block_id` before the blocks exist, so the payload references them by **`block_index`** into the `blocks` array and the repository resolves it. Transient by design — a test asserts it never reaches the database, since persisting another string-ish key is the pattern this table exists to escape. A dangling index is a validation error rather than a silently orphaned item.

## Backfill

Labels appear on only *some* items — Gabe's template labels 4-9 and 15-20 and leaves 10-14 bare, despite their plainly being the back half of Circuit A ("Side-step lunge", "Side plank"). So a label **starts** a circuit and following items in the same section belong to it until the next label, which is how a person reads the list. A per-item match would have stranded five of eleven.

Conservative at the edges: items before the first label stay NULL, and the carry-forward resets at a section boundary so the cool-down is never swept in.

**Verified by running it against restored production data**, not just reasoned about:

```
Circuit A | pos=0 | rounds=2 | rest=240      11 items (4-14)
Circuit B | pos=1 | rounds=1                  6 items (15-20)
warm-up (0-3) and cool-down (21) unassigned
```

That is the ticket's acceptance criterion, met exactly.

## Testing

9 new tests: rounds live on circuits not the template, dangling index rejected, sets link to items, ad-hoc sets don't have to, create resolves indices, warm-up stays outside circuits, `block_index` never persisted, update replaces circuits without orphans, blockless templates still work.

**Mutation-verified** — disabling the index resolution fails 2 of 9. Same habit as #227.

Backend **362 passed**, root **186 passed**, ruff + format clean on both projects, `vue-tsc` clean.

## Not in scope

Rendering circuits is SB-528 (blocked on this). Frontend gets types only, so nothing breaks.

Fixes SB-527

🤖 Generated with [Claude Code](https://claude.com/claude-code)