### PR TITLE
feat: print sheet renders circuits, rounds as columns

### DIFF
--- a/frontend/src/views/WorkoutPrintView.vue
+++ b/frontend/src/views/WorkoutPrintView.vue
@@ -58,62 +58,82 @@
       <div v-for="section in sections" :key="section.key" class="section">
         <div class="section-bar">
           <span class="section-chip">{{ section.label }}</span>
-          <span v-if="section.key === 'main' && template.rounds > 1" class="section-note">
-            Complete {{ template.rounds }} rounds
-          </span>
         </div>
 
-        <table class="sheet-table">
-          <thead>
-            <tr>
-              <th class="col-ex">Exercise</th>
-              <th class="col-target">Target / details</th>
-              <th class="col-done">Done</th>
-              <th class="col-times">Times / reps</th>
-              <th class="col-notes">Notes</th>
-            </tr>
-          </thead>
-          <tbody>
-            <template v-for="row in section.rows" :key="row.kind === 'group' ? row.key : row.item.id">
-              <tr v-if="row.kind === 'group'" class="option-head">
-                <td colspan="5">{{ row.label }} — do <strong>one</strong>, circle which</td>
-              </tr>
-              <tr
-                v-for="item in row.kind === 'group' ? row.items : [row.item]"
-                :key="item.id"
-                :class="{ 'option-item': row.kind === 'group' }"
-              >
-              <td class="col-ex font-bold uppercase">
-                <span v-if="row.kind === 'group'" class="option-mark">○</span>
-                {{ exerciseName(item.exercise_key) }}
-                <span v-if="item.variant" class="variant">({{ item.variant }})</span>
-              </td>
-              <td class="col-target">
-                <div>{{ targetText(item) }}</div>
-                <div v-for="cue in cuesFor(item.exercise_key)" :key="cue" class="cue">· {{ cue }}</div>
-                <div v-if="item.notes" class="cue">{{ item.notes }}</div>
-              </td>
-              <td class="col-done"><span class="checkbox" /></td>
-              <td class="col-times">
-                <table v-if="timeRows(item).length" class="attempts">
-                  <tr>
-                    <th>{{ item.segments?.length ? 'Segment' : 'Attempt' }}</th>
-                    <th>Time</th>
-                  </tr>
-                  <tr v-for="row in timeRows(item)" :key="row.label">
-                    <td>{{ row.label }}<span v-if="row.goal" class="goal"> ({{ row.goal }})</span></td>
-                    <td><span class="blank w-16" /></td>
-                  </tr>
-                </table>
-              </td>
-              <td class="col-notes"></td>
-            </tr>
-            </template>
-          </tbody>
-        </table>
-      </div>
+        <!-- One table per circuit: Circuit A is two rounds and Circuit B one,
+             and a single table cannot carry both sets of columns (SB-528). -->
+        <template v-for="(g, gi) in section.groups" :key="g.block?.id ?? `loose-${gi}`">
+          <div v-if="g.block" class="block-bar" data-testid="circuit-bar">
+            {{ g.block.label.toUpperCase() }}
+            <span v-if="g.rounds > 1"> — COMPLETE {{ g.rounds }} ROUNDS</span>
+          </div>
 
