### PR TITLE
feat: a logged session can be called something

### DIFF
--- a/backend/routes/workouts.py
+++ b/backend/routes/workouts.py
@@ -24,6 +24,7 @@ from src.shared.models.workout import (
     WorkoutScheduleCreate,
     WorkoutSession,
     WorkoutSessionCreate,
+    WorkoutSessionUpdate,
     WorkoutTemplate,
     WorkoutTemplateCreate,
 )
@@ -413,6 +414,36 @@ def get_session(
     )
     if row is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
+    return WorkoutSession(**row)
+
+
+@router.patch("/sessions/{session_id}", response_model=WorkoutSession)
+async def update_session(
+    session_id: UUID,
+    body: WorkoutSessionUpdate,
+    user_id: UUID = Depends(authenticate_request),
+    athlete_id: UUID | None = Depends(acting_athlete),
+) -> WorkoutSession:
+    """Rename a logged session (SB-536).
+
+    Same rule as deleting one: editable by whoever logged it, and by the coach
+    for any of their athlete's. A name is a label on the record, so this never
+    touches the sets — those are the record itself.
+    """
+    repo = WorkoutSessionsRepository(get_supabase_client())
+    existing = repo.get(user_id, session_id, athlete_id=athlete_id)
+    if existing is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
+    _require_may_modify(user_id, athlete_id, existing, "session")
+
+    # exclude_unset, not exclude_none: clearing the name back to the default is
+    # a legitimate edit, and indistinguishable from "not sent" otherwise.
+    row = repo.update(
+        user_id, session_id, body.model_dump(mode="json", exclude_unset=True), athlete_id=athlete_id
+    )
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
+    await invalidate_user(user_id)
     return WorkoutSession(**row)
 
 

--- a/backend/tests/test_workout_session_name.py
+++ b/backend/tests/test_workout_session_name.py
@@ -1,0 +1,144 @@
+"""SB-536: a logged session can be called something, and renamed.
+
+SB-531 opened the ad-hoc path; nothing named those sessions, so the Completed
+list titled them on the session type and four workouts in a week read alike.
+
+Naming is never required — a name field standing between the work and the credit
+is friction in the wrong place — so the API takes it as optional and the client
+supplies a default. Renaming afterwards follows the same rule as deleting: the
+athlete owns what they logged, the coach owns their athlete's.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+from src.shared.models.workout import WorkoutSessionCreate, WorkoutSessionUpdate
+
+COACH = uuid4()
+ATHLETE_USER = uuid4()
+ATHLETE_ID = uuid4()
+
+
+async def _noop(*a: Any, **k: Any) -> None:
+    return None
+
+
+def _row(created_by: UUID, name: str | None = None) -> dict[str, Any]:
+    return {
+        "id": str(uuid4()),
+        "user_id": str(COACH),
+        "athlete_id": str(ATHLETE_ID),
+        "created_by": str(created_by),
+        "session_date": "2026-08-02",
+        "name": name,
+        "type": "circuit",
+        "sets": [],
+    }
+
+
+def _patch_session(caller: UUID, existing: dict[str, Any], *, is_coach: bool, name: Any) -> Any:
+    repo = MagicMock()
+    repo.get.return_value = existing
+    repo.update.side_effect = lambda user_id, sid, payload, athlete_id=None: {
+        **existing,
+        **payload,
+    }
+
+    with (
+        patch("backend.routes.workouts.get_supabase_client"),
+        patch("backend.routes.workouts.WorkoutSessionsRepository", return_value=repo),
+        patch("backend.routes.workouts.coaches_athlete", return_value=is_coach),
+        patch("backend.routes.workouts.invalidate_user", new=_noop),
+    ):
+        from backend.routes.workouts import update_session
+
+        return (
+            asyncio.run(
+                update_session(
+                    session_id=UUID(existing["id"]),
+                    body=WorkoutSessionUpdate(name=name),
+                    user_id=caller,
+                    athlete_id=ATHLETE_ID,
+                )
+            ),
+            repo,
+        )
+
+
+def test_logging_a_session_never_requires_a_name() -> None:
+    """The whole point of defaulting it: nothing stands between the work and the
+    credit for it."""
+    body = WorkoutSessionCreate(session_date="2026-08-02", type="circuit")
+    assert body.name is None
+
+
+def test_a_name_survives_the_create_payload() -> None:
+    body = WorkoutSessionCreate(session_date="2026-08-02", type="circuit", name="Saturday 2 Aug")
+    assert body.model_dump(mode="json")["name"] == "Saturday 2 Aug"
+
+
+def test_an_athlete_may_rename_the_session_they_logged() -> None:
+    result, repo = _patch_session(
+        ATHLETE_USER, _row(ATHLETE_USER), is_coach=False, name="Garage circuit"
+    )
+    assert result.name == "Garage circuit"
+    repo.update.assert_called_once()
+
+
+def test_a_coach_may_rename_their_athletes_session() -> None:
+    result, _ = _patch_session(COACH, _row(COACH), is_coach=True, name="Bike test")
+    assert result.name == "Bike test"
+
+
+def test_an_athlete_may_not_rename_a_session_their_coach_logged() -> None:
+    """Hiding the control is not enforcement — Matthew's record of the session
+    is not Gabe's to relabel."""
+    with pytest.raises(HTTPException) as exc:
+        _patch_session(ATHLETE_USER, _row(COACH), is_coach=False, name="mine now")
+
+    assert exc.value.status_code == 403
+
+
+def test_renaming_never_touches_what_was_logged() -> None:
+    """The sets are the record; the name is a label on it."""
+    _, repo = _patch_session(ATHLETE_USER, _row(ATHLETE_USER), is_coach=False, name="Sunday")
+    payload = repo.update.call_args.args[2]
+    assert payload == {"name": "Sunday"}
+
+
+def test_clearing_the_name_is_a_real_edit() -> None:
+    """Explicit null falls the row back to the template name / type, which is
+    different from "not sent" — hence exclude_unset rather than exclude_none."""
+    _, repo = _patch_session(ATHLETE_USER, _row(ATHLETE_USER, "Old"), is_coach=False, name=None)
+    assert repo.update.call_args.args[2] == {"name": None}
+
+
+def test_renaming_a_session_that_is_not_there_is_a_404() -> None:
+    repo = MagicMock()
+    repo.get.return_value = None
+
+    with (
+        patch("backend.routes.workouts.get_supabase_client"),
+        patch("backend.routes.workouts.WorkoutSessionsRepository", return_value=repo),
+        patch("backend.routes.workouts.invalidate_user", new=_noop),
+    ):
+        from backend.routes.workouts import update_session
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(
+                update_session(
+                    session_id=uuid4(),
+                    body=WorkoutSessionUpdate(name="x"),
+                    user_id=COACH,
+                    athlete_id=ATHLETE_ID,
+                )
+            )
+
+    assert exc.value.status_code == 404
+    repo.update.assert_not_called()

