### PR TITLE
feat: the plan and the doing get their own tabs

### DIFF
--- a/backend/tests/test_workout_repository.py
+++ b/backend/tests/test_workout_repository.py
@@ -211,6 +211,71 @@ def test_list_attaches_completion_state():
     assert by_id[t2]["last_session_date"] is None
 
 
+def test_list_counts_sessions_per_template():
+    """list() reports how many times each plan was done (SB-530) — the "done 5x"
+    on the Plans tab. Two sessions on one template is 2, not 1; a plan nobody has
+    done is 0, which is what renders as "not yet"."""
+    supa = _FakeSupabase()
+    user = uuid4()
+    t1, t2 = str(uuid4()), str(uuid4())
+    supa.store["workout_templates"] = [
+        {"id": t1, "user_id": str(user), "name": "A", "type": "circuit", "rounds": 1},
+        {"id": t2, "user_id": str(user), "name": "B", "type": "circuit", "rounds": 1},
+    ]
+    supa.store["workout_sessions"] = [
+        {"template_id": t1, "session_date": "2026-07-21"},
+        {"template_id": t1, "session_date": "2026-07-23"},
+        # Same day, twice — still two times done.
+        {"template_id": t1, "session_date": "2026-07-23"},
+        # Ad-hoc: no plan behind it, so it counts towards nothing (SB-531).
+        {"template_id": None, "session_date": "2026-07-24"},
+    ]
+    by_id = {r["id"]: r for r in WorkoutTemplatesRepository(supa).list(user)}
+
+    assert by_id[t1]["session_count"] == 3
+    assert by_id[t2]["session_count"] == 0
+
+
+def test_session_list_counts_what_was_logged():
+    """list() says what each session logged without returning its sets (SB-530).
+
+    The Completed list reads "22 exercises logged"; shipping every set row for a
+    hundred sessions to get that number is not worth it. Exercises are distinct
+    movements — three sets of push-ups is one exercise."""
+    supa = _FakeSupabase()
+    user = uuid4()
+    s1 = str(uuid4())
+    supa.store["workout_sessions"] = [
+        {"id": s1, "user_id": str(user), "session_date": "2026-08-01", "type": "circuit"},
+    ]
+    supa.store["exercise_sets"] = [
+        {"session_id": s1, "exercise_key": "pushups"},
+        {"session_id": s1, "exercise_key": "pushups"},
+        {"session_id": s1, "exercise_key": "plank"},
+    ]
+    [row] = WorkoutSessionsRepository(supa).list(user)
+
+    assert row["set_count"] == 3
+    assert row["exercise_count"] == 2
+    # Still no sets on the wire — that is the point of counting server-side.
+    assert "sets" not in row
+
+
+def test_session_list_reports_zero_for_a_session_with_no_sets():
+    """A session with nothing under it reports 0, not a missing key — the row
+    still has to render (SB-530)."""
+    supa = _FakeSupabase()
+    user = uuid4()
+    supa.store["workout_sessions"] = [
+        {"id": str(uuid4()), "user_id": str(user), "session_date": "2026-08-01", "type": "circuit"},
+    ]
+    supa.store["exercise_sets"] = []
+    [row] = WorkoutSessionsRepository(supa).list(user)
+
+    assert row["set_count"] == 0
+    assert row["exercise_count"] == 0
+
+
 def test_session_create_round_trips_with_sets():
     supa = _FakeSupabase()
     repo = WorkoutSessionsRepository(supa)

--- a/frontend/src/components/WorkoutTemplateCard.vue
+++ b/frontend/src/components/WorkoutTemplateCard.vue
@@ -26,8 +26,21 @@
           >
             {{ authorLabel }}
           </span>
+          <!-- On a list of plans, how often it has been done says more than
+               whether it ever was — "done 5×" gives the library a history, and
+               "not yet" reads as a nudge rather than a failure (SB-530). The
+               coach views pass no count and keep the completion pill. -->
           <span
-            v-if="template.has_session"
+            v-if="showUsage"
+            class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold"
+            :class="usageCount > 0 ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'"
+            data-testid="usage-count"
+          >
+            <Check v-if="usageCount > 0" class="w-3 h-3" />
+            {{ usageCount > 0 ? `done ${usageCount}×` : 'not yet' }}
+          </span>
+          <span
+            v-else-if="template.has_session"
             class="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-xs font-semibold text-green-700"
           >
             <Check class="w-3 h-3" /> Completed<template v-if="template.last_session_date"> · {{ formatDayMonth(template.last_session_date) }}</template>
@@ -171,12 +184,25 @@ const props = withDefaults(
     canEdit?: boolean
     // e.g. "Added by Gabe" — the caller knows the names, the card just shows it.
     authoredBy?: string | null
+    // Show "done N×" / "not yet" instead of the completion pill (SB-530).
+    // Opt-in so the coach views are untouched: `false` is a real count.
+    showUsage?: boolean
   }>(),
-  { canLog: undefined, canPrint: undefined, canEdit: undefined, authoredBy: null },
+  {
+    canLog: undefined,
+    canPrint: undefined,
+    canEdit: undefined,
+    authoredBy: null,
+    showUsage: false,
+  },
 )
 
 /** Shown when a caller supplies it — the coach view labels athlete-authored rows. */
 const authorLabel = computed(() => props.authoredBy ?? null)
+
+/** How many sessions were logged against this plan (SB-530). */
+const showUsage = computed(() => props.showUsage)
+const usageCount = computed(() => props.template.session_count ?? 0)
 
 const mayLog = computed(() => props.canLog ?? !props.readonly)
 const mayPrint = computed(() => props.canPrint ?? !props.readonly)

--- a/frontend/src/components/__tests__/WorkoutTemplateCard.test.ts
+++ b/frontend/src/components/__tests__/WorkoutTemplateCard.test.ts
@@ -119,6 +119,41 @@ describe('WorkoutTemplateCard', () => {
     expect(w.text()).toContain('Not logged')
   })
 
