### PR TITLE
feat: a plan put on a day, by someone

### DIFF
--- a/backend/routes/workouts.py
+++ b/backend/routes/workouts.py
@@ -20,6 +20,8 @@ from src.shared.models.workout import (
     Exercise,
     ExerciseCreate,
     ExerciseUpdate,
+    WorkoutSchedule,
+    WorkoutScheduleCreate,
     WorkoutSession,
     WorkoutSessionCreate,
     WorkoutTemplate,
@@ -28,6 +30,7 @@ from src.shared.models.workout import (
 from src.shared.supabase_client import get_supabase_client
 from src.shared.supabase_ops import (
     ExercisesRepository,
+    WorkoutScheduleRepository,
     WorkoutSessionsRepository,
     WorkoutTemplatesRepository,
 )
@@ -290,6 +293,76 @@ async def delete_template(
 
     if not repo.delete(user_id, template_id, athlete_id=athlete_id):
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Template not found")
+    await invalidate_user(user_id)
+
+
+# ---------------------------------------------------------------- schedule
+
+
+@router.post("/schedule", response_model=WorkoutSchedule, status_code=status.HTTP_201_CREATED)
+async def create_schedule(
+    body: WorkoutScheduleCreate,
+    user_id: UUID = Depends(authenticate_request),
+    athlete_id: UUID | None = Depends(acting_athlete),
+) -> WorkoutSchedule:
+    """Put a plan on a day (SB-534).
+
+    Either side may: the coach assigning Thursday, or the athlete planning their
+    own week. Both are authorised identically — ``acting_athlete`` already
+    accepts the coach and the linked athlete — and the row records which of them
+    it was, because the screen has to say.
+    """
+    supabase = get_supabase_client()
+    template = WorkoutTemplatesRepository(supabase).get(
+        user_id, body.template_id, athlete_id=athlete_id
+    )
+    # Scheduling something you cannot see would leak its existence, and a
+    # dangling schedule row renders as a blank card.
+    if template is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Template not found")
+
+    row = WorkoutScheduleRepository(supabase).create(
+        user_id, body.model_dump(mode="json", exclude_none=True), athlete_id=athlete_id
+    )
+    await invalidate_user(user_id)
+    return WorkoutSchedule(**row)
+
+
+@router.get("/schedule", response_model=list[WorkoutSchedule])
+def list_schedule(
+    user_id: UUID = Depends(authenticate_request),
+    athlete_id: UUID | None = Depends(acting_athlete),
+    date_from: date | None = Query(default=None),
+    date_to: date | None = Query(default=None),
+) -> list[WorkoutSchedule]:
+    """Planned occasions in date order. Callers filter the window they want —
+    Coming up asks from today, a calendar would ask for a month."""
+    rows = WorkoutScheduleRepository(get_supabase_client()).list(
+        user_id, date_from=date_from, date_to=date_to, athlete_id=athlete_id
+    )
+    return [WorkoutSchedule(**r) for r in rows]
+
+
+@router.delete("/schedule/{schedule_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_schedule(
+    schedule_id: UUID,
+    user_id: UUID = Depends(authenticate_request),
+    athlete_id: UUID | None = Depends(acting_athlete),
+) -> None:
+    """Unschedule an occasion.
+
+    The same split as everything else athlete-scoped (SB-486): a coach may
+    remove anything on their athlete's calendar; the athlete may remove what
+    they put there themselves, and not the workout their coach expects of them.
+    """
+    repo = WorkoutScheduleRepository(get_supabase_client())
+    existing = repo.get(user_id, schedule_id, athlete_id=athlete_id)
+    if existing is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Scheduled workout not found")
+    _require_may_modify(user_id, athlete_id, existing, "scheduled workout")
+
+    if not repo.delete(user_id, schedule_id, athlete_id=athlete_id):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Scheduled workout not found")
     await invalidate_user(user_id)
 
 

--- a/backend/tests/test_workout_repository.py
+++ b/backend/tests/test_workout_repository.py
@@ -7,6 +7,7 @@ from typing import Any
 from uuid import UUID, uuid4
 
 from src.shared.supabase_ops.workout_repository import (
+    WorkoutScheduleRepository,
     WorkoutSessionsRepository,
     WorkoutTemplatesRepository,
 )
@@ -274,6 +275,45 @@ def test_session_list_reports_zero_for_a_session_with_no_sets():
 
     assert row["set_count"] == 0
     assert row["exercise_count"] == 0
+
+
+def test_schedule_row_always_names_its_author():
+    """Who scheduled it is the reason this is a table and not a date column, so
+    `created_by` is written on a self-owned row too (SB-534) — `_owner_fields`
+    only fills it for athlete-scoped ones."""
+    supa = _FakeSupabase()
+    user = uuid4()
+    row = WorkoutScheduleRepository(supa).create(
+        user, {"template_id": str(uuid4()), "scheduled_for": "2026-08-06"}
+    )
+    assert row["created_by"] == str(user)
+    assert row["user_id"] == str(user)
+
+
+def test_schedule_records_the_acting_coach_not_the_athlete():
+    """A coach scheduling for their athlete: the row is the athlete's, the
+    authorship is the coach's — which is what "From Matthew" reads from."""
+    supa = _FakeSupabase()
+    coach, athlete = uuid4(), uuid4()
+    row = WorkoutScheduleRepository(supa).create(
+        coach, {"template_id": str(uuid4()), "scheduled_for": "2026-08-06"}, athlete_id=athlete
+    )
+    assert row["created_by"] == str(coach)
+    assert row["athlete_id"] == str(athlete)
+
+
+def test_the_same_plan_can_sit_on_two_days_at_once():
+    """The thing `workout_templates.scheduled_for` could not do: a plan is
+    reused, an occasion happens once (SB-534)."""
+    supa = _FakeSupabase()
+    user = uuid4()
+    template = str(uuid4())
+    repo = WorkoutScheduleRepository(supa)
+    repo.create(user, {"template_id": template, "scheduled_for": "2026-08-06"})
+    repo.create(user, {"template_id": template, "scheduled_for": "2026-08-13"})
+
+    dates = [r["scheduled_for"] for r in repo.list(user)]
+    assert dates == ["2026-08-06", "2026-08-13"]
 
 
 def test_session_create_round_trips_with_sets():

--- a/backend/tests/test_workout_schedule.py
+++ b/backend/tests/test_workout_schedule.py
@@ -1,0 +1,164 @@
+"""SB-534: putting a plan on a day, and who is allowed to.
+
+Either side may schedule — Matthew assigning Thursday, or Gabe planning his own
+week — and every row remembers which of them it was, because the athlete's
+screen has to say so without being told.
+
+Removal follows the same split as every other athlete-scoped row (SB-486): a
+coach may clear anything on their athlete's calendar; the athlete may clear what
+they put there themselves, and not the workout their coach expects of them.
+
+The athlete path is covered explicitly here. Three bugs shipped in one week on
+routes only an athlete takes, every one of them fixtured as the coach.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+from typing import Any
+from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+from src.shared.models.workout import WorkoutScheduleCreate
+
+COACH = uuid4()
+ATHLETE_USER = uuid4()
+ATHLETE_ID = uuid4()
+TEMPLATE_ID = uuid4()
+
+
+async def _noop(*a: Any, **k: Any) -> None:
+    return None
+
+
+def _row(created_by: UUID) -> dict[str, Any]:
+    return {
+        "id": str(uuid4()),
+        "user_id": str(COACH),
+        "athlete_id": str(ATHLETE_ID),
+        "created_by": str(created_by),
+        "template_id": str(TEMPLATE_ID),
+        "scheduled_for": "2026-08-06",
+        "notes": None,
+    }
+
+
+def _create(caller: UUID, *, template_found: bool = True) -> Any:
+    """Call create_schedule with the repositories stubbed."""
+    sched = MagicMock()
+    sched.create.side_effect = lambda user_id, payload, athlete_id=None: {
+        **_row(user_id),
+        **payload,
+    }
+    templates = MagicMock()
+    templates.get.return_value = {"id": str(TEMPLATE_ID)} if template_found else None
+
+    with (
+        patch("backend.routes.workouts.get_supabase_client"),
+        patch("backend.routes.workouts.WorkoutScheduleRepository", return_value=sched),
+        patch("backend.routes.workouts.WorkoutTemplatesRepository", return_value=templates),
+        patch("backend.routes.workouts.invalidate_user", new=_noop),
+    ):
+        from backend.routes.workouts import create_schedule
+
+        return (
+            asyncio.run(
+                create_schedule(
+                    body=WorkoutScheduleCreate(
+                        template_id=TEMPLATE_ID, scheduled_for=date(2026, 8, 6)
+                    ),
+                    user_id=caller,
+                    athlete_id=ATHLETE_ID,
+                )
+            ),
+            sched,
+        )
+
+
+def _delete(caller: UUID, existing: dict[str, Any], *, is_coach: bool) -> Any:
+    repo = MagicMock()
+    repo.get.return_value = existing
+    repo.delete.return_value = True
+
+    with (
+        patch("backend.routes.workouts.get_supabase_client"),
+        patch("backend.routes.workouts.WorkoutScheduleRepository", return_value=repo),
+        patch("backend.routes.workouts.coaches_athlete", return_value=is_coach),
+        patch("backend.routes.workouts.invalidate_user", new=_noop),
+    ):
+        from backend.routes.workouts import delete_schedule
+
+        asyncio.run(
+            delete_schedule(schedule_id=UUID(existing["id"]), user_id=caller, athlete_id=ATHLETE_ID)
+        )
+        return repo
+
+
+def test_a_coach_can_schedule_a_workout_for_their_athlete() -> None:
+    result, repo = _create(COACH)
+    assert result.scheduled_for == date(2026, 8, 6)
+    repo.create.assert_called_once()
+
+
+def test_an_athlete_can_schedule_their_own_week() -> None:
+    """The decision this ticket records: scheduling is not a coach-only verb."""
+    result, _ = _create(ATHLETE_USER)
+    assert result.scheduled_for == date(2026, 8, 6)
+
+
+def test_the_row_records_who_scheduled_it() -> None:
+    """The whole reason this is a table and not a date column on the template."""
+    by_coach, _ = _create(COACH)
+    by_athlete, _ = _create(ATHLETE_USER)
+
+    assert by_coach.created_by == COACH
+    assert by_athlete.created_by == ATHLETE_USER
+
+
+def test_scheduling_a_template_you_cannot_see_is_a_404() -> None:
+    """Scheduling an invisible template would leak that it exists, and leave a
+    row that renders as a blank card."""
+    with pytest.raises(HTTPException) as exc:
+        _create(COACH, template_found=False)
+
+    assert exc.value.status_code == 404
+
+
+def test_a_coach_may_unschedule_anything_of_their_athletes() -> None:
+    repo = _delete(COACH, _row(COACH), is_coach=True)
+    repo.delete.assert_called_once()
+
+
+def test_an_athlete_may_unschedule_what_they_scheduled() -> None:
+    repo = _delete(ATHLETE_USER, _row(ATHLETE_USER), is_coach=False)
+    repo.delete.assert_called_once()
+
+
+def test_an_athlete_may_not_unschedule_what_their_coach_assigned() -> None:
+    """Matthew's Thursday is not Gabe's to delete — hiding the button is not
+    enforcement."""
+    with pytest.raises(HTTPException) as exc:
+        _delete(ATHLETE_USER, _row(COACH), is_coach=False)
+
+    assert exc.value.status_code == 403
+
+
+def test_unscheduling_something_that_is_not_there_is_a_404() -> None:
+    repo = MagicMock()
+    repo.get.return_value = None
+
+    with (
+        patch("backend.routes.workouts.get_supabase_client"),
+        patch("backend.routes.workouts.WorkoutScheduleRepository", return_value=repo),
+        patch("backend.routes.workouts.invalidate_user", new=_noop),
+    ):
+        from backend.routes.workouts import delete_schedule
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(delete_schedule(schedule_id=uuid4(), user_id=COACH, athlete_id=ATHLETE_ID))
+
+    assert exc.value.status_code == 404
+    repo.delete.assert_not_called()

--- a/frontend/src/components/ScheduleWorkout.vue
+++ b/frontend/src/components/ScheduleWorkout.vue
@@ -1,0 +1,95 @@
+<template>
+  <div>
+    <button
+      v-if="!open"
+      type="button"
+      class="w-full rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+      data-testid="schedule-open"
+      @click="open = true"
+    >
+      Schedule for a day
+    </button>
+
+    <div v-else class="rounded-lg border border-gray-200 p-3" data-testid="schedule-form">
+      <label class="block text-xs font-semibold uppercase tracking-wide text-gray-400 mb-1">
+        Put this on a day
+      </label>
+      <input
+        v-model="day"
+        type="date"
+        :min="today"
+        class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
+        data-testid="schedule-date"
+      />
+      <p v-if="error" class="mt-2 text-sm text-red-600" data-testid="schedule-error">{{ error }}</p>
+      <div class="mt-2 flex gap-2">
+        <button
+          type="button"
+          class="flex-1 rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700 disabled:opacity-50"
+          :disabled="!day || saving"
+          data-testid="schedule-save"
+          @click="save"
+        >
+          {{ saving ? 'Scheduling…' : 'Schedule' }}
+        </button>
+        <button
+          type="button"
+          class="rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50"
+          data-testid="schedule-cancel"
+          @click="close"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { createSchedule } from '@/composables/useWorkoutSchedule'
+import { todayLocalISO } from '@/utils/format'
+
+/**
+ * Put a plan on a day (SB-534).
+ *
+ * One component for both surfaces on purpose: the coach schedules from the
+ * athlete's detail view and the athlete from their own Plans tab, and the API
+ * authorises them identically. Two copies of this would drift, which is exactly
+ * how the athlete-side bugs of the last week happened.
+ */
+const props = defineProps<{ templateId: string; athleteId: string }>()
+const emit = defineEmits<{ (e: 'scheduled'): void }>()
+
+const open = ref(false)
+const day = ref('')
+const saving = ref(false)
+const error = ref<string | null>(null)
+const today = todayLocalISO()
+
+const close = (): void => {
+  open.value = false
+  day.value = ''
+  error.value = null
+}
+
+const save = async (): Promise<void> => {
+  if (!day.value) return
+  saving.value = true
+  error.value = null
+  try {
+    await createSchedule({ template_id: props.templateId, scheduled_for: day.value }, props.athleteId)
+    close()
+    emit('scheduled')
+  } catch (e) {
+    // The unique index rejects the same plan on the same day twice; say so
+    // rather than showing a raw constraint error.
+    const message = e instanceof Error ? e.message : 'Could not schedule it'
+    error.value = /duplicate|unique/i.test(message)
+      ? "That's already on the calendar for this day."
+      : message
+  } finally {
+    saving.value = false
+  }
+}
+</script>

--- a/frontend/src/components/__tests__/ScheduleWorkout.test.ts
+++ b/frontend/src/components/__tests__/ScheduleWorkout.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+const apiCallMock = vi.fn()
+vi.mock('@/config/api', () => ({ apiCall: (...a: unknown[]) => apiCallMock(...a) }))
+
+import ScheduleWorkout from '../ScheduleWorkout.vue'
+
+const todayISO = (): string => {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+const mountIt = () =>
+  mount(ScheduleWorkout, { props: { templateId: 't1', athleteId: 'ath1' } })
+
+// No shared mock reset: clearing a vi.fn between tests drops Vitest's handle on
+// a promise it recorded, and the rejection below is then reported as unhandled
+// even though the component catches it. Each test sets its own implementation.
+describe('ScheduleWorkout (SB-534)', () => {
+  it('will not schedule into the past', async () => {
+    const w = mountIt()
+    await w.get('[data-testid="schedule-open"]').trigger('click')
+    expect(w.get('[data-testid="schedule-date"]').attributes('min')).toBe(todayISO())
+  })
+
+  it('cannot be saved until a day is picked', async () => {
+    const w = mountIt()
+    await w.get('[data-testid="schedule-open"]').trigger('click')
+    expect(w.get('[data-testid="schedule-save"]').attributes('disabled')).toBeDefined()
+  })
+
+  it('posts the occasion and closes', async () => {
+    apiCallMock.mockResolvedValue({ id: 'sch1' })
+    const w = mountIt()
+    await w.get('[data-testid="schedule-open"]').trigger('click')
+    await w.get('[data-testid="schedule-date"]').setValue('2026-08-06')
+    await w.get('[data-testid="schedule-save"]').trigger('click')
+    await flushPromises()
+
+    expect(apiCallMock).toHaveBeenCalledWith('/workouts/schedule', {
+      method: 'POST',
+      body: JSON.stringify({ template_id: 't1', scheduled_for: '2026-08-06' }),
+      headers: { 'X-Act-As-Athlete': 'ath1' },
+    })
+    expect(w.emitted('scheduled')).toHaveLength(1)
+    expect(w.find('[data-testid="schedule-form"]').exists()).toBe(false)
+  })
+
+  it('explains a day that already has this plan on it', async () => {
+    // The unique index is the guard; a raw constraint string is not an answer.
+    apiCallMock.mockImplementation(async () => {
+      throw new Error('duplicate key value violates unique constraint')
+    })
+    const w = mountIt()
+    await w.get('[data-testid="schedule-open"]').trigger('click')
+    await w.get('[data-testid="schedule-date"]').setValue('2026-08-06')
+    await w.get('[data-testid="schedule-save"]').trigger('click')
+    await flushPromises()
+
+    expect(w.get('[data-testid="schedule-error"]').text()).toContain('already on the calendar')
+    // The form stays open with the day still in it — nothing to retype.
+    expect(w.find('[data-testid="schedule-form"]').exists()).toBe(true)
+    expect(w.emitted('scheduled')).toBeUndefined()
+  })
+})

--- a/frontend/src/composables/useWorkoutSchedule.ts
+++ b/frontend/src/composables/useWorkoutSchedule.ts
@@ -1,0 +1,53 @@
+import { ref } from 'vue'
+import { apiCall } from '@/config/api'
+import type { WorkoutScheduleEntry, WorkoutScheduleInput } from '@/types/workout'
+
+/**
+ * Planned occasions — a plan put on a day (SB-534).
+ *
+ * Both sides schedule: the coach assigning Thursday, and the athlete planning
+ * their own week. Both go through the same act-as header, because the API
+ * authorises the coach and the linked athlete identically — one code path for
+ * two callers is what stops the coach case working while the athlete's breaks.
+ */
+export async function createSchedule(
+  payload: WorkoutScheduleInput,
+  athleteId: string,
+): Promise<WorkoutScheduleEntry> {
+  return apiCall<WorkoutScheduleEntry>('/workouts/schedule', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+    headers: { 'X-Act-As-Athlete': athleteId },
+  })
+}
+
+export async function deleteSchedule(scheduleId: string, athleteId: string): Promise<void> {
+  await apiCall(`/workouts/schedule/${scheduleId}`, {
+    method: 'DELETE',
+    headers: { 'X-Act-As-Athlete': athleteId },
+  })
+}
+
+export function useWorkoutSchedule() {
+  const schedule = ref<WorkoutScheduleEntry[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  /** Occasions from `from` onwards, soonest first. Coming up asks from today. */
+  const load = async (athleteId: string, from?: string): Promise<void> => {
+    loading.value = true
+    error.value = null
+    try {
+      const query = from ? `?date_from=${from}` : ''
+      schedule.value = await apiCall<WorkoutScheduleEntry[]>(`/workouts/schedule${query}`, {
+        headers: { 'X-Act-As-Athlete': athleteId },
+      })
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load the schedule'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { schedule, loading, error, load }
+}

--- a/frontend/src/types/workout.ts
+++ b/frontend/src/types/workout.ts
@@ -170,6 +170,28 @@ export interface WorkoutTemplate {
   blocks?: TemplateBlock[]
 }
 
+/**
+ * One planned occasion (SB-534): a plan put on a date, by someone.
+ *
+ * Separate from the template because a plan is reused and an occasion happens
+ * once — and because `created_by` is what lets the screen say who scheduled it.
+ */
+export interface WorkoutScheduleEntry {
+  id: string
+  template_id: string
+  athlete_id: string | null
+  created_by: string | null
+  scheduled_for: string
+  notes: string | null
+  created_at?: string | null
+}
+
+export interface WorkoutScheduleInput {
+  template_id: string
+  scheduled_for: string
+  notes?: string | null
+}
+
 /** One row while building — loads are entered in lb (US coach), stored as kg. */
 export interface BuilderItem {
   uid: number

--- a/frontend/src/views/AthleteDetailView.vue
+++ b/frontend/src/views/AthleteDetailView.vue
@@ -53,17 +53,20 @@
         No workouts yet. Click <span class="font-semibold">+ Build workout</span> to create one.
       </div>
       <div v-else class="space-y-3 mb-6">
-        <WorkoutTemplateCard
-          v-for="t in templates"
-          :key="t.id"
-          :template="t"
-          :exercises="exercises"
-          :authored-by="authoredBy(t)"
-          @edit="router.push(`/coach/${athleteId}/build/${t.id}`)"
-          @log="router.push(`/coach/${athleteId}/log/${t.id}`)"
-          @print="router.push(`/coach/${athleteId}/print/${t.id}`)"
-          @delete="onDeleteTemplate(t.id)"
-        />
+        <div v-for="t in templates" :key="t.id">
+          <WorkoutTemplateCard
+            :template="t"
+            :exercises="exercises"
+            :authored-by="authoredBy(t)"
+            @edit="router.push(`/coach/${athleteId}/build/${t.id}`)"
+            @log="router.push(`/coach/${athleteId}/log/${t.id}`)"
+            @print="router.push(`/coach/${athleteId}/print/${t.id}`)"
+            @delete="onDeleteTemplate(t.id)"
+          />
+          <!-- Assign it to a day (SB-534). The athlete can schedule too, from
+               their own Plans tab — same component, same endpoint. -->
+          <ScheduleWorkout class="mt-2" :template-id="t.id" :athlete-id="athleteId" />
+        </div>
       </div>
 
       <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-2">
@@ -104,6 +107,7 @@ import { useAthleteDetail } from '@/composables/useCoach'
 import { useExercises } from '@/composables/useExercises'
 import AthleteProfileForm from '@/components/AthleteProfileForm.vue'
 import AthleteAccessPanel from '@/components/AthleteAccessPanel.vue'
+import ScheduleWorkout from '@/components/ScheduleWorkout.vue'
 import WorkoutTemplateCard from '@/components/WorkoutTemplateCard.vue'
 import type { WorkoutTemplate } from '@/types/workout'
 import { deleteTemplate } from '@/composables/useWorkoutTemplates'

--- a/frontend/src/views/MyWorkoutsView.vue
+++ b/frontend/src/views/MyWorkoutsView.vue
@@ -54,36 +54,42 @@
 
     <!-- ------------------------------------------------------------- Training -->
     <div v-else-if="tab === 'training'" class="space-y-5">
-      <!-- Due today gets the Start card. With nothing scheduled — which is every
-           template today, `scheduled_for` being unset on all of them — logging
-           what you just did IS the primary action, not a quiet link under an
-           empty section (SB-531). -->
+      <!-- Due today gets the Start card. When nothing is scheduled, logging what
+           you just did IS the primary action, not a quiet link under an empty
+           section (SB-531). -->
       <div
         v-if="dueToday"
         class="rounded-2xl border border-brand-300 bg-white p-5 shadow-sm"
         data-testid="start-card"
       >
         <div class="flex items-start justify-between gap-3">
-          <h2 class="text-lg font-bold text-gray-900 leading-tight">{{ dueToday.name }}</h2>
+          <h2 class="text-lg font-bold text-gray-900 leading-tight">
+            {{ dueToday.template.name }}
+          </h2>
           <span
             class="shrink-0 rounded-full bg-amber-50 px-2 py-0.5 text-xs font-bold uppercase tracking-wide text-amber-700"
           >
-            {{ formatDayPill(dueToday.scheduled_for!) }}
+            {{ formatDayPill(dueToday.scheduled_for) }}
           </span>
         </div>
-        <p class="mt-1 text-sm text-gray-500">{{ planSummary(dueToday) }}</p>
+        <!-- Who put it on the day. Either side may schedule (SB-534), and a
+             workout Gabe planned himself reads differently from one his coach
+             expects of him — same vocabulary as the Plans grouping. -->
+        <p class="mt-1 text-sm text-gray-500">
+          <span data-testid="scheduled-by">{{ dueToday.by }}</span> · {{ planSummary(dueToday.template) }}
+        </p>
         <button
           type="button"
           class="mt-3 w-full rounded-lg bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-brand-700"
           data-testid="start-workout"
-          @click="router.push(`/my/workouts/log/${dueToday.id}`)"
+          @click="router.push(`/my/workouts/log/${dueToday.template.id}`)"
         >
           Start workout
         </button>
         <button
           type="button"
           class="mt-2 w-full rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-brand-700 hover:bg-gray-50"
-          @click="router.push(`/my/workouts/print/${dueToday.id}`)"
+          @click="router.push(`/my/workouts/print/${dueToday.template.id}`)"
         >
           Print sheet
         </button>
@@ -94,7 +100,7 @@
           {{ nextUp ? 'Nothing scheduled today' : 'Did a workout on your own?' }}
         </p>
         <p v-if="nextUp" class="mt-1 text-sm text-brand-700">
-          Next up: {{ nextUp.name }}, {{ formatDayPill(nextUp.scheduled_for!) }}
+          Next up: {{ nextUp.template.name }}, {{ formatDayPill(nextUp.scheduled_for) }}
         </p>
         <p v-else class="mt-1 text-sm text-brand-700">Log it and get the credit — no plan needed.</p>
         <RouterLink
@@ -133,30 +139,50 @@
         + Log something I just did
       </RouterLink>
 
-      <!-- Renders when scheduling data exists and is simply absent when it does
-           not: `scheduled_for` is set on none of the templates, and what should
-           put a workout here (coach assigns days? a weekly pattern?) is an open
-           product decision, not something this screen should invent (SB-530). -->
+      <!-- Scheduled work, soonest first. Every row says who put it there — a
+           coach's Thursday and one the athlete planned themselves are not the
+           same thing (SB-534). -->
       <section v-if="laterUp.length" data-testid="coming-up">
         <h2 class="group-label">Coming up</h2>
         <div class="rounded-2xl border border-gray-100 bg-white shadow-sm divide-y divide-gray-100">
-          <button
-            v-for="t in laterUp"
-            :key="t.id"
-            type="button"
-            class="w-full flex items-center justify-between gap-3 px-4 py-3 text-left hover:bg-gray-50"
-            @click="router.push(`/my/workouts/log/${t.id}`)"
+          <div
+            v-for="o in laterUp"
+            :key="o.id"
+            class="flex items-center gap-2 pr-2 hover:bg-gray-50"
+            data-testid="coming-up-row"
           >
-            <span class="min-w-0">
-              <span class="block font-semibold text-gray-900 truncate">{{ t.name }}</span>
-              <span class="block text-xs text-gray-500">{{ planSummary(t) }}</span>
-            </span>
-            <span
-              class="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-semibold text-gray-500"
+            <button
+              type="button"
+              class="min-w-0 flex-1 flex items-center justify-between gap-3 px-4 py-3 text-left"
+              @click="router.push(`/my/workouts/log/${o.template.id}`)"
             >
-              {{ formatDayPill(t.scheduled_for!) }}
-            </span>
-          </button>
+              <span class="min-w-0">
+                <span class="block font-semibold text-gray-900 truncate">
+                  {{ o.template.name }}
+                </span>
+                <span class="block text-xs text-gray-500">
+                  <span data-testid="scheduled-by">{{ o.by }}</span> · {{ planSummary(o.template) }}
+                </span>
+              </span>
+              <span
+                class="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-semibold text-gray-500"
+              >
+                {{ formatDayPill(o.scheduled_for) }}
+              </span>
+            </button>
+            <!-- Only what you put there yourself. The API enforces the same
+                 rule; this keeps the button honest (SB-486). -->
+            <button
+              v-if="o.mine"
+              type="button"
+              class="shrink-0 rounded-lg p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600"
+              :aria-label="`Unschedule ${o.template.name}`"
+              data-testid="unschedule"
+              @click="unschedule(o)"
+            >
+              <X class="w-4 h-4" />
+            </button>
+          </div>
         </div>
       </section>
 
@@ -258,6 +284,15 @@
             >
               Start workout
             </button>
+            <!-- Gabe plans his own week too — scheduling is not a coach-only
+                 verb (SB-534). -->
+            <ScheduleWorkout
+              v-if="athleteId"
+              class="mt-2"
+              :template-id="t.id"
+              :athlete-id="athleteId"
+              @scheduled="reloadSchedule"
+            />
           </div>
         </div>
       </section>
@@ -288,6 +323,15 @@
             >
               Start workout
             </button>
+            <!-- Gabe plans his own week too — scheduling is not a coach-only
+                 verb (SB-534). -->
+            <ScheduleWorkout
+              v-if="athleteId"
+              class="mt-2"
+              :template-id="t.id"
+              :athlete-id="athleteId"
+              @scheduled="reloadSchedule"
+            />
           </div>
         </div>
       </section>
@@ -317,14 +361,17 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { useRouter, RouterLink } from 'vue-router'
+import { X } from 'lucide-vue-next'
 import { useMyAthlete } from '@/composables/useCoach'
 import { useMyWorkouts } from '@/composables/useMyWorkouts'
 import { useWorkoutSessions } from '@/composables/useWorkoutSessions'
+import { useWorkoutSchedule, deleteSchedule } from '@/composables/useWorkoutSchedule'
 import { deleteTemplate } from '@/composables/useWorkoutTemplates'
+import ScheduleWorkout from '@/components/ScheduleWorkout.vue'
 import WorkoutTemplateCard from '@/components/WorkoutTemplateCard.vue'
 import { formatDayPill, todayLocalISO } from '@/utils/format'
 import { prettifyKey } from '@/utils/workoutPayload'
-import type { WorkoutTemplate } from '@/types/workout'
+import type { WorkoutScheduleEntry, WorkoutTemplate } from '@/types/workout'
 
 const router = useRouter()
 const { myAthlete, loadMyAthlete } = useMyAthlete()
@@ -334,6 +381,7 @@ const {
   error: sessionsError,
   load: loadSessions,
 } = useWorkoutSessions()
+const { schedule, load: loadSchedule } = useWorkoutSchedule()
 
 const tab = ref<'training' | 'plans'>('training')
 
@@ -348,6 +396,10 @@ const tab = ref<'training' | 'plans'>('training')
  */
 const isMine = (t: WorkoutTemplate): boolean =>
   !!t.created_by && t.created_by === myAthlete.value?.linked_user_id
+
+/** The athlete this screen is about — read once rather than reached through
+ *  `myAthlete` in the template, which relies on ref unwrapping. */
+const athleteId = computed(() => myAthlete.value?.id ?? null)
 
 const mine = computed(() => templates.value.filter(isMine))
 const fromCoach = computed(() => templates.value.filter((t) => !isMine(t)))
@@ -368,22 +420,68 @@ const planSummary = (t: WorkoutTemplate): string => {
 }
 
 // ---- Coming up -----------------------------------------------------------
-// Scheduled work, soonest first. Nothing has a `scheduled_for` today, so this
-// is empty and the sections below simply do not render — deliberately, until
-// what schedules a workout is decided (SB-530).
-const upcoming = computed(() => {
+
+/** A plan on a day, with the plan resolved and the author already read. */
+interface Occasion {
+  id: string
+  template: WorkoutTemplate
+  scheduled_for: string
+  by: string
+  mine: boolean
+}
+
+const templatesById = computed<Record<string, WorkoutTemplate>>(() => {
+  const map: Record<string, WorkoutTemplate> = {}
+  for (const t of templates.value) map[t.id] = t
+  return map
+})
+
+/**
+ * Scheduled work, soonest first (SB-534).
+ *
+ * Read from occasions rather than `workout_templates.scheduled_for`: a plan is
+ * reused and an occasion happens once, so the same workout can sit on two days
+ * — and only a row can record who put it there.
+ *
+ * An occasion whose template has since been deleted is dropped rather than
+ * rendered as a blank card.
+ */
+const upcoming = computed<Occasion[]>(() => {
   const today = todayLocalISO()
-  return templates.value
-    .filter((t) => !!t.scheduled_for && t.scheduled_for >= today)
-    .sort((a, b) => (a.scheduled_for! < b.scheduled_for! ? -1 : 1))
+  const linked = myAthlete.value?.linked_user_id
+  return schedule.value
+    .filter((s) => s.scheduled_for >= today && templatesById.value[s.template_id])
+    .sort((a, b) => (a.scheduled_for < b.scheduled_for ? -1 : 1))
+    .map((s) => {
+      const mine = !!s.created_by && s.created_by === linked
+      return {
+        id: s.id,
+        template: templatesById.value[s.template_id],
+        scheduled_for: s.scheduled_for,
+        // Same words as the Plans grouping — one vocabulary, not two.
+        by: mine ? 'Mine' : coachGroupLabel.value,
+        mine,
+      }
+    })
 })
 const dueToday = computed(() => {
   const today = todayLocalISO()
-  return upcoming.value.find((t) => t.scheduled_for === today) ?? null
+  return upcoming.value.find((o) => o.scheduled_for === today) ?? null
 })
 /** Everything still ahead once the due one has been promoted to the Start card. */
-const laterUp = computed(() => upcoming.value.filter((t) => t.id !== dueToday.value?.id))
+const laterUp = computed(() => upcoming.value.filter((o) => o.id !== dueToday.value?.id))
 const nextUp = computed(() => laterUp.value[0] ?? null)
+
+const reloadSchedule = async (): Promise<void> => {
+  if (!myAthlete.value) return
+  await loadSchedule(myAthlete.value.id, todayLocalISO())
+}
+
+const unschedule = async (o: Occasion): Promise<void> => {
+  if (!myAthlete.value) return
+  await deleteSchedule(o.id, myAthlete.value.id)
+  await reloadSchedule()
+}
 
 // ---- Completed -----------------------------------------------------------
 const COMPLETED_PREVIEW = 4
@@ -459,9 +557,15 @@ onMounted(async () => {
     router.replace('/dashboard')
     return
   }
-  // Sessions are loaded alongside the plans, not on tab switch: Completed is
-  // the first thing the Training tab shows, and it is the default tab.
-  await Promise.all([load(), loadSessions(myAthlete.value.id)])
+  // Sessions and the schedule load alongside the plans, not on tab switch:
+  // Coming up and Completed are what the Training tab shows, and it is the
+  // default tab. Only occasions from today forward — the past is Completed's
+  // job, and an unmet Thursday lingering is a decision nobody has made.
+  await Promise.all([
+    load(),
+    loadSessions(myAthlete.value.id),
+    loadSchedule(myAthlete.value.id, todayLocalISO()),
+  ])
 })
 </script>
 

--- a/frontend/src/views/__tests__/MyWorkoutsView.test.ts
+++ b/frontend/src/views/__tests__/MyWorkoutsView.test.ts
@@ -48,17 +48,31 @@ const daysFromNow = (n: number): string => {
 }
 
 /**
- * Serve the three calls the athlete's home makes. Everything defaults to empty,
- * so each test names only the data it is about.
+ * Serve the calls the athlete's home makes. Everything defaults to empty, so
+ * each test names only the data it is about.
  */
-const serve = (opts: { templates?: unknown[]; sessions?: unknown[] } = {}) => {
+const serve = (
+  opts: { templates?: unknown[]; sessions?: unknown[]; schedule?: unknown[] } = {},
+) => {
   apiCallMock.mockImplementation((path: string) => {
     if (path === '/me/workouts') return Promise.resolve(opts.templates ?? [])
     if (path === '/workouts/exercises') return Promise.resolve([])
     if (path.startsWith('/workouts/sessions')) return Promise.resolve(opts.sessions ?? [])
+    if (path.startsWith('/workouts/schedule')) return Promise.resolve(opts.schedule ?? [])
     return Promise.reject(new Error(`unexpected: ${path}`))
   })
 }
+
+/** A planned occasion, authored by the coach unless told otherwise (SB-534). */
+const occasion = (o: Partial<Record<string, unknown>> = {}) => ({
+  id: 'sch1',
+  template_id: 't1',
+  athlete_id: 'ath1',
+  created_by: 'coach',
+  scheduled_for: todayISO(),
+  notes: null,
+  ...o,
+})
 
 beforeEach(() => {
   apiCallMock.mockReset()
@@ -159,7 +173,7 @@ describe('MyWorkoutsView — Training | Plans tabs (SB-530)', () => {
   })
 
   it('does not send you to the plans when one is already due', async () => {
-    serve({ templates: [{ ...template, scheduled_for: todayISO() }] })
+    serve({ templates: [template], schedule: [occasion()] })
     const w = mount(MyWorkoutsView)
     await flushPromises()
     expect(w.find('[data-testid="go-to-plans"]').exists()).toBe(false)
@@ -262,15 +276,12 @@ describe('MyWorkoutsView — Completed (SB-530)', () => {
   })
 })
 
-describe('MyWorkoutsView — Coming up (SB-530)', () => {
+describe('MyWorkoutsView — Coming up (SB-530, SB-534)', () => {
   beforeEach(() => {
     myAthlete.value = { id: 'ath1', linked_user_id: 'u1' }
   })
 
-  it('is absent entirely while nothing carries a scheduled date', async () => {
-    // `scheduled_for` is unset on every template and what should schedule one is
-    // an open product decision — so the section renders only when the data
-    // exists, and the screen is honest in the meantime.
+  it('is absent entirely while nothing is scheduled', async () => {
     serve({ templates: [template] })
     const w = mount(MyWorkoutsView)
     await flushPromises()
@@ -280,9 +291,10 @@ describe('MyWorkoutsView — Coming up (SB-530)', () => {
 
   it('promotes the workout due today to a labelled Start card', async () => {
     serve({
-      templates: [
-        { ...template, scheduled_for: todayISO() },
-        { ...template, id: 't2', name: 'Track Thursday', scheduled_for: daysFromNow(3) },
+      templates: [template, { ...template, id: 't2', name: 'Track Thursday' }],
+      schedule: [
+        occasion(),
+        occasion({ id: 'sch2', template_id: 't2', scheduled_for: daysFromNow(3) }),
       ],
     })
     const w = mount(MyWorkoutsView)
@@ -299,7 +311,7 @@ describe('MyWorkoutsView — Coming up (SB-530)', () => {
   })
 
   it('drops the ad-hoc entry to a quiet line when something is due', async () => {
-    serve({ templates: [{ ...template, scheduled_for: todayISO() }] })
+    serve({ templates: [template], schedule: [occasion()] })
     const w = mount(MyWorkoutsView)
     await flushPromises()
     const adhoc = w.get('[data-testid="log-adhoc"]')
@@ -308,7 +320,10 @@ describe('MyWorkoutsView — Coming up (SB-530)', () => {
   })
 
   it('names what is next when nothing is due today', async () => {
-    serve({ templates: [{ ...template, name: 'Track Thursday', scheduled_for: daysFromNow(3) }] })
+    serve({
+      templates: [{ ...template, name: 'Track Thursday' }],
+      schedule: [occasion({ scheduled_for: daysFromNow(3) })],
+    })
     const w = mount(MyWorkoutsView)
     await flushPromises()
     expect(w.text()).toContain('Nothing scheduled today')
@@ -317,12 +332,104 @@ describe('MyWorkoutsView — Coming up (SB-530)', () => {
     expect(w.get('[data-testid="log-adhoc"]').text()).toContain('+ Log a workout')
   })
 
-  it('ignores a date that has already passed', async () => {
-    serve({ templates: [{ ...template, scheduled_for: daysFromNow(-2) }] })
+  it('ignores a day that has already passed', async () => {
+    serve({ templates: [template], schedule: [occasion({ scheduled_for: daysFromNow(-2) })] })
     const w = mount(MyWorkoutsView)
     await flushPromises()
     expect(w.find('[data-testid="start-card"]').exists()).toBe(false)
     expect(w.find('[data-testid="coming-up"]').exists()).toBe(false)
+  })
+
+  it('asks only for occasions from today forward', async () => {
+    serve({ templates: [template] })
+    mount(MyWorkoutsView)
+    await flushPromises()
+    const call = apiCallMock.mock.calls.find((c) => String(c[0]).startsWith('/workouts/schedule'))
+    expect(String(call![0])).toContain(`date_from=${todayISO()}`)
+    expect((call![1] as { headers: Record<string, string> }).headers).toEqual({
+      'X-Act-As-Athlete': 'ath1',
+    })
+  })
+
+  it('drops an occasion whose plan has since been deleted', async () => {
+    // Otherwise it renders as a row with no name on it.
+    serve({
+      templates: [template],
+      schedule: [
+        occasion({ id: 'gone', template_id: 'deleted', scheduled_for: daysFromNow(2) }),
+        occasion({ id: 'ok', template_id: 't1', scheduled_for: daysFromNow(3) }),
+      ],
+    })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    const rows = w.findAll('[data-testid="coming-up-row"]')
+    expect(rows).toHaveLength(1)
+    expect(rows[0].text()).toContain('Monday At-Home')
+  })
+})
+
+describe('MyWorkoutsView — who scheduled it (SB-534)', () => {
+  beforeEach(() => {
+    myAthlete.value = { id: 'ath1', linked_user_id: 'u1' }
+  })
+
+  it('says the coach put it there', async () => {
+    serve({ templates: [template], schedule: [occasion({ created_by: 'coach' })] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    // A workout Matthew expects of him reads differently from one he planned.
+    expect(w.get('[data-testid="scheduled-by"]').text()).toBe('From Matthew')
+  })
+
+  it('says when the athlete put it there themselves', async () => {
+    serve({ templates: [template], schedule: [occasion({ created_by: 'u1' })] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    expect(w.get('[data-testid="scheduled-by"]').text()).toBe('Mine')
+  })
+
+  it('offers to unschedule only what the athlete scheduled', async () => {
+    serve({
+      templates: [template, { ...template, id: 't2', name: 'Track Thursday' }],
+      schedule: [
+        occasion({ id: 'sch1', created_by: 'coach', scheduled_for: daysFromNow(2) }),
+        occasion({ id: 'sch2', template_id: 't2', created_by: 'u1', scheduled_for: daysFromNow(3) }),
+      ],
+    })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    const rows = w.findAll('[data-testid="coming-up-row"]')
+    // Matthew's Thursday is not Gabe's to remove — the API says so too.
+    expect(rows[0].find('[data-testid="unschedule"]').exists()).toBe(false)
+    expect(rows[1].find('[data-testid="unschedule"]').exists()).toBe(true)
+
+    await rows[1].get('[data-testid="unschedule"]').trigger('click')
+    await flushPromises()
+    const del = apiCallMock.mock.calls.find((c) => c[1] && (c[1] as { method?: string }).method === 'DELETE')
+    expect(String(del![0])).toBe('/workouts/schedule/sch2')
+  })
+
+  it('lets the athlete put a plan on a day from the Plans tab', async () => {
+    serve({ templates: [template] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    await w.get('[data-testid="tab-plans"]').trigger('click')
+
+    await w.get('[data-testid="schedule-open"]').trigger('click')
+    await w.get('[data-testid="schedule-date"]').setValue(daysFromNow(2))
+    await w.get('[data-testid="schedule-save"]').trigger('click')
+    await flushPromises()
+
+    const post = apiCallMock.mock.calls.find((c) => c[1] && (c[1] as { method?: string }).method === 'POST')
+    expect(String(post![0])).toBe('/workouts/schedule')
+    expect(JSON.parse((post![1] as { body: string }).body)).toEqual({
+      template_id: 't1',
+      scheduled_for: daysFromNow(2),
+    })
+    // Scheduling for yourself goes through the same act-as header the coach uses.
+    expect((post![1] as { headers: Record<string, string> }).headers).toEqual({
+      'X-Act-As-Athlete': 'ath1',
+    })
   })
 })
 

--- a/src/shared/models/workout.py
+++ b/src/shared/models/workout.py
@@ -313,6 +313,34 @@ class WorkoutTemplate(BaseModel):
 
 
 # --------------------------------------------------------------------------- #
+# Schedule (a plan put on a day, by someone)
+# --------------------------------------------------------------------------- #
+class WorkoutScheduleCreate(BaseModel):
+    """Input for putting a template on a date (SB-534)."""
+
+    template_id: UUID
+    scheduled_for: date
+    notes: str | None = None
+
+
+class WorkoutSchedule(BaseModel):
+    """One planned occasion.
+
+    `created_by` is the point of the row: either a coach or the athlete may
+    schedule, and the screen has to say which without being told.
+    """
+
+    id: UUID
+    user_id: UUID
+    athlete_id: UUID | None = None
+    created_by: UUID | None = None
+    template_id: UUID
+    scheduled_for: date
+    notes: str | None = None
+    created_at: datetime | None = None
+
+
+# --------------------------------------------------------------------------- #
 # Sessions + sets (the actual performance)
 # --------------------------------------------------------------------------- #
 class ExerciseSetCreate(BaseModel):

--- a/src/shared/supabase_ops/__init__.py
+++ b/src/shared/supabase_ops/__init__.py
@@ -23,6 +23,7 @@ from .token_repository import TokenRepository
 from .users_repository import UsersRepository
 from .workout_repository import (
     ExercisesRepository,
+    WorkoutScheduleRepository,
     WorkoutSessionsRepository,
     WorkoutTemplatesRepository,
 )
@@ -44,6 +45,7 @@ __all__ = [
     "UsersRepository",
     "ExercisesRepository",
     "WorkoutTemplatesRepository",
+    "WorkoutScheduleRepository",
     "WorkoutSessionsRepository",
     "activity_to_run_dict",
     "split_to_dict",

--- a/src/shared/supabase_ops/workout_repository.py
+++ b/src/shared/supabase_ops/workout_repository.py
@@ -380,6 +380,65 @@ class WorkoutTemplatesRepository:
         return bool(cast(list[dict[str, Any]], query.execute().data))
 
 
+class WorkoutScheduleRepository:
+    """Planned occasions: a template put on a date, by a coach or the athlete.
+
+    One row per occasion rather than a date on the template (SB-534), so the
+    same plan can sit on two days at once and every row remembers who put it
+    there. `created_by` is written by ``_owner_fields`` for athlete-scoped rows
+    and set explicitly for self-owned ones, because "who scheduled this" has to
+    be answerable either way.
+    """
+
+    def __init__(self, supabase: Client):
+        self.supabase = supabase
+
+    def create(
+        self, user_id: UUID, payload: dict[str, Any], athlete_id: UUID | None = None
+    ) -> dict[str, Any]:
+        owner = _owner_fields(user_id, athlete_id)
+        # Self-owned rows get no created_by from _owner_fields (nothing else
+        # needs it), but the schedule always has to name its author.
+        owner.setdefault("created_by", str(user_id))
+        row = self.supabase.table("workout_schedule").insert({**payload, **owner}).execute()
+        return cast(list[dict[str, Any]], row.data)[0]
+
+    def list(
+        self,
+        user_id: UUID,
+        date_from: date | None = None,
+        date_to: date | None = None,
+        athlete_id: UUID | None = None,
+    ) -> list[dict[str, Any]]:
+        """Occasions in date order — soonest first, which is how they are read."""
+        query = _scope(self.supabase.table("workout_schedule").select("*"), user_id, athlete_id)
+        if date_from is not None:
+            query = query.gte("scheduled_for", date_from.isoformat())
+        if date_to is not None:
+            query = query.lte("scheduled_for", date_to.isoformat())
+        result = query.order("scheduled_for").execute()
+        return cast(list[dict[str, Any]], result.data)
+
+    def get(
+        self, user_id: UUID, schedule_id: UUID, athlete_id: UUID | None = None
+    ) -> dict[str, Any] | None:
+        query = _scope(
+            self.supabase.table("workout_schedule").select("*").eq("id", str(schedule_id)),
+            user_id,
+            athlete_id,
+        )
+        rows = cast(list[dict[str, Any]], query.execute().data)
+        return rows[0] if rows else None
+
+    def delete(self, user_id: UUID, schedule_id: UUID, athlete_id: UUID | None = None) -> bool:
+        query = _scope(
+            self.supabase.table("workout_schedule").delete().eq("id", str(schedule_id)),
+            user_id,
+            athlete_id,
+        )
+        return bool(cast(list[dict[str, Any]], query.execute().data))
+
+
 class WorkoutSessionsRepository:
     """Per-user logged sessions + their exercise sets."""
 

--- a/supabase/migrations/20260802120000_workout_schedule.sql
+++ b/supabase/migrations/20260802120000_workout_schedule.sql
@@ -1,0 +1,82 @@
+-- =====================================================
+-- workout_schedule — a plan put on a day, by someone (SB-534)
+-- =====================================================
+-- SB-530 shipped a "Coming up" section that renders whatever is scheduled and
+-- is absent while nothing is. Nothing ever was: `workout_templates.scheduled_for`
+-- (SB-335) is set on 0 of 11 templates, and it could not carry the decision
+-- anyway.
+--
+-- Three reasons a DATE column on the template is the wrong grain:
+--
+--   1. NO AUTHOR. Either side may schedule — Matthew assigns Thursday, or Gabe
+--      plans his own week — and the screen has to say which. A column records
+--      the date and nothing about who set it.
+--
+--   2. A PLAN COULD ONLY BE SCHEDULED ONCE, EVER. "Monday At-Home" every Monday
+--      overwrites its own date. The column conflates *this plan* with *this
+--      occasion*, which are different things: the plan is reused, the occasion
+--      happens once.
+--
+--   3. SCHEDULING AND COMPLETING NEVER MEET. A session references a template,
+--      not the occasion it answers, so "did he do Thursday's?" is not a query.
+--
+-- One row per planned occasion fixes all three, and is the shape recurrence
+-- expands INTO rather than replaces (SB-535): a weekly rule generates rows
+-- here, so moving or skipping one Thursday never has to cancel Thursdays.
+--
+-- `workout_templates.scheduled_for` is left in place and unread. It is NULL on
+-- every row, so there is nothing to migrate; it can be dropped once no code
+-- references it.
+-- =====================================================
+
+CREATE TABLE workout_schedule (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,  -- denormalized for RLS
+    template_id UUID NOT NULL REFERENCES workout_templates(id) ON DELETE CASCADE,
+    athlete_id UUID REFERENCES athletes(id) ON DELETE CASCADE,
+    -- Who put it on the day. This is the whole point of the table over a column:
+    -- "From Matthew" and "Mine" have to read the same on Training as on Plans.
+    created_by UUID REFERENCES users(user_id) ON DELETE SET NULL,
+    scheduled_for DATE NOT NULL,
+    notes TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- The Coming-up read: one athlete, forward from today, soonest first.
+CREATE INDEX idx_workout_schedule_athlete_date ON workout_schedule (athlete_id, scheduled_for);
+CREATE INDEX idx_workout_schedule_user_date ON workout_schedule (user_id, scheduled_for);
+CREATE INDEX idx_workout_schedule_template ON workout_schedule (template_id);
+
+-- The same plan twice on one day is a mistake, not a double session — but the
+-- same plan on two days is exactly what this table exists to allow.
+CREATE UNIQUE INDEX idx_workout_schedule_no_duplicate
+    ON workout_schedule (template_id, scheduled_for, COALESCE(athlete_id, user_id));
+
+COMMENT ON TABLE workout_schedule IS
+    'One planned occasion: a template put on a date by a coach or the athlete (SB-534)';
+COMMENT ON COLUMN workout_schedule.created_by IS
+    'Who scheduled it — the coach, or the athlete themselves. Drives the "who" on Coming up.';
+
+-- =====================================================
+-- RLS — mirrors template_items / template_blocks exactly
+-- =====================================================
+ALTER TABLE workout_schedule ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "own workout_schedule select" ON workout_schedule FOR SELECT
+    USING (user_id = auth.uid());
+CREATE POLICY "own workout_schedule insert" ON workout_schedule FOR INSERT
+    WITH CHECK (user_id = auth.uid());
+CREATE POLICY "own workout_schedule update" ON workout_schedule FOR UPDATE
+    USING (user_id = auth.uid());
+CREATE POLICY "own workout_schedule delete" ON workout_schedule FOR DELETE
+    USING (user_id = auth.uid());
+
+CREATE POLICY "coach workout_schedule select" ON workout_schedule FOR SELECT
+    USING (can_coach_athlete(athlete_id));
+CREATE POLICY "coach workout_schedule insert" ON workout_schedule FOR INSERT
+    WITH CHECK (can_coach_athlete(athlete_id));
+CREATE POLICY "coach workout_schedule update" ON workout_schedule FOR UPDATE
+    USING (can_coach_athlete(athlete_id));
+CREATE POLICY "coach workout_schedule delete" ON workout_schedule FOR DELETE
+    USING (can_coach_athlete(athlete_id));


### PR DESCRIPTION
## Summary

Fills the "Coming up" section SB-530 built, and records the product decision: **either side can schedule a workout to a future day, and the screen says which.**

`workout_templates.scheduled_for` could not carry that. It is a single DATE on the plan, so it records no author — and it means a plan can only ever be scheduled once: "Monday At-Home" every Monday overwrites its own date. It conflates the plan (reused) with the occasion (happens once).

- **New `workout_schedule` table** — one row per planned occasion: template, day, `created_by`. RLS mirrors `template_items` / `template_blocks` exactly.
- **`POST` / `GET` / `DELETE /workouts/schedule`**, athlete-scoped through the existing act-as header. Scheduling a template you cannot see is a 404 rather than a dangling row.
- **Coming up reads occasions**, not `scheduled_for`. Every row — and the due Start card — says who put it there, using the same "From Matthew" / "Mine" words as the Plans grouping rather than a second vocabulary. An occasion whose plan was deleted is dropped, not rendered blank.
- **One `ScheduleWorkout` component for both surfaces**: the coach schedules from AthleteDetailView, the athlete from their own Plans tab. The API authorises them identically, and two copies of this flow is how the athlete-side bugs of the last week happened.
- **Unscheduling follows SB-486's split**: a coach may clear anything of their athlete's; the athlete may clear what they scheduled and not what their coach assigned. Enforced on the route, not just in the buttons.
- A unique index stops the same plan landing on the same day twice, and the UI explains that rather than surfacing a constraint string.

Deliberately out of scope: recurrence (SB-535, blocked on this) and what happens to an unmet past occasion — Coming up filters from today, so a missed Thursday simply drops off.

`scheduled_for` is left in place and unread. It is NULL on all 11 templates, so there is nothing to migrate; it can be dropped once no code references it.

## Test plan

- [x] `cd frontend && npm run type-check && npx vitest run` — 386 passing, `npm run build`
- [x] `uv run --project backend ruff check/format backend/ && python -m pytest backend/tests/ -q` — 376 passing
- [x] `uv run ruff check/format src/ tests/ && uv run pytest tests/ -q` — 186 passing, coverage 60.6%
- [x] Every new test mutation-tested (8): author on self-owned rows, template-existence 404, unschedule author check, "who scheduled it", unschedule visibility, orphan-occasion filter, from-today window, act-as header on POST, duplicate-day message, `min` date, form-stays-open-on-error
- [ ] Migration applies on Supabase
- [ ] As the coach: schedule a plan from the athlete's detail view; it appears on the athlete's Training tab reading "From Matthew" with no × on it
- [ ] As the athlete: schedule one from Plans; it reads "Mine" and can be removed
- [ ] A plan scheduled for today becomes the Start card; one further out sits under Coming up

Fixes SB-534

🤖 Generated with [Claude Code](https://claude.com/claude-code)