-      <div v-if="format === 'full'" class="fold">— — — — — — — — — — <span>fold here</span> — — — — — — — — — —</div>
+          <table class="sheet-table">
+            <thead>
+              <tr>
+                <th class="col-ex">Exercise</th>
+                <th class="col-target">Target / details</th>
+                <!-- A box per round beats repeating every exercise N times. -->
+                <th v-for="r in roundCols(g.rounds)" :key="r" class="col-round">{{ r }}</th>
+                <th v-if="!roundCols(g.rounds).length" class="col-done">Done</th>
+                <th class="col-times">Times / reps</th>
+                <th class="col-notes">Notes</th>
+              </tr>
+            </thead>
+            <tbody>
+              <template v-for="row in g.rows" :key="row.kind === 'group' ? row.key : row.item.id">
+                <tr v-if="row.kind === 'group'" class="option-head">
+                  <td :colspan="4 + Math.max(roundCols(g.rounds).length, 1)">
+                    {{ row.label }} — do <strong>one</strong>, circle which
+                  </td>
+                </tr>
+                <tr
+                  v-for="item in row.kind === 'group' ? row.items : [row.item]"
+                  :key="item.id"
+                  :class="{ 'option-item': row.kind === 'group' }"
+                >
+                  <td class="col-ex font-bold uppercase">
+                    <span v-if="row.kind === 'group'" class="option-mark">○</span>
+                    {{ exerciseName(item.exercise_key) }}
+                    <!-- (L) / (R): these are distinct movements, not repeats. -->
+                    <span v-if="item.variant" class="variant">({{ variantLabel(item.variant) }})</span>
+                  </td>
+                  <td class="col-target">
+                    <div>{{ targetText(item) }}</div>
+                    <div v-for="cue in cuesFor(item.exercise_key)" :key="cue" class="cue">· {{ cue }}</div>
+                    <div v-if="item.notes" class="cue">{{ item.notes }}</div>
+                  </td>
+                  <td v-for="r in roundCols(g.rounds)" :key="r" class="col-round"></td>
+                  <td v-if="!roundCols(g.rounds).length" class="col-done"><span class="checkbox" /></td>
+                  <td class="col-times">
+                    <table v-if="timeRows(item).length" class="attempts">
+                      <tr>
+                        <th>{{ item.segments?.length ? 'Segment' : 'Attempt' }}</th>
+                        <th>Time</th>
+                      </tr>
+                      <tr v-for="tr in timeRows(item)" :key="tr.label">
+                        <td>{{ tr.label }}<span v-if="tr.goal" class="goal"> ({{ tr.goal }})</span></td>
+                        <td><span class="blank w-16" /></td>
+                      </tr>
+                    </table>
+                  </td>
+                  <td class="col-notes"></td>
+                </tr>
+              </template>
+              <!-- Rest is a step in the sequence, not a footnote on the last
+                   exercise, which is where it used to hide. -->
+              <tr v-if="g.restAfter" class="rest-row" data-testid="rest-row">
+                <td class="col-ex font-bold uppercase">Rest</td>
+                <td class="col-target">{{ fmtSecs(g.restAfter) }} — water</td>
+                <td v-for="r in roundCols(g.rounds)" :key="r" class="col-round"></td>
+                <td v-if="!roundCols(g.rounds).length" class="col-done"></td>
+                <td class="col-times"></td>
+                <td class="col-notes"></td>
+              </tr>
+            </tbody>
+          </table>
+        </template>
+      </div>
 
       <div class="sheet-footer">
         <span>Total time: <span class="blank w-24" /></span>
@@ -129,7 +149,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { useRoute, RouterLink } from 'vue-router'
 import { apiCall } from '@/config/api'
-import type { Exercise, TemplateItem, WorkoutTemplate } from '@/types/workout'
+import type { Exercise, TemplateBlock, TemplateItem, WorkoutTemplate } from '@/types/workout'
 import type { Athlete } from '@/types/coach'
 import { groupOptionItems } from '@/utils/optionGroups'
 import { fmtRange, hrZoneText, restText } from '@/utils/targets'
@@ -178,8 +198,18 @@ const SECTION_LABELS: Record<string, string> = {
   cooldown: 'Cool-down',
 }
 