--- a/frontend/src/composables/useWorkoutSessions.ts
+++ b/frontend/src/composables/useWorkoutSessions.ts
@@ -8,6 +8,22 @@ import type { WorkoutSessionInput } from '@/types/workout'
  * the athlete's behalf via X-Act-As-Athlete (the backend verifies the coach
  * actually coaches that athlete). Mirrors useWorkoutTemplates.createTemplate.
  */
+/**
+ * Rename a logged session (SB-536). Only the name — the sets are the record,
+ * and relabelling one must never disturb what was logged.
+ */
+export async function renameSession(
+  sessionId: string,
+  name: string | null,
+  athleteId: string,
+): Promise<WorkoutSession> {
+  return apiCall<WorkoutSession>(`/workouts/sessions/${sessionId}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ name }),
+    headers: { 'X-Act-As-Athlete': athleteId },
+  })
+}
+
 export async function createSession(
   payload: WorkoutSessionInput,
   athleteId: string,

--- a/frontend/src/types/coach.ts
+++ b/frontend/src/types/coach.ts
@@ -98,6 +98,8 @@ export interface WorkoutSession {
   id: string
   athlete_id: string | null
   session_date: string
+  // What the athlete calls it (SB-536); null falls back to the plan's name.
+  name: string | null
   // Which plan was performed, or null for an ad-hoc session with none behind
   // it (SB-531) — what "my own" on the Completed list is read from.
   template_id: string | null

--- a/frontend/src/types/workout.ts
+++ b/frontend/src/types/workout.ts
@@ -232,6 +232,9 @@ export interface SessionSetInput {
 
 export interface WorkoutSessionInput {
   session_date: string
+  // What the athlete calls it (SB-536). null = unnamed; the row falls back to
+  // the template name, then the type.
+  name?: string | null
   template_id?: string | null
   type: WorkoutType
   total_minutes?: number | null

--- a/frontend/src/utils/__tests__/sessionPayload.test.ts
+++ b/frontend/src/utils/__tests__/sessionPayload.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   blankAttempt,
   buildSessionPayload,
+  defaultSessionName,
   templateToRows,
   type SessionMeta,
 } from '@/utils/sessionPayload'
@@ -44,6 +45,7 @@ const row = (key: string, over: Partial<LoggerRow> = {}): LoggerRow => ({
 
 const meta: SessionMeta = {
   session_date: '2026-07-06',
+  name: null,
   type: 'circuit',
   total_minutes: 45,
   how_felt: 'good',
@@ -164,5 +166,50 @@ describe('templateToRows', () => {
     expect(rows[1].exercise.display_name).toBe('plank') // fallback (not in catalog)
     expect(rows[1].variant).toBe('front') // carried from template item
     expect(rows.every((r) => r.attempts.length === 1)).toBe(true)
+  })
+})
+
+
+describe('defaultSessionName (SB-536)', () => {
+  it('names a session after its own day and date', () => {
+    // The weekday is what he recognises; the date is what tells two Sundays
+    // apart on the Completed list.
+    expect(defaultSessionName('2026-08-02')).toBe('Sunday 2 Aug')
+    expect(defaultSessionName('2026-01-01')).toBe('Thursday 1 Jan')
+  })
+
+  it('reads the session date, never the clock', () => {
+    // A workout done Sunday but entered on Tuesday must not be called Tuesday,
+    // and must carry no time of day — SB-531's version took the weekday from
+    // the session and the hour from `new Date()`.
+    const name = defaultSessionName('2026-08-02')
+    expect(name).toBe('Sunday 2 Aug')
+    expect(name).not.toMatch(/morning|afternoon|evening/)
+  })
+
+  it('does not shift a day in negative-offset zones (timezone-safe)', () => {
+    // new Date('2026-08-01') is UTC midnight → Jul 31 locally in the US.
+    expect(defaultSessionName('2026-08-01')).toBe('Saturday 1 Aug')
+  })
+
+  it('falls back to something printable when the date is unusable', () => {
+    expect(defaultSessionName('')).toBe('Workout')
+    expect(defaultSessionName('nope')).toBe('Workout')
+  })
+})
+
+describe('buildSessionPayload — naming (SB-536)', () => {
+  const rows = [row('pushups', { attempts: [attempt({ reps: 10 })] })]
+
+  it('carries the name through', () => {
+    const p = buildSessionPayload({ ...meta, name: 'Garage circuit' }, rows)
+    expect(p.name).toBe('Garage circuit')
+  })
+
+  it('treats a blank name as no name at all', () => {
+    // An empty string is a label that reads as nothing; null falls the row back
+    // to the plan name, then the type.
+    expect(buildSessionPayload({ ...meta, name: '   ' }, rows).name).toBeNull()
+    expect(buildSessionPayload({ ...meta, name: null }, rows).name).toBeNull()
   })
 })

--- a/frontend/src/utils/sessionPayload.ts
+++ b/frontend/src/utils/sessionPayload.ts
@@ -21,6 +21,52 @@ export function todayISO(): string {
   return new Date().toISOString().slice(0, 10)
 }
 
+const WEEKDAYS_LONG = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+]
+const MONTHS_SHORT = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+]
+
+/**
+ * What an unnamed session is called until someone says otherwise (SB-536):
+ * "Sunday 2 Aug". The weekday is what he recognises; the date is what tells two
+ * Sundays apart on the Completed list.
+ *
+ * Read entirely from the session's own date, never the clock. A workout done on
+ * Sunday but entered on Tuesday evening must not be called "Tuesday" — and not
+ * "Sunday evening" either: SB-531's version took the weekday from the session
+ * and the time of day from `new Date()`, which is only right when you log the
+ * moment you finish.
+ *
+ * Parsed part-wise, because `new Date('2026-08-02')` is UTC midnight and lands
+ * on the day before west of Greenwich — every name would be off by one.
+ */
+export function defaultSessionName(dateOnly: string): string {
+  const [y, m, d] = dateOnly.split('-').map(Number)
+  if (!y || !m || !d) return 'Workout'
+  const date = new Date(y, m - 1, d)
+  if (Number.isNaN(date.getTime())) return 'Workout'
+  return `${WEEKDAYS_LONG[date.getDay()]} ${d} ${MONTHS_SHORT[m - 1]}`
+}
+
 /** A fresh empty attempt (one set of an exercise). */
 export function blankAttempt(): LoggerAttempt {
   return {
@@ -53,6 +99,7 @@ function isEmptyAttempt(a: LoggerAttempt): boolean {
 
 export interface SessionMeta {
   session_date: string
+  name: string | null
   type: WorkoutType
   total_minutes: number | null
   how_felt: string | null
@@ -107,6 +154,9 @@ export function buildSessionPayload(meta: SessionMeta, rows: LoggerRow[]): Worko
   }
   return {
     session_date: meta.session_date,
+    // Blank means "no name given" — the row falls back to the template name,
+    // then the type. An empty string would be a name that reads as nothing.
+    name: meta.name?.trim() || null,
     template_id: meta.template_id,
     type: meta.type,
     total_minutes: meta.total_minutes,

--- a/frontend/src/views/MyWorkoutsView.vue
+++ b/frontend/src/views/MyWorkoutsView.vue
@@ -222,15 +222,60 @@
             class="flex items-center justify-between gap-3 px-4 py-3"
             data-testid="completed-row"
           >
-            <div class="min-w-0">
-              <p class="font-semibold text-gray-900 truncate">{{ row.title }}</p>
-              <p class="text-xs text-gray-500">{{ row.detail }}</p>
+            <!-- Renaming after the fact (SB-536): the default is read off the
+                 date, and only he knows which one was the garage circuit. -->
+            <div v-if="renamingId === row.id" class="flex min-w-0 flex-1 items-center gap-2">
+              <input
+                v-model="renameText"
+                type="text"
+                maxlength="80"
+                class="min-w-0 flex-1 rounded-lg border border-gray-200 px-2 py-1 text-sm"
+                data-testid="rename-input"
+                @keyup.enter="saveRename(row)"
+              />
+              <button
+                type="button"
+                class="shrink-0 rounded-lg bg-brand-600 px-3 py-1 text-xs font-semibold text-white"
+                data-testid="rename-save"
+                @click="saveRename(row)"
+              >
+                Save
+              </button>
+              <button
+                type="button"
+                class="shrink-0 rounded-lg border border-gray-200 px-3 py-1 text-xs font-medium text-gray-600"
+                data-testid="rename-cancel"
+                @click="renamingId = null"
+              >
+                Cancel
+              </button>
             </div>
-            <span
-              class="shrink-0 rounded-full bg-green-50 px-2 py-0.5 text-xs font-semibold text-green-700"
-            >
-              {{ row.when }}
-            </span>
+
+            <template v-else>
+              <div class="min-w-0">
+                <p class="font-semibold text-gray-900 truncate">{{ row.title }}</p>
+                <p class="text-xs text-gray-500">{{ row.detail }}</p>
+              </div>
+              <span class="flex shrink-0 items-center gap-1">
+                <!-- Only sessions with no plan behind them: one logged against
+                     Matthew's workout is called what Matthew called it. -->
+                <button
+                  v-if="row.adhoc"
+                  type="button"
+                  class="rounded-lg p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+                  :aria-label="`Rename ${row.title}`"
+                  data-testid="rename-open"
+                  @click="startRename(row)"
+                >
+                  <Pencil class="w-3.5 h-3.5" />
+                </button>
+                <span
+                  class="rounded-full bg-green-50 px-2 py-0.5 text-xs font-semibold text-green-700"
+                >
+                  {{ row.when }}
+                </span>
+              </span>
+            </template>
           </div>
           <button
             v-if="completed.length > COMPLETED_PREVIEW && !showAllCompleted"
@@ -361,15 +406,16 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { useRouter, RouterLink } from 'vue-router'
-import { X } from 'lucide-vue-next'
+import { Pencil, X } from 'lucide-vue-next'
 import { useMyAthlete } from '@/composables/useCoach'
 import { useMyWorkouts } from '@/composables/useMyWorkouts'
-import { useWorkoutSessions } from '@/composables/useWorkoutSessions'
+import { renameSession, useWorkoutSessions } from '@/composables/useWorkoutSessions'
 import { useWorkoutSchedule, deleteSchedule } from '@/composables/useWorkoutSchedule'
 import { deleteTemplate } from '@/composables/useWorkoutTemplates'
 import ScheduleWorkout from '@/components/ScheduleWorkout.vue'
 import WorkoutTemplateCard from '@/components/WorkoutTemplateCard.vue'
 import { formatDayPill, todayLocalISO } from '@/utils/format'
+import { defaultSessionName } from '@/utils/sessionPayload'
 import { prettifyKey } from '@/utils/workoutPayload'
 import type { WorkoutScheduleEntry, WorkoutTemplate } from '@/types/workout'
 
@@ -498,6 +544,8 @@ interface CompletedRow {
   title: string
   detail: string
   when: string
+  // Only a session with no plan behind it is the athlete's to name (SB-536).
+  adhoc: boolean
 }
 
 /**
@@ -518,10 +566,11 @@ const completed = computed<CompletedRow[]>(() =>
       const logged = count > 0 ? `${count} ${count === 1 ? 'exercise' : 'exercises'}` : null
       return {
         id: s.id,
-        // No name is stored for an ad-hoc session, and asking for one before
-        // giving credit is friction in the wrong place — the kind of workout
-        // it was is the honest fallback.
-        title: name ?? prettifyKey(s.type),
+        // What he called it, then the plan's name, then the kind of workout it
+        // was. The last is the honest fallback for sessions logged before
+        // naming existed (SB-536).
+        title: s.name?.trim() || name || prettifyKey(s.type),
+        adhoc,
         detail: adhoc
           ? [logged, 'my own'].filter(Boolean).join(' · ')
           : logged
@@ -542,6 +591,29 @@ const thisWeekCount = computed(() => {
   const since = cutoff.toISOString().slice(0, 10)
   return sessions.value.filter((s) => s.session_date > since).length
 })
+
+// ---- Renaming -----------------------------------------------------------
+const renamingId = ref<string | null>(null)
+const renameText = ref('')
+
+const startRename = (row: CompletedRow): void => {
+  renamingId.value = row.id
+  renameText.value = row.title
+}
+
+/**
+ * Save the new name, or fall back to the date-derived default when it is
+ * cleared — an empty label on the Completed list would read as nothing.
+ */
+const saveRename = async (row: CompletedRow): Promise<void> => {
+  if (!myAthlete.value) return
+  const session = sessions.value.find((s) => s.id === row.id)
+  const next =
+    renameText.value.trim() || defaultSessionName(session?.session_date ?? todayLocalISO())
+  renamingId.value = null
+  await renameSession(row.id, next, myAthlete.value.id)
+  if (session) session.name = next
+}
 
 const remove = async (t: WorkoutTemplate): Promise<void> => {
   if (!myAthlete.value) return

--- a/frontend/src/views/WorkoutSessionLoggerView.vue
+++ b/frontend/src/views/WorkoutSessionLoggerView.vue
@@ -17,6 +17,22 @@
 
     <!-- Session meta -->
     <div class="bg-white rounded-2xl border border-gray-100 shadow-sm p-5 mt-4 space-y-3">
+      <!-- Named, not asked for (SB-536). It arrives filled in from the date, so
+           nothing stands between the work and the credit — but two ad-hoc
+           workouts in a week have to be tellable apart on the Completed list,
+           and only he knows which was the garage circuit. -->
+      <label v-if="!templateId" class="flex flex-col gap-1 text-sm text-gray-600">
+        Call it
+        <input
+          v-model="sessionName"
+          type="text"
+          maxlength="80"
+          class="form-input"
+          :placeholder="defaultName"
+          data-testid="session-name"
+        />
+      </label>
+
       <div class="grid grid-cols-2 gap-3">
         <label class="flex flex-col gap-1 text-sm text-gray-600">
           Date
@@ -264,6 +280,7 @@ import {
   FELT_OPTIONS,
   blankAttempt,
   buildSessionPayload,
+  defaultSessionName,
   templateToRows,
   todayISO,
 } from '@/utils/sessionPayload'
@@ -279,6 +296,9 @@ const templateId = (route.params.templateId as string | undefined) || null
 const { exercises, load } = useExercises()
 
 const sessionDate = ref(todayISO())
+// Left blank until he types: the placeholder shows what it will be called, and
+// an untouched field stays the default even if he changes the date (SB-536).
+const sessionName = ref('')
 const totalMinutes = ref<number | null>(null)
 const howFelt = ref<string | null>(null)
 const notes = ref<string | null>(null)
@@ -365,6 +385,7 @@ const payload = computed(() =>
   buildSessionPayload(
     {
       session_date: sessionDate.value,
+      name: sessionName.value || defaultName.value,
       type: sessionType.value,
       total_minutes: totalMinutes.value,
       how_felt: howFelt.value,
@@ -415,7 +436,9 @@ const keepAsPlan = async (): Promise<void> => {
   try {
     await createTemplate(
       {
-        name: sessionName(),
+        // The plan inherits the session's name, so a workout he just liked
+        // arrives in Plans already called what he called it (SB-531).
+        name: sessionName.value || defaultName.value,
         type: 'circuit',
         rounds: 1,
         items: rows.value.map((r, i) => ({
@@ -435,14 +458,11 @@ const keepAsPlan = async (): Promise<void> => {
   }
 }
 
-/** "Sunday morning" — a name he never had to stop and type. */
-const sessionName = (): string => {
-  const d = new Date(`${sessionDate.value}T12:00:00`)
-  const day = d.toLocaleDateString(undefined, { weekday: 'long' })
-  const hour = new Date().getHours()
-  const part = hour < 12 ? 'morning' : hour < 17 ? 'afternoon' : 'evening'
-  return `${day} ${part}`
-}
+/**
+ * What it will be called if he types nothing — shown as the placeholder so the
+ * name is never a surprise (SB-536).
+ */
+const defaultName = computed(() => defaultSessionName(sessionDate.value))
 
 const prefillFrom = (id: string): Promise<void> =>
   getTemplate(id, athleteId.value!).then((tpl) => {

--- a/frontend/src/views/__tests__/MyWorkoutsView.test.ts
+++ b/frontend/src/views/__tests__/MyWorkoutsView.test.ts
@@ -276,6 +276,86 @@ describe('MyWorkoutsView — Completed (SB-530)', () => {
   })
 })
 
+describe('MyWorkoutsView — session names (SB-536)', () => {
+  beforeEach(() => {
+    myAthlete.value = { id: 'ath1', linked_user_id: 'u1' }
+  })
+
+  const adhoc = (o: Partial<Record<string, unknown>> = {}) => ({
+    id: 's1',
+    template_id: null,
+    session_date: daysFromNow(-1),
+    type: 'circuit',
+    name: null,
+    sets: [],
+    exercise_count: 4,
+    ...o,
+  })
+
+  it('calls a session what the athlete called it', async () => {
+    serve({ sessions: [adhoc({ name: 'Garage circuit' })] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    expect(w.get('[data-testid="completed-row"]').text()).toContain('Garage circuit')
+  })
+
+  it('falls back to the plan name, then to the kind of workout', async () => {
+    // Sessions logged before naming existed have no name and must still read.
+    serve({
+      templates: [template],
+      sessions: [adhoc({ id: 's1', template_id: 't1' }), adhoc({ id: 's2' })],
+    })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    const rows = w.findAll('[data-testid="completed-row"]')
+    expect(rows.map((r) => r.text()).join(' ')).toContain('Monday At-Home')
+    expect(rows.map((r) => r.text()).join(' ')).toContain('Circuit')
+  })
+
+  it('renames one from the list, keeping what was logged', async () => {
+    serve({ sessions: [adhoc({ name: 'Sunday 1 Aug' })] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+
+    await w.get('[data-testid="rename-open"]').trigger('click')
+    await w.get('[data-testid="rename-input"]').setValue('Garage circuit')
+    await w.get('[data-testid="rename-save"]').trigger('click')
+    await flushPromises()
+
+    const patch = apiCallMock.mock.calls.find(
+      (c) => c[1] && (c[1] as { method?: string }).method === 'PATCH',
+    )
+    expect(String(patch![0])).toBe('/workouts/sessions/s1')
+    // Only the name — the sets are the record, not a label on it.
+    expect(JSON.parse((patch![1] as { body: string }).body)).toEqual({ name: 'Garage circuit' })
+    expect(w.get('[data-testid="completed-row"]').text()).toContain('Garage circuit')
+  })
+
+  it('clearing the name falls back to the date rather than to nothing', async () => {
+    serve({ sessions: [adhoc({ name: 'Garage circuit', session_date: '2026-08-02' })] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+
+    await w.get('[data-testid="rename-open"]').trigger('click')
+    await w.get('[data-testid="rename-input"]').setValue('   ')
+    await w.get('[data-testid="rename-save"]').trigger('click')
+    await flushPromises()
+
+    const patch = apiCallMock.mock.calls.find(
+      (c) => c[1] && (c[1] as { method?: string }).method === 'PATCH',
+    )
+    expect(JSON.parse((patch![1] as { body: string }).body)).toEqual({ name: 'Sunday 2 Aug' })
+  })
+
+  it('offers no rename on a session logged against a plan', async () => {
+    // That one is called what the coach called the workout.
+    serve({ templates: [template], sessions: [adhoc({ template_id: 't1' })] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    expect(w.find('[data-testid="rename-open"]').exists()).toBe(false)
+  })
+})
+
 describe('MyWorkoutsView — Coming up (SB-530, SB-534)', () => {
   beforeEach(() => {
     myAthlete.value = { id: 'ath1', linked_user_id: 'u1' }

--- a/frontend/src/views/__tests__/WorkoutSessionLoggerView.test.ts
+++ b/frontend/src/views/__tests__/WorkoutSessionLoggerView.test.ts
@@ -272,12 +272,15 @@ describe('WorkoutSessionLoggerView — save failure and dead ends (SB-501)', () 
 
 describe('WorkoutSessionLoggerView — ad-hoc workout (SB-531)', () => {
   // Gabe wakes up, does four exercises, wants credit. No plan involved.
-  const logSomething = async () => {
+  const logSomething = async (name?: string) => {
     h.createSession.mockResolvedValue({ id: 's9' })
     const w = await mountLogger()
     await w.find('[data-testid="add-exercise"]').trigger('click')
     await w.find('[data-testid="ex-pushups"]').trigger('click')
     await w.find('[data-testid="reps-pushups-0"]').setValue(20)
+    // A fixed date so the default name is an exact string, not today's.
+    await w.find('[data-testid="session-date"]').setValue('2026-08-02')
+    if (name !== undefined) await w.find('[data-testid="session-name"]').setValue(name)
     await w.find('[data-testid="save"]').trigger('click')
     await flushPromises()
     return w
@@ -305,17 +308,41 @@ describe('WorkoutSessionLoggerView — ad-hoc workout (SB-531)', () => {
     expect(offer.text()).toContain('Do this one again?')
   })
 
-  it('keeping it creates a reusable workout named after the day', async () => {
+  it('keeping it creates a reusable workout under the session\'s own name', async () => {
     h.createTemplate.mockResolvedValue({ id: 't9' })
-    const w = await logSomething()
+    const w = await logSomething('Garage circuit')
     await w.get('[data-testid="keep-yes"]').trigger('click')
     await flushPromises()
 
     const [payload, athleteId] = h.createTemplate.mock.calls[0]
     expect(athleteId).toBe('ath1')
-    expect(payload.name).toMatch(/^(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday) (morning|afternoon|evening)$/)
+    // The plan arrives called what he called the session (SB-536), rather than
+    // being renamed a second time.
+    expect(payload.name).toBe('Garage circuit')
     expect(payload.items[0]).toMatchObject({ exercise_key: 'pushups', position: 0 })
     expect(h.push).toHaveBeenCalledWith('/coach/ath1')
+  })
+
+  it('arrives already named, so nothing blocks the credit', async () => {
+    const w = await mountLogger()
+    await w.find('[data-testid="session-date"]').setValue('2026-08-02')
+    // Shown as a placeholder, not typed in: the name is never a surprise, and
+    // never a field he has to fill before getting the tick (SB-536).
+    const field = w.get('[data-testid="session-name"]')
+    expect(field.attributes('placeholder')).toBe('Sunday 2 Aug')
+    expect((field.element as HTMLInputElement).value).toBe('')
+  })
+
+  it('saves the default name when he types none', async () => {
+    await logSomething()
+    const [payload] = h.createSession.mock.calls[0]
+    expect(payload.name).toBe('Sunday 2 Aug')
+  })
+
+  it('saves what he calls it instead, when he says', async () => {
+    await logSomething('Garage circuit')
+    const [payload] = h.createSession.mock.calls[0]
+    expect(payload.name).toBe('Garage circuit')
   })
 
   it('declining just goes home — the session is already saved', async () => {

--- a/src/shared/models/workout.py
+++ b/src/shared/models/workout.py
@@ -392,12 +392,22 @@ class WorkoutSessionCreate(BaseModel):
     """Input for logging a session, optionally with its sets inline."""
 
     session_date: date
+    # Optional on purpose (SB-536): a required name before the work is recorded
+    # is friction in the wrong place. The client defaults one from the date.
+    name: str | None = None
     template_id: UUID | None = None
     type: WorkoutType = WorkoutType.circuit
     total_minutes: float | None = Field(default=None, ge=0)
     how_felt: str | None = None
     notes: str | None = None
     sets: list[ExerciseSetCreate] = Field(default_factory=list)
+
+
+class WorkoutSessionUpdate(BaseModel):
+    """Partial patch of a stored session. Only the name so far (SB-536) — a
+    session can be renamed long after it was logged, from the Completed list."""
+
+    name: str | None = None
 
 
 class WorkoutSession(BaseModel):
@@ -408,6 +418,8 @@ class WorkoutSession(BaseModel):
     athlete_id: UUID | None = None
     created_by: UUID | None = None
     session_date: date
+    # NULL falls back to the template's name, then to the type (SB-536).
+    name: str | None = None
     template_id: UUID | None = None
     type: WorkoutType
     total_minutes: float | None = None

--- a/src/shared/supabase_ops/workout_repository.py
+++ b/src/shared/supabase_ops/workout_repository.py
@@ -542,6 +542,29 @@ class WorkoutSessionsRepository:
         session["sets"] = cast(list[dict[str, Any]], sets.data)
         return session
 
+    def update(
+        self,
+        user_id: UUID,
+        session_id: UUID,
+        payload: dict[str, Any],
+        athlete_id: UUID | None = None,
+    ) -> dict[str, Any] | None:
+        """Patch a session's own fields — not its sets (SB-536).
+
+        Renaming is the only caller so far, and it must not disturb what was
+        logged: the sets are the record, the name is a label on it.
+        """
+        if not payload:
+            return self.get(user_id, session_id, athlete_id)
+        query = _scope(
+            self.supabase.table("workout_sessions").update(payload).eq("id", str(session_id)),
+            user_id,
+            athlete_id,
+        )
+        if not cast(list[dict[str, Any]], query.execute().data):
+            return None
+        return self.get(user_id, session_id, athlete_id)
+
     def delete(self, user_id: UUID, session_id: UUID, athlete_id: UUID | None = None) -> bool:
         query = _scope(
             self.supabase.table("workout_sessions").delete().eq("id", str(session_id)),

--- a/supabase/migrations/20260802140000_workout_session_name.sql
+++ b/supabase/migrations/20260802140000_workout_session_name.sql
@@ -1,0 +1,21 @@
+-- =====================================================
+-- A logged session can be called something (SB-536)
+-- =====================================================
+-- SB-531 made it possible to log a workout with no plan behind it. Nothing
+-- names those sessions, so SB-530's Completed list titles them on the session
+-- *type* — "Circuit" — and four ad-hoc workouts in a week are indistinguishable
+-- from one another. A session logged against a plan borrows the plan's name and
+-- reads fine, so this is only felt on the path SB-531 opened.
+--
+-- Nullable, and deliberately not required by the API: asking for a name before
+-- recording the work is friction in exactly the wrong place. The logger fills
+-- in a default from the session's own date and lets it be changed — before
+-- saving or long after.
+--
+-- Existing rows keep working: NULL falls back to the template name, then to the
+-- type, which is what every row does today.
+
+ALTER TABLE workout_sessions ADD COLUMN IF NOT EXISTS name TEXT;
+
+COMMENT ON COLUMN workout_sessions.name IS
+    'What the athlete calls this session; NULL falls back to the template name (SB-536)';


### PR DESCRIPTION
## Summary

Closes the naming question left open at the bottom of SB-530: **an ad-hoc session defaults to a name carrying the date, and can be renamed.**

Today `workout_sessions` has no name, so SB-530's Completed list titles ad-hoc rows on the session *type* — "Circuit" — and four ad-hoc workouts in a week are indistinguishable. Sessions logged against a plan borrow the plan's name and already read fine.

- **Migration**: nullable `workout_sessions.name`. NULL falls back to the plan's name, then the type, so every existing row keeps rendering.
- **Named, not asked for.** The logger shows "Sunday 2 Aug" as the *placeholder* — never a field standing between the work and the credit for it. Type over it if you want.
- **`PATCH /workouts/sessions/{id}`** to rename afterwards, from a pencil on the Completed row. Same rule as deleting (SB-486): the athlete owns what they logged, the coach owns their athlete's — enforced on the route, not by hiding the control. Only the name is patched; the sets are the record.
- **Fixes SB-531's clock bug.** `sessionName()` took the weekday from the session date and the time of day from `new Date()`, so a Sunday workout entered Tuesday evening was called "Sunday evening" — correct only if you log the moment you finish. The replacement is pure, date-only and timezone-safe (`new Date('2026-08-02')` is UTC midnight, one day early west of Greenwich).
- Clearing a name falls back to the date rather than leaving a blank label. The PATCH uses `exclude_unset` so "clear this" stays distinguishable from "not sent".
- "Save to my workouts" now carries the session's name onto the plan.

Renaming is offered only on ad-hoc sessions — one logged against Matthew's workout is called what Matthew called it.

## Test plan

- [x] `cd frontend && npm run type-check && npx vitest run` — 400 passing, `npm run build`
- [x] `uv run --project backend ruff check/format backend/ && python -m pytest backend/tests/ -q` — 384 passing
- [x] `uv run ruff check/format src/ tests/ && uv run pytest tests/ -q` — 186 passing, coverage 60.5%
- [x] Mutation-tested (8): clock-derived default, UTC day-shift, blank-name-as-empty-string, Completed ignoring the stored name, rename offered on coach sessions, cleared rename saved empty, route author check, `exclude_none` vs `exclude_unset`
- [x] Updated SB-531's naming test rather than deleting it — it asserted the old "Sunday morning" shape
- [ ] Migration applies on Supabase
- [ ] Log two ad-hoc workouts in a week; they read differently on Completed
- [ ] Rename one from the list; the count and "N exercises logged" are unchanged
- [ ] A session logged against a plan shows no rename control

Fixes SB-536

🤖 Generated with [Claude Code](https://claude.com/claude-code)