### PR TITLE
fix: the logging flow no longer dead-ends on an athlete

### DIFF
--- a/frontend/src/utils/apiErrors.ts
+++ b/frontend/src/utils/apiErrors.ts
@@ -1,0 +1,32 @@
+/**
+ * Plain-English cause for a failed request (SB-501).
+ *
+ * Gabe's whole experience of SB-522 was one line of red text reading
+ * "HTTP 422". SB-523 fixed that on the print sheet; the logger had the same
+ * problem, so the wording lives here rather than being written twice and
+ * drifting.
+ *
+ * The raw message stays visible next to this, small — useful when debugging,
+ * not shouted at the person using the app.
+ */
+export function explainStatus(status: number | null | undefined, action = 'load this'): string {
+  switch (status) {
+    case 401:
+    case 403:
+      return `You may not have access, or your session expired. Try signing in again.`
+    case 404:
+      return `We couldn't find it — it may have been deleted.`
+    case 409:
+      return `That conflicts with something already saved.`
+    case 422:
+      return `Something in the request was wrong, so the server turned it down. This is a bug on our side, not something you did.`
+    default:
+      if (status && status >= 500) return `The server had a problem. Trying again usually works.`
+      return `Check your connection and try again — we couldn't ${action}.`
+  }
+}
+
+/** The HTTP status apiCall attached to an error, when it has one. */
+export function statusOf(e: unknown): number | null {
+  return (e as { status?: number })?.status ?? null
+}

--- a/frontend/src/views/WorkoutPrintView.vue
+++ b/frontend/src/views/WorkoutPrintView.vue
@@ -153,7 +153,7 @@ import type { Exercise, TemplateBlock, TemplateItem, WorkoutTemplate } from '@/t
 import type { Athlete } from '@/types/coach'
 import { groupOptionItems } from '@/utils/optionGroups'
 import { fmtRange, hrZoneText, restText } from '@/utils/targets'
-import { useMyAthlete } from '@/composables/useCoach'
+import { useActingAthlete } from '@/composables/useActingAthlete'
 
 const route = useRoute()
 const templateId = String(route.params.templateId)
@@ -165,18 +165,18 @@ const templateId = String(route.params.templateId)
 // Only the coach route carries an athleteId, so it must stay nullable:
 // String(undefined) yields the string "undefined", which the API rejects as an
 // invalid UUID with a bare 422 (SB-522).
-const coachRouteAthleteId = route.params.athleteId ? String(route.params.athleteId) : null
-const isCoachRoute = coachRouteAthleteId !== null
-const backTo = isCoachRoute ? `/coach/${coachRouteAthleteId}` : '/my/workouts'
-
-// Every workout request is scoped by athlete id, and a coach-assigned template
-// belongs to the ATHLETE row — not to the athlete's user account. Omitting the
-// header sends the query down the "my own self-authored rows" branch
-// (athlete_id IS NULL), which can never match it, so the athlete got a 404
-// (SB-524). Resolve the caller's athlete row and scope by its id, exactly as
-// MyWorkoutsView already does.
-const { myAthlete, loadMyAthlete } = useMyAthlete()
-const scopeAthleteId = ref<string | null>(coachRouteAthleteId)
+// Every workout request is scoped by an athlete id, and a coach-assigned
+// template belongs to the ATHLETE row — not to the athlete's user account.
+// Omitting the header sends the query down the "my own self-authored rows"
+// branch (athlete_id IS NULL), which can never match it, so the athlete got a
+// 404 (SB-524).
+//
+// useActingAthlete already resolves exactly this for both routes — the coach's
+// :athleteId param, or the caller's own athlete row — and owns the back-link
+// too. SB-524 hand-rolled it here; this is that duplication removed (SB-501).
+const { athleteId: scopeAthleteId, isSelf, homePath, resolveAthlete } = useActingAthlete()
+const isCoachRoute = !isSelf.value
+const backTo = homePath
 
 const template = ref<WorkoutTemplate | null>(null)
 const athleteName = ref('')