+/**
+ * The sheet's structure: sections, each split into circuits (SB-528).
+ *
+ * A circuit gets its own table so it can carry its own round columns — Circuit
+ * A is two rounds while Circuit B is one, and a single table cannot have both.
+ * Items outside any circuit (the warm-up, the cool-down) form an unlabelled
+ * group that renders exactly as before.
+ */
 const sections = computed(() => {
   const items = [...(template.value?.items ?? [])].sort((a, b) => a.position - b.position)
+  const blocksById = new Map((template.value?.blocks ?? []).map((b) => [b.id, b]))
+
   const order: string[] = []
   const by: Record<string, TemplateItem[]> = {}
   for (const item of items) {
@@ -190,15 +220,41 @@ const sections = computed(() => {
     }
     by[key].push(item)
   }
-  return order.map((key) => ({
-    key,
-    label: SECTION_LABELS[key] ?? key.replace(/_/g, ' '),
-    items: by[key],
-    // "Pick one of N" alternatives fold into a single block (SB-448) — printed
-    // flat, the aerobic day told Gabe to do all three.
-    rows: groupOptionItems(by[key]),
-  }))
+
+  return order.map((key) => {
+    // Partition in position order, so a circuit stays contiguous on the page.
+    const groups: { block: TemplateBlock | null; items: TemplateItem[] }[] = []
+    for (const item of by[key]) {
+      const block = (item.block_id && blocksById.get(item.block_id)) || null
+      const last = groups[groups.length - 1]
+      if (last && last.block?.id === block?.id) last.items.push(item)
+      else groups.push({ block, items: [item] })
+    }
+    return {
+      key,
+      label: SECTION_LABELS[key] ?? key.replace(/_/g, ' '),
+      items: by[key],
+      groups: groups.map((g) => ({
+        block: g.block,
+        // Rounds live on the circuit; fall back to the template for the
+        // blockless case, which is every template until SB-527 backfilled.
+        rounds: g.block?.rounds ?? (template.value?.rounds ?? 1),
+        restAfter: g.block?.rest_after_seconds ?? null,
+        // "Pick one of N" alternatives fold into a single row (SB-448) —
+        // printed flat, the aerobic day told Gabe to do all three.
+        rows: groupOptionItems(g.items),
+      })),
+    }
+  })
 })
+
+/** R1, R2, ... — a box per round. One round needs no columns, just "Done". */
+const roundCols = (rounds: number): string[] =>
+  rounds > 1 ? Array.from({ length: rounds }, (_, i) => `R${i + 1}`) : []
+
+/** "left" -> "L". The sheet is narrow; the full word costs a line break. */
+const SHORT_VARIANT: Record<string, string> = { left: 'L', right: 'R' }
+const variantLabel = (v: string): string => SHORT_VARIANT[v.toLowerCase()] ?? v
 
 const exerciseName = (key: string) => exercises.value.get(key)?.display_name ?? key
 
@@ -414,6 +470,20 @@ onMounted(load)
 .col-ex { width: 18%; }
 .col-target { width: 34%; }
 .col-done { width: 7%; text-align: center; }
+/* Narrow, so the round boxes cost little width and Notes keeps room to
+   actually write in (SB-528). */
+.col-round { width: 5%; text-align: center; }
+.block-bar {
+  background: #e9e9e9;
+  border: 1px solid #000;
+  border-bottom: 0;
+  padding: 0.25em 0.5em;
+  font-weight: 700;
+  font-size: 0.9em;
+  letter-spacing: 0.02em;
+  margin-top: 0.6em;
+}
+.rest-row td { background: #f7f7f7; }
 .col-times { width: 22%; }
 .col-notes { width: 19%; }
 .variant { font-weight: 400; text-transform: none; }
@@ -452,14 +522,6 @@ onMounted(load)
   font-size: 0.75em;
 }
 .goal { color: #444; }
-.fold {
-  text-align: center;
-  color: #555;
-  font-style: italic;
-  margin: 1.5em 0;
-  white-space: nowrap;
-  overflow: hidden;
-}
 .sheet-footer {
   display: flex;
   justify-content: space-between;

--- a/frontend/src/views/__tests__/WorkoutPrintView.test.ts
+++ b/frontend/src/views/__tests__/WorkoutPrintView.test.ts
@@ -70,7 +70,6 @@ describe('WorkoutPrintView (SB-231)', () => {
     expect(w.text()).toContain('Warm-up')
     expect(w.text()).toContain('Workout')
     expect(w.text()).toContain('Great work!')
-    expect(w.text()).toContain('fold here')
   })
 
   it('renders attempt rows for timed reps and segment goals for broken reps', async () => {
@@ -239,18 +238,115 @@ describe('WorkoutPrintView rounds (SB-529)', () => {
     })
   }
 
-  it('tells the athlete how many rounds to complete', async () => {
+  it('gives each round its own column to write in', async () => {
+    // SB-528 turned rounds from a sentence into columns: three rounds is three
+    // boxes per exercise, not the same exercise printed three times.
     withRounds(3)
     const w = mount(WorkoutPrintView)
     await flushPromises()
-    expect(w.text()).toContain('Complete 3 rounds')
+    const heads = w.findAll('th').map((h) => h.text())
+    expect(heads).toContain('R1')
+    expect(heads).toContain('R2')
+    expect(heads).toContain('R3')
+    expect(heads).not.toContain('Done')
   })
 
-  it('stays quiet for a single-round workout', async () => {
+  it('one round needs no columns, just a tick box', async () => {
     withRounds(1)
     const w = mount(WorkoutPrintView)
     await flushPromises()
-    expect(w.text()).not.toContain('Complete 1 rounds')
-    expect(w.text()).not.toContain('rounds')
+    const heads = w.findAll('th').map((h) => h.text())
+    expect(heads).toContain('Done')
+    expect(heads).not.toContain('R1')
+  })
+
+  it('prints one row per exercise however many rounds there are', async () => {
+    // The complaint that started this: a two-round circuit read as duplicated
+    // rows. Row count must not scale with rounds.
+    withRounds(1)
+    const one = mount(WorkoutPrintView)
+    await flushPromises()
+    const rowsAtOne = one.findAll('tbody tr').length
+
+    withRounds(4)
+    const four = mount(WorkoutPrintView)
+    await flushPromises()
+    expect(four.findAll('tbody tr').length).toBe(rowsAtOne)
+  })
+})
+
+describe('WorkoutPrintView circuits (SB-528)', () => {
+  // Gabe's Monday shape, now that SB-527 makes it data: Circuit A twice with a
+  // four-minute water break, then Circuit B once.
+  const blocks = [
+    { id: 'bA', template_id: 't1', label: 'Circuit A', position: 0, rounds: 2, rest_after_seconds: 240 },
+    { id: 'bB', template_id: 't1', label: 'Circuit B', position: 1, rounds: 1, rest_after_seconds: null },
+  ]
+  const items = [
+    { id: 'w', exercise_key: 'easy_jog', section: 'warmup', position: 0, block_id: null, target_distance_m: 804, target_reps: null, target_duration_seconds: null, target_load_kg: null, rest_seconds: null, variant: null, notes: null },
+    { id: 'a1', exercise_key: 'interval_run', section: 'main', position: 1, block_id: 'bA', target_duration_seconds: 60, target_reps: null, target_load_kg: null, target_distance_m: null, rest_seconds: null, variant: 'left', notes: null },
+    { id: 'a2', exercise_key: 'interval_run', section: 'main', position: 2, block_id: 'bA', target_duration_seconds: 60, target_reps: null, target_load_kg: null, target_distance_m: null, rest_seconds: null, variant: 'right', notes: null },
+    { id: 'b1', exercise_key: 'easy_jog', section: 'main', position: 3, block_id: 'bB', target_duration_seconds: 60, target_reps: null, target_load_kg: null, target_distance_m: null, rest_seconds: null, variant: null, notes: null },
+  ]
+
+  const render = async () => {
+    apiCallMock.mockReset()
+    apiCallMock.mockImplementation((path: string) => {
+      if (path.startsWith('/workouts/templates/'))
+        return Promise.resolve({ ...template, rounds: 1, blocks, items })
+      if (path.startsWith('/athletes/')) return Promise.resolve({ id: 'a1', display_name: 'Gabe' })
+      if (path === '/workouts/exercises') return Promise.resolve(exercises)
+      return Promise.reject(new Error(`unexpected: ${path}`))
+    })
+    const w = mount(WorkoutPrintView)
+    await flushPromises()
+    return w
+  }
+
+  it('heads each circuit with its own round count', async () => {
+    const w = await render()
+    const bars = w.findAll('[data-testid="circuit-bar"]').map((b) => b.text())
+    expect(bars[0]).toContain('CIRCUIT A')
+    expect(bars[0]).toContain('COMPLETE 2 ROUNDS')
+    expect(bars[1]).toContain('CIRCUIT B')
+    // One round is the default; saying so would be noise.
+    expect(bars[1]).not.toContain('ROUNDS')
+  })
+
+  it('gives each circuit its own columns, since their rounds differ', async () => {
+    // The reason a circuit gets its own table: A needs R1/R2, B needs neither.
+    const w = await render()
+    const tables = w.findAll('table.sheet-table')
+    const heads = tables.map((t) => t.findAll('th').map((h) => h.text()))
+    expect(heads[1]).toContain('R1')
+    expect(heads[1]).toContain('R2')
+    expect(heads[2]).toContain('Done')
+    expect(heads[2]).not.toContain('R1')
+  })
+
+  it('renders rest as a row in the sequence, not a note on the last exercise', async () => {
+    const w = await render()
+    const rest = w.get('[data-testid="rest-row"]')
+    expect(rest.text()).toContain('Rest')
+    expect(rest.text()).toContain('4:00')
+    expect(rest.text()).toContain('water')
+  })
+
+  it('marks left and right as the distinct movements they are', async () => {
+    const w = await render()
+    expect(w.text()).toContain('(L)')
+    expect(w.text()).toContain('(R)')
+  })
+
+  it('keeps the warm-up out of any circuit', async () => {
+    const w = await render()
+    // Three tables: loose warm-up, Circuit A, Circuit B.
+    expect(w.findAll('table.sheet-table')).toHaveLength(3)
+    expect(w.findAll('[data-testid="circuit-bar"]')).toHaveLength(2)
+  })
+
+  it('no longer prints a fold line', async () => {
+    const w = await render()
+    expect(w.text()).not.toContain('fold here')
   })
 })


### PR DESCRIPTION
Printing Gabe's Monday workout read as duplicated rows, carried an unnecessary fold line, and gave him nowhere to record the second round of Circuit A.

## Rounds are columns now

```
┌───────────────────────────┬────────────┬────┬────┬───────┐
│ CIRCUIT A — COMPLETE 2 ROUNDS                             │
├───────────────────────────┼────────────┼────┼────┼───────┤
│ Exercise                  │ Target     │ R1 │ R2 │ Notes │
│ Side-step lunge (L)       │ 1:00       │    │    │       │
│ Side plank (L)            │ 1:00       │    │    │       │
│ Rest                      │ 4:00 water │    │    │       │
└───────────────────────────┴────────────┴────┴────┴───────┘
```

Two rounds of eleven exercises is **eleven rows with two boxes each**, not twenty-two rows. There's a test asserting row count doesn't scale with rounds, because that was the original complaint.

## One table per circuit

Circuit A is two rounds and Circuit B is one — a single table cannot carry both sets of columns. Each circuit heads with its own count, putting the instruction where it applies instead of in a paragraph at the top. A single-round circuit stays silent; "COMPLETE 1 ROUNDS" is noise.

## Rest is a step, not a footnote

It showed up as `"...; then 4-min rest"` tacked onto the last exercise's notes. Now it's a row: **Rest · 4:00 — water**.

## Variants read as (L) and (R)

`lunge` appears five times in this template and they are genuinely different movements. Showing the variant beside the name is what stops the list looking like repeats — the thing that prompted "it just seems to add a row twice". Short forms because the sheet is narrow and "(left)" costs a line break.

## Fold line gone

Removed from the full-page format, style and all.

## Built on SB-527

All of this reads `template_blocks`, which #228 added and backfilled in production — so Gabe's *existing* workout renders correctly, not only new ones. Blockless templates fall back to `template.rounds` and render exactly as before.

## Testing

The SB-529 rounds tests are **updated, not dropped**. They asserted the prose "Complete 3 rounds"; they now assert R1/R2/R3 column headers. Same intent — the suite fails if rounds stop being honoured — expressed through the new UI.

Six new circuit tests: per-circuit headers and counts, differing columns between circuits, rest as a row, (L)/(R), warm-up staying outside any circuit, and no fold line.

**Mutation-verified**: forcing per-circuit rounds to 1 fails three tests.

`vue-tsc --noEmit` clean. **335 tests, 40 files, all passing.**

Fixes SB-528

🤖 Generated with [Claude Code](https://claude.com/claude-code)