+  it('swaps the completion pill for a usage count when asked (SB-530)', () => {
+    const w = mount(WorkoutTemplateCard, {
+      props: {
+        template: {
+          ...template,
+          has_session: true,
+          last_session_date: '2026-07-23',
+          session_count: 5,
+        },
+        showUsage: true,
+      },
+    })
+    // How often it was done says more on a list of plans than whether it ever
+    // was — and it replaces the pill rather than sitting beside it.
+    expect(w.get('[data-testid="usage-count"]').text()).toBe('done 5×')
+    expect(w.text()).not.toContain('Completed')
+  })
+
+  it('reads "not yet" for a plan nobody has done (SB-530)', () => {
+    const w = mount(WorkoutTemplateCard, {
+      props: { template: { ...template, session_count: 0 }, showUsage: true },
+    })
+    expect(w.get('[data-testid="usage-count"]').text()).toBe('not yet')
+    expect(w.text()).not.toContain('Not logged')
+  })
+
+  it('leaves the coach views on the completion pill (SB-530)', () => {
+    // The card is shared; opting in is what keeps AthleteDetailView unchanged.
+    const w = mount(WorkoutTemplateCard, {
+      props: { template: { ...template, has_session: false, session_count: 3 } },
+    })
+    expect(w.find('[data-testid="usage-count"]').exists()).toBe(false)
+    expect(w.text()).toContain('Not logged')
+  })
+
   it('shows the scheduled date when set (SB-335)', () => {
     const w = mount(WorkoutTemplateCard, {
       props: { template: { ...template, scheduled_for: '2026-07-28' } },

--- a/frontend/src/composables/useWorkoutSessions.ts
+++ b/frontend/src/composables/useWorkoutSessions.ts
@@ -1,4 +1,6 @@
+import { ref } from 'vue'
 import { apiCall } from '@/config/api'
+import type { WorkoutSession } from '@/types/coach'
 import type { WorkoutSessionInput } from '@/types/workout'
 
 /**
@@ -15,4 +17,38 @@ export async function createSession(
     body: JSON.stringify(payload),
     headers: { 'X-Act-As-Athlete': athleteId },
   })
+}
+
+/**
+ * An athlete's logged sessions, newest first (SB-530).
+ *
+ * `GET /workouts/sessions` has existed since SB-230 and nothing on the athlete's
+ * screen ever called it — which is why "zero sessions ever logged" was invisible
+ * rather than merely true. Same act-as header as `createSession`: the backend
+ * authorises the coach and the linked athlete identically, so this one function
+ * serves both callers.
+ *
+ * Sets are not returned by the list endpoint; `exercise_count` says what was
+ * logged instead.
+ */
+export function useWorkoutSessions() {
+  const sessions = ref<WorkoutSession[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const load = async (athleteId: string, limit = 100): Promise<void> => {
+    loading.value = true
+    error.value = null
+    try {
+      sessions.value = await apiCall<WorkoutSession[]>(`/workouts/sessions?limit=${limit}`, {
+        headers: { 'X-Act-As-Athlete': athleteId },
+      })
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load sessions'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { sessions, loading, error, load }
 }

--- a/frontend/src/types/coach.ts
+++ b/frontend/src/types/coach.ts
@@ -98,11 +98,19 @@ export interface WorkoutSession {
   id: string
   athlete_id: string | null
   session_date: string
+  // Which plan was performed, or null for an ad-hoc session with none behind
+  // it (SB-531) — what "my own" on the Completed list is read from.
+  template_id: string | null
   type: WorkoutType
   total_minutes: number | null
   how_felt: string | null
   notes: string | null
   sets: ExerciseSet[]
+  // What was logged (SB-530). The list endpoint returns no sets, so these carry
+  // the "22 exercises logged" line; a single-session read leaves them at 0 and
+  // `sets` answers instead.
+  set_count?: number
+  exercise_count?: number
 }
 
 // ---- Coach home aggregate (SB-266) ----

--- a/frontend/src/types/workout.ts
+++ b/frontend/src/types/workout.ts
@@ -164,6 +164,8 @@ export interface WorkoutTemplate {
   scheduled_for?: string | null
   // Completion (SB-334): a logged session references this template.
   has_session?: boolean
+  // How many times it has been done (SB-530) — "done 5×" / "not yet" on Plans.
+  session_count?: number
   last_session_date?: string | null  /** Circuits, in position order (SB-527). Empty for simple templates. */
   blocks?: TemplateBlock[]
 }

--- a/frontend/src/utils/__tests__/format.test.ts
+++ b/frontend/src/utils/__tests__/format.test.ts
@@ -6,6 +6,7 @@ import {
   formatDuration,
   formatDate,
   formatDayMonth,
+  formatDayPill,
   formatMonthLabel,
   formatRelativeTime,
   distanceLabel,
@@ -171,5 +172,39 @@ describe('formatDayMonth', () => {
 
   it('falls back to the raw string when unparseable', () => {
     expect(formatDayMonth('nope')).toBe('nope')
+  })
+})
+
+describe('formatDayPill (SB-530)', () => {
+  // "today" is passed in rather than read from the clock, so these assert the
+  // arithmetic and not the day the suite happens to run on.
+  const today = '2026-08-05' // a Wednesday
+
+  it('names the days either side of now in words', () => {
+    expect(formatDayPill('2026-08-05', today)).toBe('Today')
+    expect(formatDayPill('2026-08-04', today)).toBe('Yesterday')
+    expect(formatDayPill('2026-08-06', today)).toBe('Tomorrow')
+  })
+
+  it('uses the weekday inside the surrounding week', () => {
+    // An athlete reads their week in weekdays — "Sat" says more about how close
+    // a workout is than "Aug 8" does.
+    expect(formatDayPill('2026-08-08', today)).toBe('Sat')
+    expect(formatDayPill('2026-08-01', today)).toBe('Sat')
+  })
+
+  it('falls back to the date once a weekday stops being unambiguous', () => {
+    expect(formatDayPill('2026-08-12', today)).toBe('Aug 12')
+    expect(formatDayPill('2026-07-29', today)).toBe('Jul 29')
+  })
+
+  it('does not shift a day in negative-offset zones (timezone-safe)', () => {
+    // new Date('2026-08-05') is UTC midnight → Aug 4 locally in the US, which
+    // would render every "Today" as "Yesterday".
+    expect(formatDayPill('2026-08-05', '2026-08-05')).toBe('Today')
+  })
+
+  it('falls back to the raw string when unparseable', () => {
+    expect(formatDayPill('nope', today)).toBe('nope')
   })
 })

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -68,6 +68,44 @@ export const formatDayMonth = (dateOnly: string): string => {
   return `${name} ${day}`
 }
 
+/** Local midnight for a date-only 'YYYY-MM-DD' — never `new Date(str)`, which
+ *  reads it as UTC and lands on the day before west of Greenwich. */
+const localMidnight = (dateOnly: string): Date | null => {
+  const [y, m, d] = dateOnly.split('-').map(Number)
+  if (!y || !m || !d) return null
+  const date = new Date(y, m - 1, d)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+/** Today as 'YYYY-MM-DD', in the athlete's own timezone. */
+export const todayLocalISO = (): string => {
+  const now = new Date()
+  const m = String(now.getMonth() + 1).padStart(2, '0')
+  const d = String(now.getDate()).padStart(2, '0')
+  return `${now.getFullYear()}-${m}-${d}`
+}
+
+/**
+ * The short "when" a training row wears (SB-530): 'Today', 'Yesterday', a
+ * weekday inside the surrounding week, else 'Jul 20'.
+ *
+ * An athlete reads their week in weekdays — "Thu" says more about whether a
+ * workout is close than "Aug 6" does — but a weekday alone is ambiguous beyond
+ * seven days, where the date is the honest answer.
+ */
+export const formatDayPill = (dateOnly: string, today = todayLocalISO()): string => {
+  const then = localMidnight(dateOnly)
+  const now = localMidnight(today)
+  if (!then || !now) return dateOnly
+  const days = Math.round((then.getTime() - now.getTime()) / 86_400_000)
+  if (days === 0) return 'Today'
+  if (days === -1) return 'Yesterday'
+  if (days === 1) return 'Tomorrow'
+  if (days > 1 && days < 7) return WEEKDAYS[then.getDay()]
+  if (days < -1 && days > -7) return WEEKDAYS[then.getDay()]
+  return formatDayMonth(dateOnly)
+}
+
 export const formatDate = (iso: string): string => {
   const d = new Date(iso)
   if (Number.isNaN(d.getTime())) return iso

--- a/frontend/src/views/AthleteDetailView.vue
+++ b/frontend/src/views/AthleteDetailView.vue
@@ -86,7 +86,9 @@
             </p>
           </div>
           <div class="text-right text-sm text-gray-600">
-            <p>{{ s.sets.length }} {{ s.sets.length === 1 ? 'set' : 'sets' }}</p>
+            <!-- The list endpoint returns no sets, so this read "0 sets" on
+                 every session; `set_count` is what it always meant (SB-530). -->
+            <p>{{ setCount(s) }} {{ setCount(s) === 1 ? 'set' : 'sets' }}</p>
             <p v-if="s.total_minutes" class="text-xs text-gray-400">{{ s.total_minutes }} min</p>
           </div>
         </div>
@@ -105,7 +107,7 @@ import AthleteAccessPanel from '@/components/AthleteAccessPanel.vue'
 import WorkoutTemplateCard from '@/components/WorkoutTemplateCard.vue'
 import type { WorkoutTemplate } from '@/types/workout'
 import { deleteTemplate } from '@/composables/useWorkoutTemplates'
-import type { Athlete } from '@/types/coach'
+import type { Athlete, WorkoutSession } from '@/types/coach'
 
 const route = useRoute()
 const router = useRouter()
@@ -122,6 +124,9 @@ const authoredBy = (t: WorkoutTemplate): string | null => {
   if (!linked || !t.created_by || t.created_by !== linked) return null
   return `Added by ${athlete.value?.display_name ?? 'athlete'}`
 }
+/** Sets logged in a session, from the count the list carries (SB-530). */
+const setCount = (s: WorkoutSession): number => s.set_count ?? s.sets?.length ?? 0
+
 const { exercises, load: loadExercises } = useExercises()
 
 const editing = ref(false)

--- a/frontend/src/views/MyWorkoutsView.vue
+++ b/frontend/src/views/MyWorkoutsView.vue
@@ -1,37 +1,40 @@
 <template>
   <div class="container-app py-8 max-w-2xl">
-    <div class="flex items-start justify-between gap-4 mb-6">
-      <div>
-        <h1 class="text-2xl font-bold text-gray-900 mb-1">My workouts</h1>
-        <p class="text-sm text-gray-500">
-          Workouts your coach has assigned, plus any you build yourself.
-        </p>
-      </div>
-      <!-- "+ New workout" used to be the loudest control here and it built a
-           PLAN, which read as "do a workout" and was the reported confusion
-           (SB-530). Building is secondary; doing is the point. -->
-      <RouterLink
-        to="/my/workouts/build"
-        class="shrink-0 rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50"
-      >
-        + Build a workout
-      </RouterLink>
+    <div class="mb-4">
+      <h1 class="text-2xl font-bold text-gray-900 mb-1">My training</h1>
+      <p class="text-sm text-gray-500">What you're doing, and the plans behind it.</p>
     </div>
 
-    <!-- Nothing is scheduled yet — `scheduled_for` is unset on every template —
-         so logging what you just did IS the primary action (SB-531). When
-         scheduling lands this becomes the "due today" card and the ad-hoc link
-         drops beneath it. -->
-    <div class="mb-5 rounded-2xl border border-brand-200 bg-brand-50 p-5 text-center">
-      <p class="text-sm font-semibold text-brand-800">Did a workout on your own?</p>
-      <p class="mt-1 text-sm text-brand-700">Log it and get the credit — no plan needed.</p>
-      <RouterLink
-        to="/my/workouts/log"
-        class="mt-3 inline-block rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700"
-        data-testid="log-adhoc"
+    <!-- Two tabs, and the whole point of them: "workout" meant both the plan and
+         the doing, so "+ New workout" could not be read (SB-530). Splitting the
+         nouns splits the verbs — building lives only where plans live, and the
+         doing screen has exactly one primary control. -->
+    <div class="flex gap-5 border-b border-gray-200 mb-5" role="tablist">
+      <button
+        type="button"
+        role="tab"
+        class="tab"
+        :class="tab === 'training' ? 'tab-on' : ''"
+        :aria-selected="tab === 'training'"
+        data-testid="tab-training"
+        @click="tab = 'training'"
       >
-        + Log a workout
-      </RouterLink>
+        Training
+      </button>
+      <button
+        type="button"
+        role="tab"
+        class="tab"
+        :class="tab === 'plans' ? 'tab-on' : ''"
+        :aria-selected="tab === 'plans'"
+        data-testid="tab-plans"
+        @click="tab = 'plans'"
+      >
+        Plans
+        <span v-if="templates.length" class="ml-1 text-xs font-medium text-gray-400 tabular-nums">
+          {{ templates.length }}
+        </span>
+      </button>
     </div>
 
     <div v-if="loading" class="space-y-3">
@@ -49,43 +52,290 @@
       {{ error }}
     </div>
 
-    <div
-      v-else-if="templates.length === 0"
-      class="bg-white rounded-xl border border-gray-100 shadow-sm p-8 text-center text-gray-500"
-    >
-      <p>No workouts yet.</p>
+    <!-- ------------------------------------------------------------- Training -->
+    <div v-else-if="tab === 'training'" class="space-y-5">
+      <!-- Due today gets the Start card. With nothing scheduled — which is every
+           template today, `scheduled_for` being unset on all of them — logging
+           what you just did IS the primary action, not a quiet link under an
+           empty section (SB-531). -->
+      <div
+        v-if="dueToday"
+        class="rounded-2xl border border-brand-300 bg-white p-5 shadow-sm"
+        data-testid="start-card"
+      >
+        <div class="flex items-start justify-between gap-3">
+          <h2 class="text-lg font-bold text-gray-900 leading-tight">{{ dueToday.name }}</h2>
+          <span
+            class="shrink-0 rounded-full bg-amber-50 px-2 py-0.5 text-xs font-bold uppercase tracking-wide text-amber-700"
+          >
+            {{ formatDayPill(dueToday.scheduled_for!) }}
+          </span>
+        </div>
+        <p class="mt-1 text-sm text-gray-500">{{ planSummary(dueToday) }}</p>
+        <button
+          type="button"
+          class="mt-3 w-full rounded-lg bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-brand-700"
+          data-testid="start-workout"
+          @click="router.push(`/my/workouts/log/${dueToday.id}`)"
+        >
+          Start workout
+        </button>
+        <button
+          type="button"
+          class="mt-2 w-full rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-brand-700 hover:bg-gray-50"
+          @click="router.push(`/my/workouts/print/${dueToday.id}`)"
+        >
+          Print sheet
+        </button>
+      </div>
+
+      <div v-else class="rounded-2xl border border-brand-200 bg-brand-50 p-5 text-center">
+        <p class="text-sm font-semibold text-brand-800">
+          {{ nextUp ? 'Nothing scheduled today' : 'Did a workout on your own?' }}
+        </p>
+        <p v-if="nextUp" class="mt-1 text-sm text-brand-700">
+          Next up: {{ nextUp.name }}, {{ formatDayPill(nextUp.scheduled_for!) }}
+        </p>
+        <p v-else class="mt-1 text-sm text-brand-700">Log it and get the credit — no plan needed.</p>
+        <RouterLink
+          to="/my/workouts/log"
+          class="mt-3 inline-block rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700"
+          data-testid="log-adhoc"
+        >
+          + Log a workout
+        </RouterLink>
+        <p v-if="nextUp" class="mt-2 text-xs text-brand-700">
+          Did something on your own? Get credit for it.
+        </p>
+      </div>
+
+      <!-- Nothing is scheduled, so without this the plans are a tab away and the
+           athlete has to find them — the same "finished but no door" failure
+           that hid logging and athlete-authoring (SB-530). -->
+      <button
+        v-if="!dueToday && templates.length"
+        type="button"
+        class="w-full rounded-lg border border-gray-200 px-4 py-2 text-center text-sm font-medium text-brand-700 hover:bg-gray-50"
+        data-testid="go-to-plans"
+        @click="tab = 'plans'"
+      >
+        Or start one of your {{ templates.length }} plans
+      </button>
+
+      <!-- With a workout due, the ad-hoc path keeps its place as a quiet line
+           beneath the Start card rather than disappearing (SB-531). -->
+      <RouterLink
+        v-if="dueToday"
+        to="/my/workouts/log"
+        class="block rounded-lg border border-gray-200 px-4 py-2 text-center text-sm font-medium text-brand-700 hover:bg-gray-50"
+        data-testid="log-adhoc"
+      >
+        + Log something I just did
+      </RouterLink>
+
+      <!-- Renders when scheduling data exists and is simply absent when it does
+           not: `scheduled_for` is set on none of the templates, and what should
+           put a workout here (coach assigns days? a weekly pattern?) is an open
+           product decision, not something this screen should invent (SB-530). -->
+      <section v-if="laterUp.length" data-testid="coming-up">
+        <h2 class="group-label">Coming up</h2>
+        <div class="rounded-2xl border border-gray-100 bg-white shadow-sm divide-y divide-gray-100">
+          <button
+            v-for="t in laterUp"
+            :key="t.id"
+            type="button"
+            class="w-full flex items-center justify-between gap-3 px-4 py-3 text-left hover:bg-gray-50"
+            @click="router.push(`/my/workouts/log/${t.id}`)"
+          >
+            <span class="min-w-0">
+              <span class="block font-semibold text-gray-900 truncate">{{ t.name }}</span>
+              <span class="block text-xs text-gray-500">{{ planSummary(t) }}</span>
+            </span>
+            <span
+              class="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-semibold text-gray-500"
+            >
+              {{ formatDayPill(t.scheduled_for!) }}
+            </span>
+          </button>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="group-label">
+          <span>Completed ({{ completed.length }})</span>
+          <span v-if="thisWeekCount" class="text-xs font-medium normal-case tracking-normal text-gray-400">
+            {{ thisWeekCount }} this week
+          </span>
+        </h2>
+
+        <div
+          v-if="sessionsError"
+          class="rounded-xl border border-amber-100 bg-amber-50 p-4 text-sm text-amber-700"
+        >
+          Couldn't load what you've done — {{ sessionsError }}
+        </div>
+
+        <div
+          v-else-if="completed.length === 0"
+          class="rounded-2xl border border-dashed border-gray-200 p-6 text-center"
+          data-testid="completed-empty"
+        >
+          <p class="text-sm font-semibold text-gray-700">Nothing logged yet</p>
+          <p class="mt-1 text-sm text-gray-500">
+            Finish a workout and it lands here — with a count that only goes up.
+          </p>
+        </div>
+
+        <div
+          v-else
+          class="rounded-2xl border border-gray-100 bg-white shadow-sm divide-y divide-gray-100"
+        >
+          <div
+            v-for="row in visibleCompleted"
+            :key="row.id"
+            class="flex items-center justify-between gap-3 px-4 py-3"
+            data-testid="completed-row"
+          >
+            <div class="min-w-0">
+              <p class="font-semibold text-gray-900 truncate">{{ row.title }}</p>
+              <p class="text-xs text-gray-500">{{ row.detail }}</p>
+            </div>
+            <span
+              class="shrink-0 rounded-full bg-green-50 px-2 py-0.5 text-xs font-semibold text-green-700"
+            >
+              {{ row.when }}
+            </span>
+          </div>
+          <button
+            v-if="completed.length > COMPLETED_PREVIEW && !showAllCompleted"
+            type="button"
+            class="w-full px-4 py-2.5 text-sm font-medium text-brand-700 hover:bg-gray-50"
+            data-testid="see-all-completed"
+            @click="showAllCompleted = true"
+          >
+            See all {{ completed.length }}
+          </button>
+        </div>
+      </section>
     </div>
 
-    <div v-else class="space-y-4">
-      <WorkoutTemplateCard
-        v-for="t in templates"
-        :key="t.id"
-        :template="t"
-        :exercises="exercises"
-        can-log
-        can-print
-        :can-edit="isMine(t)"
-        @log="router.push(`/my/workouts/log/${t.id}`)"
-        @print="router.push(`/my/workouts/print/${t.id}`)"
-        @edit="router.push(`/my/workouts/build/${t.id}`)"
-        @delete="remove(t)"
-      />
+    <!-- ---------------------------------------------------------------- Plans -->
+    <div v-else class="space-y-5">
+      <!-- "+ Build a workout" is unambiguous here and nowhere else: everything
+           around it is already a plan (SB-530). -->
+      <RouterLink
+        to="/my/workouts/build"
+        class="block rounded-lg border border-gray-200 px-4 py-2.5 text-center text-sm font-medium text-gray-700 hover:bg-gray-50"
+        data-testid="build-workout"
+      >
+        + Build a workout
+      </RouterLink>
+
+      <section v-if="fromCoach.length" data-testid="group-from-coach">
+        <h2 class="group-label">
+          <span>{{ coachGroupLabel }}</span>
+          <span class="tabular-nums">{{ fromCoach.length }}</span>
+        </h2>
+        <div class="space-y-4">
+          <div v-for="t in fromCoach" :key="t.id">
+            <WorkoutTemplateCard
+              :template="t"
+              :exercises="exercises"
+              show-usage
+              :can-log="false"
+              can-print
+              :can-edit="false"
+              @print="router.push(`/my/workouts/print/${t.id}`)"
+            />
+            <!-- The "log this" icon was an unlabelled tooltip, which does not
+                 exist on a phone — the most frequent action on the screen was
+                 the least visible one (SB-530). -->
+            <button
+              type="button"
+              class="mt-2 w-full rounded-lg bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-brand-700"
+              data-testid="start-workout"
+              @click="router.push(`/my/workouts/log/${t.id}`)"
+            >
+              Start workout
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section v-if="mine.length" data-testid="group-mine">
+        <h2 class="group-label">
+          <span>Mine</span>
+          <span class="tabular-nums">{{ mine.length }}</span>
+        </h2>
+        <div class="space-y-4">
+          <div v-for="t in mine" :key="t.id">
+            <WorkoutTemplateCard
+              :template="t"
+              :exercises="exercises"
+              show-usage
+              :can-log="false"
+              can-print
+              can-edit
+              @print="router.push(`/my/workouts/print/${t.id}`)"
+              @edit="router.push(`/my/workouts/build/${t.id}`)"
+              @delete="remove(t)"
+            />
+            <button
+              type="button"
+              class="mt-2 w-full rounded-lg bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-brand-700"
+              data-testid="start-workout"
+              @click="router.push(`/my/workouts/log/${t.id}`)"
+            >
+              Start workout
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <!-- Athlete-authored workouts shipped in SB-486 and every plan on the
+           account is still the coach's — the capability exists and nobody found
+           it. Saying what the group is for is the cheap half of the fix. -->
+      <div
+        v-if="mine.length === 0"
+        class="rounded-2xl border border-dashed border-gray-200 p-6 text-center"
+        data-testid="mine-empty"
+      >
+        <p class="text-sm font-semibold text-gray-700">Made something up at practice?</p>
+        <p class="mt-1 text-sm text-gray-500">Build it once and it's here to reuse and print.</p>
+      </div>
+
+      <div
+        v-if="templates.length === 0"
+        class="bg-white rounded-xl border border-gray-100 shadow-sm p-8 text-center text-gray-500"
+      >
+        <p>No workouts yet.</p>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRouter, RouterLink } from 'vue-router'
 import { useMyAthlete } from '@/composables/useCoach'
 import { useMyWorkouts } from '@/composables/useMyWorkouts'
+import { useWorkoutSessions } from '@/composables/useWorkoutSessions'
 import { deleteTemplate } from '@/composables/useWorkoutTemplates'
 import WorkoutTemplateCard from '@/components/WorkoutTemplateCard.vue'
+import { formatDayPill, todayLocalISO } from '@/utils/format'
+import { prettifyKey } from '@/utils/workoutPayload'
 import type { WorkoutTemplate } from '@/types/workout'
 
 const router = useRouter()
 const { myAthlete, loadMyAthlete } = useMyAthlete()
 const { templates, exercises, loading, error, load } = useMyWorkouts()
+const {
+  sessions,
+  error: sessionsError,
+  load: loadSessions,
+} = useWorkoutSessions()
+
+const tab = ref<'training' | 'plans'>('training')
 
 /**
  * Mine to change (SB-486). A workout the coach prescribed can be logged and
@@ -98,6 +348,102 @@ const { templates, exercises, loading, error, load } = useMyWorkouts()
  */
 const isMine = (t: WorkoutTemplate): boolean =>
   !!t.created_by && t.created_by === myAthlete.value?.linked_user_id
+
+const mine = computed(() => templates.value.filter(isMine))
+const fromCoach = computed(() => templates.value.filter((t) => !isMine(t)))
+
+/**
+ * "From Matthew" when the plans agree on who wrote them, "From my coach" when
+ * they do not. Authorship is the thing worth showing — it is what makes "Mine"
+ * feel legitimate rather than odd — and `source` already carries the name.
+ */
+const coachGroupLabel = computed(() => {
+  const names = new Set(fromCoach.value.map((t) => t.source).filter(Boolean))
+  return names.size === 1 ? `From ${[...names][0]}` : 'From my coach'
+})
+
+const planSummary = (t: WorkoutTemplate): string => {
+  const n = t.items?.length ?? 0
+  return `${t.type} · ${n} ${n === 1 ? 'exercise' : 'exercises'}`
+}
+
+// ---- Coming up -----------------------------------------------------------
+// Scheduled work, soonest first. Nothing has a `scheduled_for` today, so this
+// is empty and the sections below simply do not render — deliberately, until
+// what schedules a workout is decided (SB-530).
+const upcoming = computed(() => {
+  const today = todayLocalISO()
+  return templates.value
+    .filter((t) => !!t.scheduled_for && t.scheduled_for >= today)
+    .sort((a, b) => (a.scheduled_for! < b.scheduled_for! ? -1 : 1))
+})
+const dueToday = computed(() => {
+  const today = todayLocalISO()
+  return upcoming.value.find((t) => t.scheduled_for === today) ?? null
+})
+/** Everything still ahead once the due one has been promoted to the Start card. */
+const laterUp = computed(() => upcoming.value.filter((t) => t.id !== dueToday.value?.id))
+const nextUp = computed(() => laterUp.value[0] ?? null)
+
+// ---- Completed -----------------------------------------------------------
+const COMPLETED_PREVIEW = 4
+const showAllCompleted = ref(false)
+
+const templateNames = computed<Record<string, string>>(() => {
+  const map: Record<string, string> = {}
+  for (const t of templates.value) map[t.id] = t.name
+  return map
+})
+
+interface CompletedRow {
+  id: string
+  title: string
+  detail: string
+  when: string
+}
+
+/**
+ * What has actually been done, newest first — the half of the loop that had
+ * never been shown. The count in the heading is the reward, so it stays
+ * truthful: at zero it says so rather than hiding the section.
+ *
+ * A session with no plan behind it is marked "my own" and otherwise looks
+ * exactly like the coach's — noted, not demoted.
+ */
+const completed = computed<CompletedRow[]>(() =>
+  [...sessions.value]
+    .sort((a, b) => (a.session_date < b.session_date ? 1 : -1))
+    .map((s) => {
+      const adhoc = !s.template_id
+      const name = s.template_id ? templateNames.value[s.template_id] : null
+      const count = s.exercise_count ?? s.sets?.length ?? 0
+      const logged = count > 0 ? `${count} ${count === 1 ? 'exercise' : 'exercises'}` : null
+      return {
+        id: s.id,
+        // No name is stored for an ad-hoc session, and asking for one before
+        // giving credit is friction in the wrong place — the kind of workout
+        // it was is the honest fallback.
+        title: name ?? prettifyKey(s.type),
+        detail: adhoc
+          ? [logged, 'my own'].filter(Boolean).join(' · ')
+          : logged
+            ? `${logged} logged`
+            : 'Logged',
+        when: formatDayPill(s.session_date),
+      }
+    }),
+)
+
+const visibleCompleted = computed(() =>
+  showAllCompleted.value ? completed.value : completed.value.slice(0, COMPLETED_PREVIEW),
+)
+
+const thisWeekCount = computed(() => {
+  const cutoff = new Date()
+  cutoff.setDate(cutoff.getDate() - 7)
+  const since = cutoff.toISOString().slice(0, 10)
+  return sessions.value.filter((s) => s.session_date > since).length
+})
 
 const remove = async (t: WorkoutTemplate): Promise<void> => {
   if (!myAthlete.value) return
@@ -113,6 +459,20 @@ onMounted(async () => {
     router.replace('/dashboard')
     return
   }
-  await load()
+  // Sessions are loaded alongside the plans, not on tab switch: Completed is
+  // the first thing the Training tab shows, and it is the default tab.
+  await Promise.all([load(), loadSessions(myAthlete.value.id)])
 })
 </script>
+
+<style scoped>
+.tab {
+  @apply pb-2 text-sm font-semibold text-gray-400 border-b-2 border-transparent -mb-px;
+}
+.tab-on {
+  @apply text-gray-900 border-brand-500;
+}
+.group-label {
+  @apply mb-2 flex items-baseline justify-between text-xs font-bold uppercase tracking-wider text-gray-400;
+}
+</style>

--- a/frontend/src/views/__tests__/MyWorkoutsView.test.ts
+++ b/frontend/src/views/__tests__/MyWorkoutsView.test.ts
@@ -36,10 +36,35 @@ const template = {
   created_at: '2026-07-20T00:00:00Z',
 }
 
+/** Today in the athlete's own zone — the view compares date-only strings. */
+const todayISO = (): string => {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+const daysFromNow = (n: number): string => {
+  const d = new Date()
+  d.setDate(d.getDate() + n)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+/**
+ * Serve the three calls the athlete's home makes. Everything defaults to empty,
+ * so each test names only the data it is about.
+ */
+const serve = (opts: { templates?: unknown[]; sessions?: unknown[] } = {}) => {
+  apiCallMock.mockImplementation((path: string) => {
+    if (path === '/me/workouts') return Promise.resolve(opts.templates ?? [])
+    if (path === '/workouts/exercises') return Promise.resolve([])
+    if (path.startsWith('/workouts/sessions')) return Promise.resolve(opts.sessions ?? [])
+    return Promise.reject(new Error(`unexpected: ${path}`))
+  })
+}
+
 beforeEach(() => {
   apiCallMock.mockReset()
   loadMyAthlete.mockClear()
   replaceMock.mockClear()
+  pushMock.mockClear()
   myAthlete.value = null
 })
 
@@ -54,13 +79,11 @@ describe('MyWorkoutsView (SB-332)', () => {
 
   it('renders assigned workouts for a linked athlete', async () => {
     myAthlete.value = { id: 'a1', display_name: 'Gabe' }
-    apiCallMock.mockImplementation((path: string) => {
-      if (path === '/me/workouts') return Promise.resolve([template])
-      if (path === '/workouts/exercises') return Promise.resolve([])
-      return Promise.reject(new Error(`unexpected: ${path}`))
-    })
+    serve({ templates: [template] })
     const w = mount(MyWorkoutsView)
     await flushPromises()
+    // Plans is where the plans live now (SB-530).
+    await w.get('[data-testid="tab-plans"]').trigger('click')
     expect(w.text()).toContain('Monday At-Home')
     expect(w.text()).toContain('Coached by Matthew')
     expect(replaceMock).not.toHaveBeenCalled()
@@ -68,13 +91,10 @@ describe('MyWorkoutsView (SB-332)', () => {
 
   it('shows the empty state when nothing is assigned', async () => {
     myAthlete.value = { id: 'a1', display_name: 'Gabe' }
-    apiCallMock.mockImplementation((path: string) => {
-      if (path === '/me/workouts') return Promise.resolve([])
-      if (path === '/workouts/exercises') return Promise.resolve([])
-      return Promise.reject(new Error('unexpected'))
-    })
+    serve()
     const w = mount(MyWorkoutsView)
     await flushPromises()
+    await w.get('[data-testid="tab-plans"]').trigger('click')
     expect(w.text()).toContain('No workouts yet')
   })
 })
@@ -82,7 +102,7 @@ describe('MyWorkoutsView (SB-332)', () => {
 describe('MyWorkoutsView — ad-hoc entry (SB-531)', () => {
   it('offers logging a workout with no plan behind it', async () => {
     myAthlete.value = { id: 'ath1', linked_user_id: 'u1' }
-    apiCallMock.mockResolvedValue([])
+    serve()
     const w = mount(MyWorkoutsView)
     await flushPromises()
     const link = w.get('[data-testid="log-adhoc"]')
@@ -92,10 +112,293 @@ describe('MyWorkoutsView — ad-hoc entry (SB-531)', () => {
 
   it('demotes building a plan — it was the loudest control and the wrong verb', async () => {
     myAthlete.value = { id: 'ath1', linked_user_id: 'u1' }
-    apiCallMock.mockResolvedValue([])
+    serve()
     const w = mount(MyWorkoutsView)
     await flushPromises()
+    await w.get('[data-testid="tab-plans"]').trigger('click')
     expect(w.text()).toContain('+ Build a workout')
     expect(w.text()).not.toContain('+ New workout')
+  })
+})
+
+describe('MyWorkoutsView — Training | Plans tabs (SB-530)', () => {
+  beforeEach(() => {
+    myAthlete.value = { id: 'ath1', linked_user_id: 'u1' }
+  })
+
+  it('opens on Training, where building a plan is not offered at all', async () => {
+    serve({ templates: [template] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    // The reported confusion was two verbs competing for one button; the split
+    // is only worth anything if "+ Build" is absent from the doing screen.
+    expect(w.text()).not.toContain('+ Build a workout')
+    expect(w.get('[data-testid="tab-training"]').attributes('aria-selected')).toBe('true')
+  })
+
+  it('keeps building on Plans and nowhere else', async () => {
+    serve({ templates: [template] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    expect(w.find('[data-testid="build-workout"]').exists()).toBe(false)
+    await w.get('[data-testid="tab-plans"]').trigger('click')
+    expect(w.get('[data-testid="build-workout"]').attributes('href')).toBe('/my/workouts/build')
+  })
+
+  it('points at the plans from Training while nothing is scheduled', async () => {
+    // Otherwise the plans are a tab away with nothing saying so, which is the
+    // same "built but no door" failure the split is meant to end.
+    serve({ templates: [template] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    const jump = w.get('[data-testid="go-to-plans"]')
+    expect(jump.text()).toContain('Or start one of your 1 plans')
+    await jump.trigger('click')
+    expect(w.get('[data-testid="tab-plans"]').attributes('aria-selected')).toBe('true')
+    expect(w.find('[data-testid="build-workout"]').exists()).toBe(true)
+  })
+
+  it('does not send you to the plans when one is already due', async () => {
+    serve({ templates: [{ ...template, scheduled_for: todayISO() }] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    expect(w.find('[data-testid="go-to-plans"]').exists()).toBe(false)
+  })
+
+  it('loads the athlete\'s own sessions with the act-as header', async () => {
+    serve()
+    mount(MyWorkoutsView)
+    await flushPromises()
+    const call = apiCallMock.mock.calls.find((c) => String(c[0]).startsWith('/workouts/sessions'))
+    expect(call).toBeDefined()
+    expect((call![1] as { headers: Record<string, string> }).headers).toEqual({
+      'X-Act-As-Athlete': 'ath1',
+    })
+  })
+})
+
+describe('MyWorkoutsView — Completed (SB-530)', () => {
+  beforeEach(() => {
+    myAthlete.value = { id: 'ath1', linked_user_id: 'u1' }
+  })
+
+  it('counts what has been done and says what each session logged', async () => {
+    serve({
+      templates: [template],
+      sessions: [
+        {
+          id: 's1',
+          template_id: 't1',
+          session_date: daysFromNow(-1),
+          type: 'circuit',
+          sets: [],
+          exercise_count: 22,
+        },
+      ],
+    })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    // The count is the reward, and the row has to say what it was.
+    expect(w.text()).toContain('Completed (1)')
+    expect(w.text()).toContain('Monday At-Home')
+    expect(w.text()).toContain('22 exercises logged')
+  })
+
+  it('marks an ad-hoc session "my own" without demoting it', async () => {
+    serve({
+      templates: [template],
+      sessions: [
+        {
+          id: 's1',
+          template_id: null,
+          session_date: daysFromNow(-1),
+          type: 'circuit',
+          sets: [],
+          exercise_count: 4,
+        },
+        {
+          id: 's2',
+          template_id: 't1',
+          session_date: daysFromNow(-2),
+          type: 'circuit',
+          sets: [],
+          exercise_count: 12,
+        },
+      ],
+    })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    const [adhoc, coached] = w.findAll('[data-testid="completed-row"]')
+    expect(adhoc.text()).toContain('4 exercises · my own')
+    expect(coached.text()).toContain('12 exercises logged')
+    // Noted, not demoted: it gets the same row treatment as the coach's.
+    expect(adhoc.classes()).toEqual(coached.classes())
+  })
+
+  it('says so honestly when nothing has been logged', async () => {
+    serve({ templates: [template] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    expect(w.text()).toContain('Completed (0)')
+    expect(w.find('[data-testid="completed-empty"]').exists()).toBe(true)
+  })
+
+  it('previews four and offers the rest behind "See all"', async () => {
+    serve({
+      sessions: Array.from({ length: 6 }, (_, i) => ({
+        id: `s${i}`,
+        template_id: null,
+        session_date: daysFromNow(-i - 1),
+        type: 'circuit',
+        sets: [],
+        exercise_count: 3,
+      })),
+    })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    expect(w.findAll('[data-testid="completed-row"]')).toHaveLength(4)
+    await w.get('[data-testid="see-all-completed"]').trigger('click')
+    expect(w.findAll('[data-testid="completed-row"]')).toHaveLength(6)
+  })
+})
+
+describe('MyWorkoutsView — Coming up (SB-530)', () => {
+  beforeEach(() => {
+    myAthlete.value = { id: 'ath1', linked_user_id: 'u1' }
+  })
+
+  it('is absent entirely while nothing carries a scheduled date', async () => {
+    // `scheduled_for` is unset on every template and what should schedule one is
+    // an open product decision — so the section renders only when the data
+    // exists, and the screen is honest in the meantime.
+    serve({ templates: [template] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    expect(w.find('[data-testid="coming-up"]').exists()).toBe(false)
+    expect(w.find('[data-testid="start-card"]').exists()).toBe(false)
+  })
+
+  it('promotes the workout due today to a labelled Start card', async () => {
+    serve({
+      templates: [
+        { ...template, scheduled_for: todayISO() },
+        { ...template, id: 't2', name: 'Track Thursday', scheduled_for: daysFromNow(3) },
+      ],
+    })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    const card = w.get('[data-testid="start-card"]')
+    expect(card.text()).toContain('Monday At-Home')
+    expect(card.text()).toContain('Today')
+    await card.get('[data-testid="start-workout"]').trigger('click')
+    expect(pushMock).toHaveBeenCalledWith('/my/workouts/log/t1')
+    // The one still ahead stays in Coming up rather than doubling up.
+    const coming = w.get('[data-testid="coming-up"]')
+    expect(coming.text()).toContain('Track Thursday')
+    expect(coming.text()).not.toContain('Monday At-Home')
+  })
+
+  it('drops the ad-hoc entry to a quiet line when something is due', async () => {
+    serve({ templates: [{ ...template, scheduled_for: todayISO() }] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    const adhoc = w.get('[data-testid="log-adhoc"]')
+    expect(adhoc.text()).toContain('+ Log something I just did')
+    expect(adhoc.attributes('href')).toBe('/my/workouts/log')
+  })
+
+  it('names what is next when nothing is due today', async () => {
+    serve({ templates: [{ ...template, name: 'Track Thursday', scheduled_for: daysFromNow(3) }] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    expect(w.text()).toContain('Nothing scheduled today')
+    expect(w.text()).toContain('Next up: Track Thursday')
+    // Logging is still the primary control when nothing is due.
+    expect(w.get('[data-testid="log-adhoc"]').text()).toContain('+ Log a workout')
+  })
+
+  it('ignores a date that has already passed', async () => {
+    serve({ templates: [{ ...template, scheduled_for: daysFromNow(-2) }] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    expect(w.find('[data-testid="start-card"]').exists()).toBe(false)
+    expect(w.find('[data-testid="coming-up"]').exists()).toBe(false)
+  })
+})
+
+describe('MyWorkoutsView — Plans grouping (SB-530)', () => {
+  beforeEach(() => {
+    myAthlete.value = { id: 'ath1', linked_user_id: 'u1' }
+  })
+
+  it('separates the coach\'s plans from the athlete\'s own', async () => {
+    serve({
+      templates: [
+        { ...template, session_count: 5 },
+        {
+          ...template,
+          id: 't2',
+          name: 'Saturday garage circuit',
+          created_by: 'u1',
+          source: null,
+          session_count: 0,
+        },
+      ],
+    })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    await w.get('[data-testid="tab-plans"]').trigger('click')
+
+    const fromCoach = w.get('[data-testid="group-from-coach"]')
+    expect(fromCoach.text()).toContain('From Matthew')
+    expect(fromCoach.text()).toContain('Monday At-Home')
+    expect(fromCoach.text()).not.toContain('Saturday garage circuit')
+
+    const mine = w.get('[data-testid="group-mine"]')
+    expect(mine.text()).toContain('Saturday garage circuit')
+    // Athlete-authored workouts shipped and nobody found them (SB-486); the
+    // empty prompt only belongs on an account that has none.
+    expect(w.find('[data-testid="mine-empty"]').exists()).toBe(false)
+  })
+
+  it('shows how often each plan has been done', async () => {
+    serve({ templates: [{ ...template, session_count: 5 }, { ...template, id: 't2', name: 'Speed Endurance', session_count: 0 }] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    await w.get('[data-testid="tab-plans"]').trigger('click')
+    const counts = w.findAll('[data-testid="usage-count"]').map((n) => n.text())
+    expect(counts).toContain('done 5×')
+    expect(counts).toContain('not yet')
+  })
+
+  it('offers a labelled Start workout on every plan, not an icon tooltip', async () => {
+    serve({ templates: [template] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    await w.get('[data-testid="tab-plans"]').trigger('click')
+    // The old control was an unlabelled icon with a `title`, which does not
+    // exist on touch — the most frequent action was the least visible one.
+    expect(w.find('[data-testid="log-this"]').exists()).toBe(false)
+    await w.get('[data-testid="start-workout"]').trigger('click')
+    expect(pushMock).toHaveBeenCalledWith('/my/workouts/log/t1')
+  })
+
+  it('prompts an athlete who has authored nothing to build something', async () => {
+    serve({ templates: [template] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    await w.get('[data-testid="tab-plans"]').trigger('click')
+    expect(w.find('[data-testid="group-mine"]').exists()).toBe(false)
+    expect(w.get('[data-testid="mine-empty"]').text()).toContain('Made something up at practice?')
+  })
+
+  it('falls back to a generic coach label when the plans disagree on authorship', async () => {
+    serve({
+      templates: [template, { ...template, id: 't2', name: 'Bike day', source: 'Coach Dana' }],
+    })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    await w.get('[data-testid="tab-plans"]').trigger('click')
+    expect(w.get('[data-testid="group-from-coach"]').text()).toContain('From my coach')
   })
 })

--- a/src/shared/models/workout.py
+++ b/src/shared/models/workout.py
@@ -305,6 +305,11 @@ class WorkoutTemplate(BaseModel):
     # when a logged session references it. False/None on single-template reads.
     has_session: bool = False
     last_session_date: date | None = None
+    # How many sessions reference this template (SB-530) — the "done 5x" the
+    # Plans tab shows, which turns a library into something with history rather
+    # than a filing cabinet. Same batched query as has_session, so it costs
+    # nothing extra. 0 on single-template reads, where that join is not run.
+    session_count: int = 0
 
 
 # --------------------------------------------------------------------------- #
@@ -382,3 +387,9 @@ class WorkoutSession(BaseModel):
     notes: str | None = None
     sets: list[ExerciseSet] = Field(default_factory=list)
     created_at: datetime | None = None
+    # What was logged, populated by the list query (SB-530), which returns no
+    # sets: a session row has to be able to say "22 exercises logged" without
+    # the caller fetching each session in turn. Both are 0 on a single-session
+    # read, where `sets` is present and carries the same answer.
+    set_count: int = 0
+    exercise_count: int = 0

--- a/src/shared/supabase_ops/workout_repository.py
+++ b/src/shared/supabase_ops/workout_repository.py
@@ -309,14 +309,21 @@ class WorkoutTemplatesRepository:
             .execute()
         )
         last_by_template: dict[str, str] = {}
+        count_by_template: dict[str, int] = {}
         for s in cast(list[dict[str, Any]], sessions.data):
             tid, d = s.get("template_id"), s.get("session_date")
-            if tid and d and (tid not in last_by_template or d > last_by_template[tid]):
+            if not tid:
+                continue
+            # Counted per session, not per distinct date: doing the same plan
+            # twice in a day is twice done (SB-530).
+            count_by_template[tid] = count_by_template.get(tid, 0) + 1
+            if d and (tid not in last_by_template or d > last_by_template[tid]):
                 last_by_template[tid] = d
         for t in templates:
             last = last_by_template.get(t["id"])
             t["has_session"] = last is not None
             t["last_session_date"] = last
+            t["session_count"] = count_by_template.get(t["id"], 0)
         return templates
 
     def list_for_athletes(self, athlete_ids: Sequence[UUID]) -> list[dict[str, Any]]:
@@ -407,7 +414,34 @@ class WorkoutSessionsRepository:
         if date_to is not None:
             query = query.lte("session_date", date_to.isoformat())
         result = query.order("session_date", desc=True).limit(limit).execute()
-        return cast(list[dict[str, Any]], result.data)
+        sessions = cast(list[dict[str, Any]], result.data)
+        if not sessions:
+            return sessions
+
+        # Attach what was logged (SB-530) without dragging every set across the
+        # wire: "22 exercises logged" is the whole point of the Completed list,
+        # but a hundred sessions' worth of full set rows is not. One batched
+        # query over two columns answers it.
+        ids = [s["id"] for s in sessions]
+        rows = (
+            self.supabase.table("exercise_sets")
+            .select("session_id, exercise_key")
+            .in_("session_id", ids)
+            .execute()
+        )
+        sets_by_session: dict[str, int] = {}
+        exercises_by_session: dict[str, set[str]] = {}
+        for r in cast(list[dict[str, Any]], rows.data):
+            sid = str(r.get("session_id"))
+            sets_by_session[sid] = sets_by_session.get(sid, 0) + 1
+            exercises_by_session.setdefault(sid, set()).add(r.get("exercise_key"))
+        for s in sessions:
+            sid = str(s["id"])
+            s["set_count"] = sets_by_session.get(sid, 0)
+            # Distinct movements, not sets: three rounds of push-ups is one
+            # exercise, and that is the number the prescription is written in.
+            s["exercise_count"] = len(exercises_by_session.get(sid, ()))
+        return sessions
 
     def list_for_athletes(
         self, athlete_ids: Sequence[UUID], limit: int = 10


### PR DESCRIPTION
## Summary

Implements the agreed athlete-home design (SB-530). One word — "workout" — meant both the plan and the doing, so `+ New workout` could not be read. Two tabs split the nouns, which splits the verbs.

- **Training | Plans tabs.** Training is the doing screen and its only primary control is Start workout; `+ Build a workout` exists only on Plans, surrounded by plans.
- **Start workout is labelled and full width.** It was an unlabelled icon with a `title` tooltip — which does not exist on touch — so the most frequent action was the least visible one.
- **Completed (N)** on Training, the count in the label because the count is the reward. Each row says what was logged ("22 exercises logged"); ad-hoc sessions are marked "my own" and get the identical row treatment — noted, not demoted. Four shown, the rest behind "See all N".
- **Plans grouped into From Matthew / Mine**, each plan wearing "done 5×" or "not yet". The coach label falls back to "From my coach" when the plans disagree on authorship.
- **Coming up renders when the data exists and is absent when it does not.** `scheduled_for` is set on 0 of 11 templates and what schedules a workout is an open product decision — no rule is invented here. While nothing is scheduled, Training points at the plans rather than leaving them a tab away undiscovered.
- SB-531's ad-hoc entry keeps its place: prominent when nothing is due, a quiet line under the Start card when something is.

Backend, both on batched queries that already existed:

- `WorkoutTemplate.session_count` joins the query that already computes `has_session` — that is the "done 5×".
- `WorkoutSession.set_count` / `exercise_count` on the list endpoint, so Completed can say what was logged without shipping every set row. `GET /workouts/sessions` has existed since SB-230 and nothing on the athlete's screen ever called it; `useWorkoutSessions` now has a list function.
- Incidental fix: AthleteDetailView read `sets.length` on a list response that carries no sets, so it reported "0 sets" for every session.

## Test plan

- [x] `cd frontend && npm run type-check && npx vitest run` — 376 passing
- [x] `uv run --project backend ruff check backend/ && python -m pytest backend/tests/ -q` — 365 passing
- [x] `uv run ruff check src/ tests/ && uv run pytest tests/ -q` — 186 passing, coverage 60.7%
- [x] `npm run build`
- [x] Every new test mutation-tested: past-date filter, due-today match, "my own" mark, `isMine` grouping, usage pill text, usage opt-in, weekday window, per-template count, distinct-exercise count — each mutation fails the test that guards it
- [ ] On the athlete account: Training opens first and offers no `+ Build`; Plans shows From Matthew / Mine with usage counts; Start workout opens the logger for that plan
- [ ] Coach views (AthleteDetailView, CoachView) still show the Completed / Not logged pill, and session rows now show a real set count

Fixes SB-530

🤖 Generated with [Claude Code](https://claude.com/claude-code)