@@ -356,14 +356,13 @@ const load = async () => {
   errorStatus.value = null
   try {
     // On the athlete route the scope id is not in the URL — resolve it first.
-    if (!isCoachRoute && scopeAthleteId.value === null) {
-      await loadMyAthlete(true)
-      if (!myAthlete.value) {
+    if (scopeAthleteId.value === null) {
+      await resolveAthlete()
+      if (scopeAthleteId.value === null) {
         throw Object.assign(new Error('No athlete profile is linked to this account.'), {
           status: 404,
         })
       }
-      scopeAthleteId.value = myAthlete.value.id
     }
     const headers = { 'X-Act-As-Athlete': scopeAthleteId.value as string }
     const [tpl, catalog] = await Promise.all([
@@ -375,7 +374,7 @@ const load = async () => {
     // Only a coach needs the athlete's name in the heading — printing your own
     // sheet does not, so skip the extra request.
     if (isCoachRoute) {
-      const athlete = await apiCall<Athlete>(`/athletes/${coachRouteAthleteId}`)
+      const athlete = await apiCall<Athlete>(`/athletes/${scopeAthleteId.value}`)
       athleteName.value = athlete.display_name
     }
   } catch (e) {

--- a/frontend/src/views/WorkoutSessionLoggerView.vue
+++ b/frontend/src/views/WorkoutSessionLoggerView.vue
@@ -175,17 +175,37 @@
     </div>
 
     <!-- Save -->
-    <div class="mt-6 flex items-center gap-3">
-      <button
-        type="button"
-        class="btn-primary"
-        :disabled="!canSave || saving"
-        data-testid="save"
-        @click="save"
+    <div class="mt-6">
+      <div class="flex items-center gap-3">
+        <button
+          type="button"
+          class="btn-primary"
+          :disabled="!canSave || saving"
+          data-testid="save"
+          @click="save"
+        >
+          {{ saving ? 'Saving…' : 'Save session' }}
+        </button>
+        <!-- A disabled button with no reason is a dead end (SB-501). -->
+        <span v-if="blockedReason" class="text-sm text-gray-500" data-testid="save-blocked">
+          {{ blockedReason }}
+        </span>
+      </div>
+
+      <div
+        v-if="error"
+        class="mt-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2"
+        data-testid="save-error"
       >
-        {{ saving ? 'Saving…' : 'Save session' }}
-      </button>
-      <span v-if="error" class="text-sm text-red-600">{{ error }}</span>
+        <p class="text-sm font-medium text-red-800">Couldn't save this session</p>
+        <p class="mt-1 text-sm text-red-700">{{ explainStatus(errorStatus, 'save it') }}</p>
+        <!-- The thing an athlete most needs to know mid-workout: nothing was
+             lost, so do not redo the whole session. -->
+        <p class="mt-1 text-sm text-red-700">
+          Everything you logged is still on this page — press Save session to try again.
+        </p>
+        <p class="mt-2 text-xs text-red-400">{{ error }}</p>
+      </div>
     </div>
   </div>
 </template>
@@ -208,6 +228,7 @@ import {
 } from '@/utils/sessionPayload'
 import type { Exercise, LoggerRow, WorkoutType } from '@/types/workout'
 import { useActingAthlete } from '@/composables/useActingAthlete'
+import { explainStatus, statusOf } from '@/utils/apiErrors'
 
 const route = useRoute()
 const router = useRouter()
@@ -226,6 +247,7 @@ const sessionType = ref<WorkoutType>('circuit')
 const picking = ref(false)
 const saving = ref(false)
 const error = ref<string | null>(null)
+const errorStatus = ref<number | null>(null)
 
 let nextUid = 1
 
@@ -311,15 +333,25 @@ const payload = computed(() =>
 
 const canSave = computed(() => sessionDate.value.length > 0 && payload.value.sets.length > 0)
 
+/** Why Save is unavailable, so the button is never just dead (SB-501). */
+const blockedReason = computed<string | null>(() => {
+  if (saving.value || canSave.value) return null
+  if (!sessionDate.value) return 'Pick a date first.'
+  if (!rows.value.length) return 'Add an exercise to log.'
+  return 'Fill in at least one value — reps, time or weight.'
+})
+
 const save = async (): Promise<void> => {
   if (!canSave.value) return
   saving.value = true
   error.value = null
+  errorStatus.value = null
   try {
     await createSession(payload.value, athleteId.value!)
     router.push(homePath.value)
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Failed to save session'
+    errorStatus.value = statusOf(e)
   } finally {
     saving.value = false
   }

--- a/frontend/src/views/__tests__/WorkoutSessionLoggerView.test.ts
+++ b/frontend/src/views/__tests__/WorkoutSessionLoggerView.test.ts
@@ -196,3 +196,69 @@ describe('WorkoutSessionLoggerView', () => {
     expect(w.find('[data-testid="row-pushups"]').exists()).toBe(false)
   })
 })
+
+describe('WorkoutSessionLoggerView — save failure and dead ends (SB-501)', () => {
+  const addPushups = async (w: Awaited<ReturnType<typeof mountLogger>>) => {
+    await w.find('[data-testid="add-exercise"]').trigger('click')
+    await w.find('[data-testid="ex-pushups"]').trigger('click')
+    await w.find('[data-testid="reps-pushups-0"]').setValue(20)
+  }
+
+  it('says why Save is unavailable instead of offering a dead button', async () => {
+    // A disabled control with no explanation is the worst kind of friction
+    // mid-workout: nothing to read, nothing to fix.
+    const w = await mountLogger()
+    expect(w.get('[data-testid="save"]').attributes('disabled')).toBeDefined()
+    expect(w.get('[data-testid="save-blocked"]').text()).toContain('Add an exercise')
+  })
+
+  it('drops the explanation once the session can be saved', async () => {
+    const w = await mountLogger()
+    await addPushups(w)
+    expect(w.find('[data-testid="save-blocked"]').exists()).toBe(false)
+    expect(w.get('[data-testid="save"]').attributes('disabled')).toBeUndefined()
+  })
+
+  it('explains a failed save in words, not a status code', async () => {
+    const w = await mountLogger()
+    await addPushups(w)
+    h.createSession.mockRejectedValueOnce(Object.assign(new Error('HTTP 500'), { status: 500 }))
+    await w.get('[data-testid="save"]').trigger('click')
+    await flushPromises()
+
+    const panel = w.get('[data-testid="save-error"]')
+    expect(panel.text()).toContain("Couldn't save this session")
+    expect(panel.text()).toContain('The server had a problem')
+    expect(panel.text()).toContain('HTTP 500') // raw detail still available
+  })
+
+  it('tells the athlete their work was not lost', async () => {
+    // The thing that actually matters when a save fails mid-session: do not
+    // make a kid think he has to log the whole workout again.
+    const w = await mountLogger()
+    await addPushups(w)
+    h.createSession.mockRejectedValueOnce(Object.assign(new Error('nope'), { status: 500 }))
+    await w.get('[data-testid="save"]').trigger('click')
+    await flushPromises()
+
+    expect(w.get('[data-testid="save-error"]').text()).toContain('still on this page')
+    // And it genuinely is not lost — the row survives.
+    expect(w.find('[data-testid="reps-pushups-0"]').exists()).toBe(true)
+    expect(h.push).not.toHaveBeenCalled()
+  })
+
+  it('lets a retry succeed after a failure', async () => {
+    const w = await mountLogger()
+    await addPushups(w)
+    h.createSession.mockRejectedValueOnce(Object.assign(new Error('nope'), { status: 500 }))
+    await w.get('[data-testid="save"]').trigger('click')
+    await flushPromises()
+
+    h.createSession.mockResolvedValueOnce({ id: 's1' })
+    await w.get('[data-testid="save"]').trigger('click')
+    await flushPromises()
+
+    expect(w.find('[data-testid="save-error"]').exists()).toBe(false)
+    expect(h.push).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Three bits of friction on the path Gabe actually uses, plus a duplication I left behind earlier today.

## A failed save showed "HTTP 500" and nothing else

Same defect #224 fixed on the print sheet, still present in the logger. Now it explains the cause in words and — the part that matters mid-workout — says his work is safe:

> **Couldn't save this session**
> The server had a problem. Trying again usually works.
> Everything you logged is still on this page — press Save session to try again.

That last line is the point. A kid who loses a save and *thinks* he's lost the session will either redo the whole thing or give up. The raw message stays, small, for debugging. A test covers failure-then-retry-succeeds.

## Save was disabled with no reason

A dead button with nothing to read is the worst kind of friction between rounds. It now names which of the three things is missing — a date, an exercise, or a value — and the explanation disappears once the session can be saved.

## Wording extracted

`utils/apiErrors.ts` — the status-to-English mapping is needed in two places now, and copy that exists twice drifts apart. Same reasoning as `groupOptionItems` after SB-448.

## Removes duplication from #225

The print view hand-rolled athlete resolution when **`useActingAthlete` already did exactly that** — the coach's `:athleteId` param or the caller's own athlete row, plus the back-link — and was already used by the builder and logger. Had I looked, SB-524 would have been three lines instead of a new code path.

The print tests pass unchanged through the refactor, which is what makes it safe.

## Audit

Checked both of today's bug classes across the frontend:

- **`String()` on an optional route param** (SB-522): no other instance. The remaining calls are required params on single-route views.
- **Raw `{{ error }}`**: 17 files. This covers the logging path; the rest deserve their own pass rather than a drive-by.

## Testing

5 new tests: disabled-with-reason, reason clears, failure explained in words, work-not-lost (asserts the row survives *and* no navigation), retry succeeds.

Mutation-verified: swapping the explanation back for the raw message fails a test.

`vue-tsc --noEmit` clean. **340 tests, all passing.**

Fixes SB-501

🤖 Generated with [Claude Code](https://claude.com/claude-code)