### PR TITLE
feat: log a workout with no plan behind it

### DIFF
--- a/frontend/src/views/MyWorkoutsView.vue
+++ b/frontend/src/views/MyWorkoutsView.vue
@@ -7,11 +7,30 @@
           Workouts your coach has assigned, plus any you build yourself.
         </p>
       </div>
+      <!-- "+ New workout" used to be the loudest control here and it built a
+           PLAN, which read as "do a workout" and was the reported confusion
+           (SB-530). Building is secondary; doing is the point. -->
       <RouterLink
         to="/my/workouts/build"
-        class="shrink-0 rounded-lg bg-brand-600 px-3 py-2 text-sm font-medium text-white hover:bg-brand-700"
+        class="shrink-0 rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50"
       >
-        + New workout
+        + Build a workout
+      </RouterLink>
+    </div>
+
+    <!-- Nothing is scheduled yet — `scheduled_for` is unset on every template —
+         so logging what you just did IS the primary action (SB-531). When
+         scheduling lands this becomes the "due today" card and the ad-hoc link
+         drops beneath it. -->
+    <div class="mb-5 rounded-2xl border border-brand-200 bg-brand-50 p-5 text-center">
+      <p class="text-sm font-semibold text-brand-800">Did a workout on your own?</p>
+      <p class="mt-1 text-sm text-brand-700">Log it and get the credit — no plan needed.</p>
+      <RouterLink
+        to="/my/workouts/log"
+        class="mt-3 inline-block rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700"
+        data-testid="log-adhoc"
+      >
+        + Log a workout
       </RouterLink>
     </div>
 

--- a/frontend/src/views/WorkoutSessionLoggerView.vue
+++ b/frontend/src/views/WorkoutSessionLoggerView.vue
@@ -4,9 +4,15 @@
       ← Back
     </RouterLink>
 
-    <h1 class="text-2xl font-bold text-gray-900 mt-4">Log workout</h1>
+    <!-- No plan behind it: he is not logging *against* anything (SB-531). -->
+    <h1 class="text-2xl font-bold text-gray-900 mt-4">
+      {{ templateId ? 'Log workout' : 'New workout' }}
+    </h1>
     <p v-if="templateName" class="text-sm text-gray-500 mt-1" data-testid="from-template">
       From <span class="font-medium text-gray-700">{{ templateName }}</span>
+    </p>
+    <p v-else class="text-sm text-gray-500 mt-1">
+      Add what you did — it counts the same as a workout from your coach.
     </p>
 
     <!-- Session meta -->
@@ -174,8 +180,43 @@
       />
     </div>
 
+    <!-- Kept a workout he invented (SB-531) -->
+    <div
+      v-if="savedAdhoc"
+      class="mt-6 rounded-2xl border border-brand-200 bg-brand-50 p-5"
+      data-testid="keep-offer"
+    >
+      <p class="text-base font-semibold text-brand-900">Logged — nice one.</p>
+      <p class="mt-1 text-sm text-brand-800">
+        Do this one again? Save it to your workouts and it&rsquo;s one tap next time — and
+        printable.
+      </p>
+      <div class="mt-4 flex flex-wrap gap-2">
+        <button
+          type="button"
+          class="btn-primary text-sm"
+          :disabled="keeping"
+          data-testid="keep-yes"
+          @click="keepAsPlan"
+        >
+          {{ keeping ? 'Saving…' : 'Save to my workouts' }}
+        </button>
+        <button
+          type="button"
+          class="rounded-lg border border-brand-200 px-3 py-2 text-sm font-medium text-brand-700"
+          data-testid="keep-no"
+          @click="router.push(homePath)"
+        >
+          No thanks
+        </button>
+      </div>
+      <p v-if="keepError" class="mt-2 text-sm text-red-700">
+        Couldn&rsquo;t save it as a workout — your session is logged either way.
+      </p>
+    </div>
+
     <!-- Save -->
-    <div class="mt-6">
+    <div v-else class="mt-6">
       <div class="flex items-center gap-3">
         <button
           type="button"
@@ -217,7 +258,7 @@ import { Info } from 'lucide-vue-next'
 import ExercisePicker from '@/components/ExercisePicker.vue'
 import ExerciseDescription from '@/components/ExerciseDescription.vue'
 import { useExercises } from '@/composables/useExercises'
-import { getTemplate } from '@/composables/useWorkoutTemplates'
+import { createTemplate, getTemplate } from '@/composables/useWorkoutTemplates'
 import { createSession } from '@/composables/useWorkoutSessions'
 import {
   FELT_OPTIONS,
@@ -226,7 +267,7 @@ import {
   templateToRows,
   todayISO,
 } from '@/utils/sessionPayload'
-import type { Exercise, LoggerRow, WorkoutType } from '@/types/workout'
+import type { Exercise, LoggerRow, WorkoutTemplateInput, WorkoutType } from '@/types/workout'
 import { useActingAthlete } from '@/composables/useActingAthlete'
 import { explainStatus, statusOf } from '@/utils/apiErrors'
 
@@ -248,6 +289,9 @@ const picking = ref(false)
 const saving = ref(false)
 const error = ref<string | null>(null)
 const errorStatus = ref<number | null>(null)
+const savedAdhoc = ref(false)
+const keeping = ref(false)
+const keepError = ref(false)
 
 let nextUid = 1
 
@@ -348,6 +392,13 @@ const save = async (): Promise<void> => {
   errorStatus.value = null
   try {
     await createSession(payload.value, athleteId.value!)
+    // An ad-hoc session is the one moment he might want to keep the workout:
+    // he just did it and liked it. Nobody opens an empty builder cold, which is
+    // why every plan he has is his coach's (SB-531).
+    if (!templateId) {
+      savedAdhoc.value = true
+      return
+    }
     router.push(homePath.value)
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Failed to save session'
@@ -355,6 +406,42 @@ const save = async (): Promise<void> => {
   } finally {
     saving.value = false
   }
+}
+
+/** Turn what he just logged into a reusable workout (SB-531). */
+const keepAsPlan = async (): Promise<void> => {
+  keeping.value = true
+  keepError.value = false
+  try {
+    await createTemplate(
+      {
+        name: sessionName(),
+        type: 'circuit',
+        rounds: 1,
+        items: rows.value.map((r, i) => ({
+          exercise_key: r.exercise.key,
+          section: 'main',
+          position: i,
+        })),
+      } as WorkoutTemplateInput,
+      athleteId.value!,
+    )
+    router.push(homePath.value)
+  } catch {
+    // The session is already saved; failing to keep it is not worth losing that.
+    keepError.value = true
+  } finally {
+    keeping.value = false
+  }
+}
+
+/** "Sunday morning" — a name he never had to stop and type. */
+const sessionName = (): string => {
+  const d = new Date(`${sessionDate.value}T12:00:00`)
+  const day = d.toLocaleDateString(undefined, { weekday: 'long' })
+  const hour = new Date().getHours()
+  const part = hour < 12 ? 'morning' : hour < 17 ? 'afternoon' : 'evening'
+  return `${day} ${part}`
 }
 
 const prefillFrom = (id: string): Promise<void> =>

--- a/frontend/src/views/__tests__/MyWorkoutsView.test.ts
+++ b/frontend/src/views/__tests__/MyWorkoutsView.test.ts
@@ -16,7 +16,8 @@ const pushMock = vi.fn()
 // to provide RouterLink as well as the router itself.
 vi.mock('vue-router', () => ({
   useRouter: () => ({ replace: replaceMock, push: pushMock }),
-  RouterLink: { template: '<a><slot /></a>' },
+  // `to` is forwarded so tests can assert where a link actually goes.
+  RouterLink: { props: ['to'], template: '<a :href="to"><slot /></a>' },
 }))
 
 import MyWorkoutsView from '../MyWorkoutsView.vue'
@@ -75,5 +76,26 @@ describe('MyWorkoutsView (SB-332)', () => {
     const w = mount(MyWorkoutsView)
     await flushPromises()
     expect(w.text()).toContain('No workouts yet')
+  })
+})
+
+describe('MyWorkoutsView — ad-hoc entry (SB-531)', () => {
+  it('offers logging a workout with no plan behind it', async () => {
+    myAthlete.value = { id: 'ath1', linked_user_id: 'u1' }
+    apiCallMock.mockResolvedValue([])
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    const link = w.get('[data-testid="log-adhoc"]')
+    expect(link.attributes('href')).toBe('/my/workouts/log')
+    expect(w.text()).toContain('Did a workout on your own?')
+  })
+
+  it('demotes building a plan — it was the loudest control and the wrong verb', async () => {
+    myAthlete.value = { id: 'ath1', linked_user_id: 'u1' }
+    apiCallMock.mockResolvedValue([])
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    expect(w.text()).toContain('+ Build a workout')
+    expect(w.text()).not.toContain('+ New workout')
   })
 })

--- a/frontend/src/views/__tests__/WorkoutSessionLoggerView.test.ts
+++ b/frontend/src/views/__tests__/WorkoutSessionLoggerView.test.ts
@@ -4,6 +4,7 @@ import { mount, flushPromises } from '@vue/test-utils'
 const h = vi.hoisted(() => ({
   createSession: vi.fn(),
   getTemplate: vi.fn(),
+  createTemplate: vi.fn(),
   push: vi.fn(),
   replace: vi.fn(),
   isCoach: { value: true },
@@ -46,6 +47,7 @@ vi.mock('@/composables/useCoach', () => ({
 }))
 vi.mock('@/composables/useWorkoutTemplates', () => ({
   getTemplate: (...a: unknown[]) => h.getTemplate(...a),
+  createTemplate: (...a: unknown[]) => h.createTemplate(...a),
 }))
 vi.mock('@/composables/useWorkoutSessions', () => ({
   createSession: (...a: unknown[]) => h.createSession(...a),
@@ -133,6 +135,10 @@ describe('WorkoutSessionLoggerView', () => {
     const [payload, athleteId] = h.createSession.mock.calls[0]
     expect(athleteId).toBe('ath1')
     expect(payload.sets[0]).toMatchObject({ exercise_key: 'farmers_carry', load_kg: 4.5 })
+    // No template behind this one, so it offers to keep it rather than leaving
+    // straight away (SB-531). Declining goes home as before.
+    expect(w.find('[data-testid="keep-offer"]').exists()).toBe(true)
+    await w.find('[data-testid="keep-no"]').trigger('click')
     expect(h.push).toHaveBeenCalledWith('/coach/ath1')
   })
 
@@ -259,6 +265,86 @@ describe('WorkoutSessionLoggerView — save failure and dead ends (SB-501)', () 
     await flushPromises()
 
     expect(w.find('[data-testid="save-error"]').exists()).toBe(false)
-    expect(h.push).toHaveBeenCalled()
+    // Ad-hoc: the keep-offer stands in for navigation (SB-531).
+    expect(w.find('[data-testid="keep-offer"]').exists()).toBe(true)
+  })
+})
+
+describe('WorkoutSessionLoggerView — ad-hoc workout (SB-531)', () => {
+  // Gabe wakes up, does four exercises, wants credit. No plan involved.
+  const logSomething = async () => {
+    h.createSession.mockResolvedValue({ id: 's9' })
+    const w = await mountLogger()
+    await w.find('[data-testid="add-exercise"]').trigger('click')
+    await w.find('[data-testid="ex-pushups"]').trigger('click')
+    await w.find('[data-testid="reps-pushups-0"]').setValue(20)
+    await w.find('[data-testid="save"]').trigger('click')
+    await flushPromises()
+    return w
+  }
+
+  it('titles it a new workout, not a log against something', async () => {
+    const w = await mountLogger()
+    expect(w.text()).toContain('New workout')
+    expect(w.find('[data-testid="from-template"]').exists()).toBe(false)
+  })
+
+  it('saves with no template behind it', async () => {
+    await logSomething()
+    const [payload] = h.createSession.mock.calls[0]
+    expect(payload.template_id ?? null).toBeNull()
+    expect(payload.sets).toHaveLength(1)
+  })
+
+  it('offers to keep it rather than requiring a name up front', async () => {
+    // Asking him to name it before he gets the tick is friction in the wrong
+    // place — credit first, the offer second.
+    const w = await logSomething()
+    const offer = w.get('[data-testid="keep-offer"]')
+    expect(offer.text()).toContain('Logged')
+    expect(offer.text()).toContain('Do this one again?')
+  })
+
+  it('keeping it creates a reusable workout named after the day', async () => {
+    h.createTemplate.mockResolvedValue({ id: 't9' })
+    const w = await logSomething()
+    await w.get('[data-testid="keep-yes"]').trigger('click')
+    await flushPromises()
+
+    const [payload, athleteId] = h.createTemplate.mock.calls[0]
+    expect(athleteId).toBe('ath1')
+    expect(payload.name).toMatch(/^(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday) (morning|afternoon|evening)$/)
+    expect(payload.items[0]).toMatchObject({ exercise_key: 'pushups', position: 0 })
+    expect(h.push).toHaveBeenCalledWith('/coach/ath1')
+  })
+
+  it('declining just goes home — the session is already saved', async () => {
+    const w = await logSomething()
+    await w.get('[data-testid="keep-no"]').trigger('click')
+    expect(h.createTemplate).not.toHaveBeenCalled()
+    expect(h.push).toHaveBeenCalledWith('/coach/ath1')
+  })
+
+  it('a failed keep does not imply the session was lost', async () => {
+    h.createTemplate.mockRejectedValueOnce(new Error('nope'))
+    const w = await logSomething()
+    await w.get('[data-testid="keep-yes"]').trigger('click')
+    await flushPromises()
+    expect(w.get('[data-testid="keep-offer"]').text()).toContain('your session is logged either way')
+  })
+
+  it('a workout from a template still leaves straight away', async () => {
+    // The existing flow must not change.
+    h.params = { athleteId: 'ath1', templateId: 't1' }
+    h.getTemplate.mockResolvedValue({ id: 't1', name: 'Monday At-Home', rounds: 1, items: [] })
+    h.createSession.mockResolvedValue({ id: 's10' })
+    const w = await mountLogger()
+    await w.find('[data-testid="add-exercise"]').trigger('click')
+    await w.find('[data-testid="ex-pushups"]').trigger('click')
+    await w.find('[data-testid="reps-pushups-0"]').setValue(15)
+    await w.find('[data-testid="save"]').trigger('click')
+    await flushPromises()
+    expect(w.find('[data-testid="keep-offer"]').exists()).toBe(false)
+    expect(h.push).toHaveBeenCalledWith('/coach/ath1')
   })
 })


### PR DESCRIPTION
Gabe wakes up, does four exercises, wants credit. There was no way to record that — and the capability was **already built**.

```
workout_sessions.template_id     nullable  YES
exercise_sets.template_item_id   nullable  YES
route /my/workouts/log           exists, no :templateId
logger with no template          starts empty, skips prefill
links to it in the UI            none
```

Schema, route and view all present. Nothing linked to it. Third feature found finished and unreachable, after logging itself and athlete-authored workouts (see SB-530).

## The door

On the athlete's screen, logging what you just did is now the prominent action:

> **Did a workout on your own?**
> Log it and get the credit — no plan needed.
> `[+ Log a workout]`

Nothing is *ever* scheduled today — `scheduled_for` is unset on all 11 templates — so this is the only thing that screen can usefully offer right now. When scheduling lands, this becomes the "due today" card and the ad-hoc link drops beneath it.

## "+ New workout" was the wrong verb, loudly

It was the biggest control on the page and it built a **plan**, which read as "do a workout". Demoted to a quiet outline button and renamed **+ Build a workout**. Two verbs were competing for one button; naming them apart separates them.

The logger now says **New workout** rather than "Log workout" when there's no template, because he isn't logging *against* anything.

## The loop worth having

After saving:

> **Logged — nice one.**
> Do this one again? Save it to your workouts and it's one tap next time — and printable.
> `[Save to my workouts]` `[No thanks]`

That's the on-ramp to authoring. All nine of Gabe's plans are Matthew's because nobody opens an empty builder cold — but having just finished something he liked, saving it to repeat is an obvious yes.

Declining just goes home. A failed keep says *"your session is logged either way"*, because it is — losing the plan must never imply losing the credit.

**The name defaults to "Sunday morning"** rather than being asked for. Requiring a name before he gets the tick is friction in exactly the wrong place.

## Testing

Two existing tests asserted the old navigate-immediately behaviour. **Updated to the new flow, not deleted** — deleting a test because the feature changed shape is how coverage rots.

9 new tests: the entry point and its destination, the demoted builder, no-template save, the offer, keeping it (named after the day, items in order), declining, a failed keep, and — importantly — that a template-based workout still leaves straight away.

Mutation-verified: skipping the offer fails six.

`vue-tsc --noEmit` clean. **349 tests, all passing.**

## Scope

The ad-hoc slice of SB-530 only. Tabs and "Coming up" need `scheduled_for`; "Completed" needs sessions to exist. This needs neither, and it's what breaks the zero-sessions deadlock.

Fixes SB-531

🤖 Generated with [Claude Code](https://claude.com/claude-code)