### PR TITLE
feat: a week that repeats

### DIFF
--- a/backend/routes/workouts.py
+++ b/backend/routes/workouts.py
@@ -20,6 +20,9 @@ from src.shared.models.workout import (
     Exercise,
     ExerciseCreate,
     ExerciseUpdate,
+    WorkoutRecurrence,
+    WorkoutRecurrenceCreate,
+    WorkoutRecurrenceUpdate,
     WorkoutSchedule,
     WorkoutScheduleCreate,
     WorkoutSession,
@@ -31,6 +34,7 @@ from src.shared.models.workout import (
 from src.shared.supabase_client import get_supabase_client
 from src.shared.supabase_ops import (
     ExercisesRepository,
+    WorkoutRecurrenceRepository,
     WorkoutScheduleRepository,
     WorkoutSessionsRepository,
     WorkoutTemplatesRepository,
@@ -337,8 +341,17 @@ def list_schedule(
     date_to: date | None = Query(default=None),
 ) -> list[WorkoutSchedule]:
     """Planned occasions in date order. Callers filter the window they want —
-    Coming up asks from today, a calendar would ask for a month."""
-    rows = WorkoutScheduleRepository(get_supabase_client()).list(
+    Coming up asks from today, a calendar would ask for a month.
+
+    Any weekly pattern that owes days produces them first (SB-535), so Coming up
+    is populated by reading it rather than by a cron job somebody has to
+    remember exists. The watermark makes a second read the same day free.
+    """
+    supabase = get_supabase_client()
+    WorkoutRecurrenceRepository(supabase).materialise(
+        user_id, today=date.today(), athlete_id=athlete_id
+    )
+    rows = WorkoutScheduleRepository(supabase).list(
         user_id, date_from=date_from, date_to=date_to, athlete_id=athlete_id
     )
     return [WorkoutSchedule(**r) for r in rows]
@@ -364,6 +377,102 @@ async def delete_schedule(
 
     if not repo.delete(user_id, schedule_id, athlete_id=athlete_id):
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Scheduled workout not found")
+    await invalidate_user(user_id)
+
+
+# ---------------------------------------------------------------- recurrence
+
+
+@router.post("/recurrence", response_model=WorkoutRecurrence, status_code=status.HTTP_201_CREATED)
+async def create_recurrence(
+    body: WorkoutRecurrenceCreate,
+    user_id: UUID = Depends(authenticate_request),
+    athlete_id: UUID | None = Depends(acting_athlete),
+) -> WorkoutRecurrence:
+    """Repeat a workout weekly (SB-535).
+
+    Either side, like one-off scheduling: Matthew sets the in-season week, and
+    the athlete can repeat something of their own. The rule records who set it,
+    and every occasion it generates inherits that.
+    """
+    supabase = get_supabase_client()
+    template = WorkoutTemplatesRepository(supabase).get(
+        user_id, body.template_id, athlete_id=athlete_id
+    )
+    if template is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Template not found")
+
+    repo = WorkoutRecurrenceRepository(supabase)
+    row = repo.create(
+        user_id, body.model_dump(mode="json", exclude_none=True), athlete_id=athlete_id
+    )
+    # Generate straight away, so the pattern shows on the next screen rather
+    # than whenever the schedule next happens to be read.
+    repo.materialise(user_id, today=date.today(), athlete_id=athlete_id)
+    await invalidate_user(user_id)
+    return WorkoutRecurrence(**row)
+
+
+@router.get("/recurrence", response_model=list[WorkoutRecurrence])
+def list_recurrence(
+    user_id: UUID = Depends(authenticate_request),
+    athlete_id: UUID | None = Depends(acting_athlete),
+) -> list[WorkoutRecurrence]:
+    """Every pattern, active or not — the UI says what repeats and offers to
+    stop it."""
+    rows = WorkoutRecurrenceRepository(get_supabase_client()).list(user_id, athlete_id=athlete_id)
+    return [WorkoutRecurrence(**r) for r in rows]
+
+
+@router.patch("/recurrence/{recurrence_id}", response_model=WorkoutRecurrence)
+async def update_recurrence(
+    recurrence_id: UUID,
+    body: WorkoutRecurrenceUpdate,
+    user_id: UUID = Depends(authenticate_request),
+    athlete_id: UUID | None = Depends(acting_athlete),
+) -> WorkoutRecurrence:
+    """Change a pattern, or turn it off.
+
+    Turning it off stops future occasions and leaves everything already
+    generated alone — including anything logged against it. Changing the days
+    takes effect from the next ungenerated day forward; it never rearranges a
+    week the athlete has already been shown.
+    """
+    repo = WorkoutRecurrenceRepository(get_supabase_client())
+    existing = repo.get(user_id, recurrence_id, athlete_id=athlete_id)
+    if existing is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Repeat not found")
+    _require_may_modify(user_id, athlete_id, existing, "repeat")
+
+    row = repo.update(
+        user_id,
+        recurrence_id,
+        body.model_dump(mode="json", exclude_unset=True),
+        athlete_id=athlete_id,
+    )
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Repeat not found")
+    await invalidate_user(user_id)
+    return WorkoutRecurrence(**row)
+
+
+@router.delete("/recurrence/{recurrence_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_recurrence(
+    recurrence_id: UUID,
+    user_id: UUID = Depends(authenticate_request),
+    athlete_id: UUID | None = Depends(acting_athlete),
+) -> None:
+    """Remove a pattern. Occasions it already generated survive — they are on
+    the calendar, and deleting a rule is not a claim that the next two weeks
+    never happened. `recurrence_id` on those rows goes null."""
+    repo = WorkoutRecurrenceRepository(get_supabase_client())
+    existing = repo.get(user_id, recurrence_id, athlete_id=athlete_id)
+    if existing is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Repeat not found")
+    _require_may_modify(user_id, athlete_id, existing, "repeat")
+
+    if not repo.delete(user_id, recurrence_id, athlete_id=athlete_id):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Repeat not found")
     await invalidate_user(user_id)
 
 

--- a/backend/tests/test_workout_recurrence_routes.py
+++ b/backend/tests/test_workout_recurrence_routes.py
@@ -1,0 +1,219 @@
+"""SB-535: who may set a week that repeats, and what turning it off means.
+
+Recurrence follows one-off scheduling exactly (SB-534): either side may set a
+pattern, the rule records which of them did, and only its author — or the coach,
+for their athlete — may change it. Repeating is not a coach-only verb, for the
+same reason scheduling is not.
+
+The athlete path is covered explicitly; it is the surface where the bugs land.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+from typing import Any
+from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+from src.shared.models.workout import WorkoutRecurrenceCreate, WorkoutRecurrenceUpdate
+
+COACH = uuid4()
+ATHLETE_USER = uuid4()
+ATHLETE_ID = uuid4()
+TEMPLATE_ID = uuid4()
+
+
+async def _noop(*a: Any, **k: Any) -> None:
+    return None
+
+
+def _row(created_by: UUID, **over: Any) -> dict[str, Any]:
+    return {
+        "id": str(uuid4()),
+        "user_id": str(COACH),
+        "athlete_id": str(ATHLETE_ID),
+        "created_by": str(created_by),
+        "template_id": str(TEMPLATE_ID),
+        "byweekday": [1, 4],
+        "starts_on": "2026-08-03",
+        "ends_on": None,
+        "active": True,
+        "generated_through": None,
+        **over,
+    }
+
+
+def _create(
+    caller: UUID, *, template_found: bool = True, byweekday: list[int] | None = None
+) -> Any:
+    repo = MagicMock()
+    repo.create.side_effect = lambda user_id, payload, athlete_id=None: {
+        **_row(user_id),
+        **payload,
+    }
+    templates = MagicMock()
+    templates.get.return_value = {"id": str(TEMPLATE_ID)} if template_found else None
+
+    with (
+        patch("backend.routes.workouts.get_supabase_client"),
+        patch("backend.routes.workouts.WorkoutRecurrenceRepository", return_value=repo),
+        patch("backend.routes.workouts.WorkoutTemplatesRepository", return_value=templates),
+        patch("backend.routes.workouts.invalidate_user", new=_noop),
+    ):
+        from backend.routes.workouts import create_recurrence
+
+        return (
+            asyncio.run(
+                create_recurrence(
+                    body=WorkoutRecurrenceCreate(
+                        template_id=TEMPLATE_ID,
+                        byweekday=byweekday or [1, 4],
+                        starts_on=date(2026, 8, 3),
+                    ),
+                    user_id=caller,
+                    athlete_id=ATHLETE_ID,
+                )
+            ),
+            repo,
+        )
+
+
+def _patch(caller: UUID, existing: dict[str, Any], *, is_coach: bool, **fields: Any) -> Any:
+    repo = MagicMock()
+    repo.get.return_value = existing
+    repo.update.side_effect = lambda user_id, rid, payload, athlete_id=None: {
+        **existing,
+        **payload,
+    }
+
+    with (
+        patch("backend.routes.workouts.get_supabase_client"),
+        patch("backend.routes.workouts.WorkoutRecurrenceRepository", return_value=repo),
+        patch("backend.routes.workouts.coaches_athlete", return_value=is_coach),
+        patch("backend.routes.workouts.invalidate_user", new=_noop),
+    ):
+        from backend.routes.workouts import update_recurrence
+
+        return (
+            asyncio.run(
+                update_recurrence(
+                    recurrence_id=UUID(existing["id"]),
+                    body=WorkoutRecurrenceUpdate(**fields),
+                    user_id=caller,
+                    athlete_id=ATHLETE_ID,
+                )
+            ),
+            repo,
+        )
+
+
+def test_a_coach_can_set_the_week_that_repeats() -> None:
+    result, repo = _create(COACH)
+    assert result.byweekday == [1, 4]
+    repo.create.assert_called_once()
+
+
+def test_an_athlete_can_repeat_something_of_their_own() -> None:
+    """Consistency with SB-534: if scheduling is not coach-only, repeating is
+    not either."""
+    result, _ = _create(ATHLETE_USER)
+    assert result.created_by == ATHLETE_USER
+
+
+def test_creating_a_pattern_generates_its_first_occasions_immediately() -> None:
+    """Otherwise the repeat is invisible until something else reads the
+    schedule, which reads as it not having worked."""
+    _, repo = _create(COACH)
+    repo.materialise.assert_called_once()
+
+
+def test_repeating_a_template_you_cannot_see_is_a_404() -> None:
+    with pytest.raises(HTTPException) as exc:
+        _create(COACH, template_found=False)
+
+    assert exc.value.status_code == 404
+
+
+def test_weekdays_are_validated_and_normalised() -> None:
+    """0 = Sunday .. 6 = Saturday. Duplicates collapse and the order is fixed,
+    so two ways of saying the same week store identically."""
+    body = WorkoutRecurrenceCreate(
+        template_id=TEMPLATE_ID, byweekday=[4, 1, 4], starts_on=date(2026, 8, 3)
+    )
+    assert body.byweekday == [1, 4]
+
+    with pytest.raises(ValueError):
+        WorkoutRecurrenceCreate(template_id=TEMPLATE_ID, byweekday=[7], starts_on=date(2026, 8, 3))
+    with pytest.raises(ValueError):
+        WorkoutRecurrenceCreate(template_id=TEMPLATE_ID, byweekday=[], starts_on=date(2026, 8, 3))
+
+
+def test_turning_a_pattern_off_is_a_patch_not_a_delete() -> None:
+    """Stops future occasions; everything already generated — and anything
+    logged against it — is left alone."""
+    result, repo = _patch(ATHLETE_USER, _row(ATHLETE_USER), is_coach=False, active=False)
+    assert result.active is False
+    assert repo.update.call_args.args[2] == {"active": False}
+
+
+def test_a_coach_may_change_their_athletes_pattern() -> None:
+    result, _ = _patch(COACH, _row(COACH), is_coach=True, byweekday=[2])
+    assert result.byweekday == [2]
+
+
+def test_an_athlete_may_not_change_a_pattern_their_coach_set() -> None:
+    """Matthew's in-season week is not Gabe's to rewrite."""
+    with pytest.raises(HTTPException) as exc:
+        _patch(ATHLETE_USER, _row(COACH), is_coach=False, active=False)
+
+    assert exc.value.status_code == 403
+
+
+def test_deleting_a_pattern_leaves_what_it_already_generated() -> None:
+    """Those occasions are on the calendar; removing the rule is not a claim
+    that the next two weeks never happened."""
+    repo = MagicMock()
+    existing = _row(ATHLETE_USER)
+    repo.get.return_value = existing
+    repo.delete.return_value = True
+
+    with (
+        patch("backend.routes.workouts.get_supabase_client"),
+        patch("backend.routes.workouts.WorkoutRecurrenceRepository", return_value=repo),
+        patch("backend.routes.workouts.coaches_athlete", return_value=False),
+        patch("backend.routes.workouts.invalidate_user", new=_noop),
+    ):
+        from backend.routes.workouts import delete_recurrence
+
+        asyncio.run(
+            delete_recurrence(
+                recurrence_id=UUID(existing["id"]), user_id=ATHLETE_USER, athlete_id=ATHLETE_ID
+            )
+        )
+
+    repo.delete.assert_called_once()
+    # No schedule rows are touched here — the FK goes null on its own.
+    assert "workout_schedule" not in str(repo.mock_calls)
+
+
+def test_reading_the_schedule_generates_what_is_owed_first() -> None:
+    """Coming up fills by being read, rather than by a cron job somebody has to
+    remember exists."""
+    sched = MagicMock()
+    sched.list.return_value = []
+    rec = MagicMock()
+
+    with (
+        patch("backend.routes.workouts.get_supabase_client"),
+        patch("backend.routes.workouts.WorkoutScheduleRepository", return_value=sched),
+        patch("backend.routes.workouts.WorkoutRecurrenceRepository", return_value=rec),
+    ):
+        from backend.routes.workouts import list_schedule
+
+        list_schedule(user_id=ATHLETE_USER, athlete_id=ATHLETE_ID)
+
+    rec.materialise.assert_called_once()
+    sched.list.assert_called_once()

--- a/backend/tests/test_workout_repository.py
+++ b/backend/tests/test_workout_repository.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from datetime import date
 from types import SimpleNamespace
 from typing import Any
 from uuid import UUID, uuid4
 
 from src.shared.supabase_ops.workout_repository import (
+    WorkoutRecurrenceRepository,
     WorkoutScheduleRepository,
     WorkoutSessionsRepository,
     WorkoutTemplatesRepository,
@@ -456,3 +458,145 @@ def test_template_item_without_ranges_is_unchanged():
     assert item["target_reps"] == 15
     assert item.get("target_reps_max") is None
     assert item.get("rest_mode") is None
+
+
+# --- SB-535: a weekly pattern generating occasions --------------------------
+
+MONDAY = date(2026, 8, 3)
+
+
+def _rule(user: UUID, **over: Any) -> dict[str, Any]:
+    return {
+        "id": str(uuid4()),
+        "user_id": str(user),
+        "athlete_id": None,
+        "created_by": str(user),
+        "template_id": str(uuid4()),
+        "byweekday": [1],  # Mondays
+        "starts_on": "2026-08-03",
+        "ends_on": None,
+        "active": True,
+        "generated_through": None,
+        **over,
+    }
+
+
+def test_materialise_generates_the_occasions_a_rule_owes():
+    supa = _FakeSupabase()
+    user = uuid4()
+    supa.store["workout_recurrence"] = [_rule(user)]
+
+    written = WorkoutRecurrenceRepository(supa).materialise(user, today=MONDAY, horizon_days=14)
+
+    rows = supa.store["workout_schedule"]
+    assert written == 3
+    assert [r["scheduled_for"] for r in rows] == ["2026-08-03", "2026-08-10", "2026-08-17"]
+    # Generated occasions carry the pattern's author, so "who scheduled this"
+    # keeps working with no special case (SB-534).
+    assert all(r["created_by"] == str(user) for r in rows)
+    assert all(r["recurrence_id"] == supa.store["workout_recurrence"][0]["id"] for r in rows)
+
+
+def test_materialise_twice_generates_nothing_the_second_time():
+    """The watermark: reading the schedule again the same day is free."""
+    supa = _FakeSupabase()
+    user = uuid4()
+    supa.store["workout_recurrence"] = [_rule(user)]
+    repo = WorkoutRecurrenceRepository(supa)
+
+    repo.materialise(user, today=MONDAY, horizon_days=14)
+    before = len(supa.store["workout_schedule"])
+    again = repo.materialise(user, today=MONDAY, horizon_days=14)
+
+    assert again == 0
+    assert len(supa.store["workout_schedule"]) == before
+
+
+def test_a_skipped_occasion_does_not_come_back():
+    """Delete one Monday; the rule keeps producing the rest and never refills
+    the hole. This is the whole reason generation carries a watermark instead
+    of reconciling against what exists."""
+    supa = _FakeSupabase()
+    user = uuid4()
+    supa.store["workout_recurrence"] = [_rule(user)]
+    repo = WorkoutRecurrenceRepository(supa)
+    repo.materialise(user, today=MONDAY, horizon_days=14)
+
+    supa.store["workout_schedule"] = [
+        r for r in supa.store["workout_schedule"] if r["scheduled_for"] != "2026-08-10"
+    ]
+    repo.materialise(user, today=MONDAY, horizon_days=14)
+
+    dates = [r["scheduled_for"] for r in supa.store["workout_schedule"]]
+    assert "2026-08-10" not in dates
+    assert dates == ["2026-08-03", "2026-08-17"]
+
+
+def test_a_rule_that_is_off_generates_nothing():
+    supa = _FakeSupabase()
+    user = uuid4()
+    supa.store["workout_recurrence"] = [_rule(user, active=False)]
+
+    assert WorkoutRecurrenceRepository(supa).materialise(user, today=MONDAY) == 0
+    assert supa.store.get("workout_schedule", []) == []
+
+
+def test_materialise_leaves_a_hand_scheduled_day_alone():
+    """The athlete's own entry wins over the pattern, and the unique index on
+    (template, day) would reject a second row anyway (SB-534)."""
+    supa = _FakeSupabase()
+    user = uuid4()
+    rule = _rule(user)
+    supa.store["workout_recurrence"] = [rule]
+    supa.store["workout_schedule"] = [
+        {
+            "id": str(uuid4()),
+            "user_id": str(user),
+            "template_id": rule["template_id"],
+            "scheduled_for": "2026-08-03",
+            "recurrence_id": None,
+        }
+    ]
+
+    WorkoutRecurrenceRepository(supa).materialise(user, today=MONDAY, horizon_days=14)
+
+    on_the_third = [r for r in supa.store["workout_schedule"] if r["scheduled_for"] == "2026-08-03"]
+    assert len(on_the_third) == 1
+    assert on_the_third[0]["recurrence_id"] is None  # still the hand-made one
+
+
+def test_materialise_with_no_rules_does_nothing():
+    supa = _FakeSupabase()
+    assert WorkoutRecurrenceRepository(supa).materialise(uuid4(), today=MONDAY) == 0
+
+
+def test_the_watermark_moves_even_when_nothing_was_written():
+    """A pass that writes no rows has still decided those days.
+
+    Every date the rule owed was already taken by a hand-scheduled occasion, so
+    nothing is inserted — but if the watermark stayed put, deleting that
+    occasion later would let the rule recreate it, which is the skipped-day bug
+    coming back through the side door.
+    """
+    supa = _FakeSupabase()
+    user = uuid4()
+    rule = _rule(user)
+    supa.store["workout_recurrence"] = [rule]
+    supa.store["workout_schedule"] = [
+        {
+            "id": str(uuid4()),
+            "user_id": str(user),
+            "template_id": rule["template_id"],
+            "scheduled_for": d,
+            "recurrence_id": None,
+        }
+        for d in ("2026-08-03", "2026-08-10", "2026-08-17")
+    ]
+    repo = WorkoutRecurrenceRepository(supa)
+
+    assert repo.materialise(user, today=MONDAY, horizon_days=14) == 0
+    assert supa.store["workout_recurrence"][0]["generated_through"] == "2026-08-17"
+
+    supa.store["workout_schedule"] = []
+    assert repo.materialise(user, today=MONDAY, horizon_days=14) == 0
+    assert supa.store["workout_schedule"] == []

--- a/frontend/src/components/ScheduleWorkout.vue
+++ b/frontend/src/components/ScheduleWorkout.vue
@@ -11,8 +11,32 @@
     </button>
 
     <div v-else class="rounded-lg border border-gray-200 p-3" data-testid="schedule-form">
+      <!-- One control, two shapes. A week that repeats is the same act as a
+           single day — putting it behind a separate screen would make the
+           common case (Matthew's in-season week) the hidden one (SB-535). -->
+      <div class="mb-2 flex gap-1 text-xs">
+        <button
+          type="button"
+          class="mode"
+          :class="repeat ? 'mode-off' : 'mode-on'"
+          data-testid="mode-once"
+          @click="repeat = false"
+        >
+          Once
+        </button>
+        <button
+          type="button"
+          class="mode"
+          :class="repeat ? 'mode-on' : 'mode-off'"
+          data-testid="mode-repeat"
+          @click="repeat = true"
+        >
+          Every week
+        </button>
+      </div>
+
       <label class="block text-xs font-semibold uppercase tracking-wide text-gray-400 mb-1">
-        Put this on a day
+        {{ repeat ? 'Starting' : 'Put this on a day' }}
       </label>
       <input
         v-model="day"
@@ -21,16 +45,37 @@
         class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
         data-testid="schedule-date"
       />
+
+      <div v-if="repeat" class="mt-2" data-testid="weekday-chips">
+        <span class="block text-xs font-semibold uppercase tracking-wide text-gray-400 mb-1">
+          On these days
+        </span>
+        <div class="flex gap-1">
+          <button
+            v-for="d in WEEKDAY_CHIPS"
+            :key="d.value"
+            type="button"
+            class="chip"
+            :class="days.includes(d.value) ? 'chip-on' : 'chip-off'"
+            :aria-pressed="days.includes(d.value)"
+            :data-testid="`weekday-${d.value}`"
+            @click="toggleDay(d.value)"
+          >
+            {{ d.label }}
+          </button>
+        </div>
+      </div>
+
       <p v-if="error" class="mt-2 text-sm text-red-600" data-testid="schedule-error">{{ error }}</p>
       <div class="mt-2 flex gap-2">
         <button
           type="button"
           class="flex-1 rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700 disabled:opacity-50"
-          :disabled="!day || saving"
+          :disabled="!canSave || saving"
           data-testid="schedule-save"
           @click="save"
         >
-          {{ saving ? 'Scheduling…' : 'Schedule' }}
+          {{ saving ? 'Scheduling…' : repeat ? 'Repeat weekly' : 'Schedule' }}
         </button>
         <button
           type="button"
@@ -46,12 +91,13 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { createSchedule } from '@/composables/useWorkoutSchedule'
+import { WEEKDAY_CHIPS, createRecurrence } from '@/composables/useWorkoutRecurrence'
 import { todayLocalISO } from '@/utils/format'
 
 /**
- * Put a plan on a day (SB-534).
+ * Put a plan on a day, once or every week (SB-534, SB-535).
  *
  * One component for both surfaces on purpose: the coach schedules from the
  * athlete's detail view and the athlete from their own Plans tab, and the API
@@ -62,23 +108,44 @@ const props = defineProps<{ templateId: string; athleteId: string }>()
 const emit = defineEmits<{ (e: 'scheduled'): void }>()
 
 const open = ref(false)
+const repeat = ref(false)
 const day = ref('')
+const days = ref<number[]>([])
 const saving = ref(false)
 const error = ref<string | null>(null)
 const today = todayLocalISO()
 
+const toggleDay = (d: number): void => {
+  days.value = days.value.includes(d) ? days.value.filter((x) => x !== d) : [...days.value, d]
+}
+
+/** A repeat with no days picked would silently never fire. */
+const canSave = computed(() => !!day.value && (!repeat.value || days.value.length > 0))
+
 const close = (): void => {
   open.value = false
+  repeat.value = false
   day.value = ''
+  days.value = []
   error.value = null
 }
 
 const save = async (): Promise<void> => {
-  if (!day.value) return
+  if (!canSave.value) return
   saving.value = true
   error.value = null
   try {
-    await createSchedule({ template_id: props.templateId, scheduled_for: day.value }, props.athleteId)
+    if (repeat.value) {
+      await createRecurrence(
+        { template_id: props.templateId, byweekday: days.value, starts_on: day.value },
+        props.athleteId,
+      )
+    } else {
+      await createSchedule(
+        { template_id: props.templateId, scheduled_for: day.value },
+        props.athleteId,
+      )
+    }
     close()
     emit('scheduled')
   } catch (e) {
@@ -93,3 +160,24 @@ const save = async (): Promise<void> => {
   }
 }
 </script>
+
+<style scoped>
+.mode {
+  @apply rounded-lg px-2.5 py-1 font-semibold;
+}
+.mode-on {
+  @apply bg-brand-600 text-white;
+}
+.mode-off {
+  @apply border border-gray-200 text-gray-600;
+}
+.chip {
+  @apply h-8 w-8 rounded-full text-xs font-semibold;
+}
+.chip-on {
+  @apply bg-brand-600 text-white;
+}
+.chip-off {
+  @apply border border-gray-200 text-gray-600;
+}
+</style>

--- a/frontend/src/components/__tests__/ScheduleWorkout.test.ts
+++ b/frontend/src/components/__tests__/ScheduleWorkout.test.ts
@@ -47,6 +47,57 @@ describe('ScheduleWorkout (SB-534)', () => {
     expect(w.find('[data-testid="schedule-form"]').exists()).toBe(false)
   })
 
+  it('repeats weekly on the days picked, starting from the date', async () => {
+    apiCallMock.mockImplementation(async () => ({ id: 'r1' }))
+    const w = mountIt()
+    await w.get('[data-testid="schedule-open"]').trigger('click')
+    await w.get('[data-testid="mode-repeat"]').trigger('click')
+    await w.get('[data-testid="schedule-date"]').setValue('2026-08-03')
+    await w.get('[data-testid="weekday-1"]').trigger('click') // Monday
+    await w.get('[data-testid="weekday-4"]').trigger('click') // Thursday
+    await w.get('[data-testid="schedule-save"]').trigger('click')
+    await flushPromises()
+
+    const post = apiCallMock.mock.calls.at(-1)!
+    expect(String(post[0])).toBe('/workouts/recurrence')
+    expect(JSON.parse((post[1] as { body: string }).body)).toEqual({
+      template_id: 't1',
+      byweekday: [1, 4],
+      starts_on: '2026-08-03',
+    })
+    expect(w.emitted('scheduled')).toHaveLength(1)
+  })
+
+  it('will not save a repeat with no days picked', async () => {
+    // It would be a pattern that silently never fires.
+    const w = mountIt()
+    await w.get('[data-testid="schedule-open"]').trigger('click')
+    await w.get('[data-testid="mode-repeat"]').trigger('click')
+    await w.get('[data-testid="schedule-date"]').setValue('2026-08-03')
+    expect(w.get('[data-testid="schedule-save"]').attributes('disabled')).toBeDefined()
+  })
+
+  it('a day can be unpicked again', async () => {
+    const w = mountIt()
+    await w.get('[data-testid="schedule-open"]').trigger('click')
+    await w.get('[data-testid="mode-repeat"]').trigger('click')
+    await w.get('[data-testid="weekday-1"]').trigger('click')
+    expect(w.get('[data-testid="weekday-1"]').attributes('aria-pressed')).toBe('true')
+    await w.get('[data-testid="weekday-1"]').trigger('click')
+    expect(w.get('[data-testid="weekday-1"]').attributes('aria-pressed')).toBe('false')
+  })
+
+  it('stays a one-off unless repeating is chosen', async () => {
+    apiCallMock.mockImplementation(async () => ({ id: 'sch1' }))
+    const w = mountIt()
+    await w.get('[data-testid="schedule-open"]').trigger('click')
+    expect(w.find('[data-testid="weekday-chips"]').exists()).toBe(false)
+    await w.get('[data-testid="schedule-date"]').setValue('2026-08-03')
+    await w.get('[data-testid="schedule-save"]').trigger('click')
+    await flushPromises()
+    expect(String(apiCallMock.mock.calls.at(-1)![0])).toBe('/workouts/schedule')
+  })
+
   it('explains a day that already has this plan on it', async () => {
     // The unique index is the guard; a raw constraint string is not an answer.
     apiCallMock.mockImplementation(async () => {

--- a/frontend/src/composables/__tests__/useWorkoutRecurrence.test.ts
+++ b/frontend/src/composables/__tests__/useWorkoutRecurrence.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { WEEKDAY_CHIPS, describeRecurrence } from '@/composables/useWorkoutRecurrence'
+
+describe('describeRecurrence (SB-535)', () => {
+  it('reads a pattern back in weekday order', () => {
+    // Stored order should not leak into what the athlete reads.
+    expect(describeRecurrence([4, 1])).toBe('Every Mon, Thu')
+    expect(describeRecurrence([1])).toBe('Every Mon')
+  })
+
+  it('says "Every day" rather than listing all seven', () => {
+    expect(describeRecurrence([0, 1, 2, 3, 4, 5, 6])).toBe('Every day')
+  })
+
+  it('numbers Sunday first, matching Date.getDay()', () => {
+    // The stored values come from the UI, so this convention has to hold on
+    // both sides — Python converts once, in the expansion helper.
+    expect(describeRecurrence([0])).toBe('Every Sun')
+    expect(describeRecurrence([6])).toBe('Every Sat')
+    expect(WEEKDAY_CHIPS.map((c) => c.value)).toEqual([0, 1, 2, 3, 4, 5, 6])
+    expect(WEEKDAY_CHIPS[0].label).toBe('Su')
+  })
+})

--- a/frontend/src/composables/useWorkoutRecurrence.ts
+++ b/frontend/src/composables/useWorkoutRecurrence.ts
@@ -1,0 +1,74 @@
+import { ref } from 'vue'
+import { apiCall } from '@/config/api'
+import type { WorkoutRecurrence, WorkoutRecurrenceInput } from '@/types/workout'
+
+/** Sunday-first, matching `Date.getDay()` and the stored `byweekday` values. */
+export const WEEKDAY_CHIPS: { value: number; label: string }[] = [
+  { value: 0, label: 'Su' },
+  { value: 1, label: 'M' },
+  { value: 2, label: 'Tu' },
+  { value: 3, label: 'W' },
+  { value: 4, label: 'Th' },
+  { value: 5, label: 'F' },
+  { value: 6, label: 'Sa' },
+]
+
+const FULL = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+/** "Every Mon, Thu" — what a pattern reads as on the plan it belongs to. */
+export function describeRecurrence(byweekday: number[]): string {
+  const days = [...byweekday].sort((a, b) => a - b).map((d) => FULL[d])
+  if (days.length === 7) return 'Every day'
+  return `Every ${days.join(', ')}`
+}
+
+/**
+ * Weekly patterns (SB-535). Both sides set them, through the same act-as header
+ * as one-off scheduling — repeating is not a coach-only verb any more than
+ * scheduling was.
+ */
+export async function createRecurrence(
+  payload: WorkoutRecurrenceInput,
+  athleteId: string,
+): Promise<WorkoutRecurrence> {
+  return apiCall<WorkoutRecurrence>('/workouts/recurrence', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+    headers: { 'X-Act-As-Athlete': athleteId },
+  })
+}
+
+/** Turn a pattern off. Future occasions stop; everything already generated —
+ *  and anything logged against it — is left alone. */
+export async function stopRecurrence(
+  recurrenceId: string,
+  athleteId: string,
+): Promise<WorkoutRecurrence> {
+  return apiCall<WorkoutRecurrence>(`/workouts/recurrence/${recurrenceId}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ active: false }),
+    headers: { 'X-Act-As-Athlete': athleteId },
+  })
+}
+
+export function useWorkoutRecurrence() {
+  const recurrences = ref<WorkoutRecurrence[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const load = async (athleteId: string): Promise<void> => {
+    loading.value = true
+    error.value = null
+    try {
+      recurrences.value = await apiCall<WorkoutRecurrence[]>('/workouts/recurrence', {
+        headers: { 'X-Act-As-Athlete': athleteId },
+      })
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load repeats'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { recurrences, loading, error, load }
+}

--- a/frontend/src/types/workout.ts
+++ b/frontend/src/types/workout.ts
@@ -184,6 +184,33 @@ export interface WorkoutScheduleEntry {
   scheduled_for: string
   notes: string | null
   created_at?: string | null
+  // The pattern that produced it (SB-535); null when scheduled by hand.
+  recurrence_id?: string | null
+}
+
+/**
+ * A weekly pattern that generates occasions (SB-535). The rule is what repeats;
+ * the occasions it produces are ordinary schedule rows, so everything reading
+ * Coming up needs no knowledge that recurrence exists.
+ */
+export interface WorkoutRecurrence {
+  id: string
+  template_id: string
+  athlete_id: string | null
+  created_by: string | null
+  // 0 = Sunday .. 6 = Saturday — the same numbers `Date.getDay()` returns.
+  byweekday: number[]
+  starts_on: string
+  ends_on: string | null
+  active: boolean
+  generated_through: string | null
+}
+
+export interface WorkoutRecurrenceInput {
+  template_id: string
+  byweekday: number[]
+  starts_on: string
+  ends_on?: string | null
 }
 
 export interface WorkoutScheduleInput {

--- a/frontend/src/views/MyWorkoutsView.vue
+++ b/frontend/src/views/MyWorkoutsView.vue
@@ -331,6 +331,24 @@
             </button>
             <!-- Gabe plans his own week too — scheduling is not a coach-only
                  verb (SB-534). -->
+            <!-- What repeats, and how to stop it (SB-535). -->
+            <div
+              v-if="repeatFor(t.id)"
+              class="mt-2 flex items-center justify-between gap-2 rounded-lg bg-brand-50 px-3 py-2"
+              data-testid="repeat-line"
+            >
+              <span class="text-xs font-semibold text-brand-800">
+                {{ describeRepeat(repeatFor(t.id)!.byweekday) }}
+              </span>
+              <button
+                type="button"
+                class="text-xs font-medium text-brand-700 underline"
+                data-testid="repeat-stop"
+                @click="stopRepeat(repeatFor(t.id)!.id)"
+              >
+                Stop repeating
+              </button>
+            </div>
             <ScheduleWorkout
               v-if="athleteId"
               class="mt-2"
@@ -370,6 +388,24 @@
             </button>
             <!-- Gabe plans his own week too — scheduling is not a coach-only
                  verb (SB-534). -->
+            <!-- What repeats, and how to stop it (SB-535). -->
+            <div
+              v-if="repeatFor(t.id)"
+              class="mt-2 flex items-center justify-between gap-2 rounded-lg bg-brand-50 px-3 py-2"
+              data-testid="repeat-line"
+            >
+              <span class="text-xs font-semibold text-brand-800">
+                {{ describeRepeat(repeatFor(t.id)!.byweekday) }}
+              </span>
+              <button
+                type="button"
+                class="text-xs font-medium text-brand-700 underline"
+                data-testid="repeat-stop"
+                @click="stopRepeat(repeatFor(t.id)!.id)"
+              >
+                Stop repeating
+              </button>
+            </div>
             <ScheduleWorkout
               v-if="athleteId"
               class="mt-2"
@@ -411,6 +447,11 @@ import { useMyAthlete } from '@/composables/useCoach'
 import { useMyWorkouts } from '@/composables/useMyWorkouts'
 import { renameSession, useWorkoutSessions } from '@/composables/useWorkoutSessions'
 import { useWorkoutSchedule, deleteSchedule } from '@/composables/useWorkoutSchedule'
+import {
+  describeRecurrence,
+  stopRecurrence,
+  useWorkoutRecurrence,
+} from '@/composables/useWorkoutRecurrence'
 import { deleteTemplate } from '@/composables/useWorkoutTemplates'
 import ScheduleWorkout from '@/components/ScheduleWorkout.vue'
 import WorkoutTemplateCard from '@/components/WorkoutTemplateCard.vue'
@@ -428,6 +469,7 @@ const {
   load: loadSessions,
 } = useWorkoutSessions()
 const { schedule, load: loadSchedule } = useWorkoutSchedule()
+const { recurrences, load: loadRecurrence } = useWorkoutRecurrence()
 
 const tab = ref<'training' | 'plans'>('training')
 
@@ -520,7 +562,25 @@ const nextUp = computed(() => laterUp.value[0] ?? null)
 
 const reloadSchedule = async (): Promise<void> => {
   if (!myAthlete.value) return
-  await loadSchedule(myAthlete.value.id, todayLocalISO())
+  // Both: a new pattern generates occasions, so the schedule changed too.
+  await Promise.all([
+    loadSchedule(myAthlete.value.id, todayLocalISO()),
+    loadRecurrence(myAthlete.value.id),
+  ])
+}
+
+/** The live pattern for a plan, if it has one (SB-535). */
+const repeatFor = (templateId: string) =>
+  recurrences.value.find((r) => r.template_id === templateId && r.active) ?? null
+
+const describeRepeat = describeRecurrence
+
+const stopRepeat = async (recurrenceId: string): Promise<void> => {
+  if (!myAthlete.value) return
+  // Turning it off stops future occasions and leaves the ones already on the
+  // calendar — and anything logged against them — alone.
+  await stopRecurrence(recurrenceId, myAthlete.value.id)
+  await reloadSchedule()
 }
 
 const unschedule = async (o: Occasion): Promise<void> => {
@@ -637,6 +697,7 @@ onMounted(async () => {
     load(),
     loadSessions(myAthlete.value.id),
     loadSchedule(myAthlete.value.id, todayLocalISO()),
+    loadRecurrence(myAthlete.value.id),
   ])
 })
 </script>

--- a/frontend/src/views/__tests__/MyWorkoutsView.test.ts
+++ b/frontend/src/views/__tests__/MyWorkoutsView.test.ts
@@ -52,12 +52,18 @@ const daysFromNow = (n: number): string => {
  * each test names only the data it is about.
  */
 const serve = (
-  opts: { templates?: unknown[]; sessions?: unknown[]; schedule?: unknown[] } = {},
+  opts: {
+    templates?: unknown[]
+    sessions?: unknown[]
+    schedule?: unknown[]
+    recurrence?: unknown[]
+  } = {},
 ) => {
   apiCallMock.mockImplementation((path: string) => {
     if (path === '/me/workouts') return Promise.resolve(opts.templates ?? [])
     if (path === '/workouts/exercises') return Promise.resolve([])
     if (path.startsWith('/workouts/sessions')) return Promise.resolve(opts.sessions ?? [])
+    if (path.startsWith('/workouts/recurrence')) return Promise.resolve(opts.recurrence ?? [])
     if (path.startsWith('/workouts/schedule')) return Promise.resolve(opts.schedule ?? [])
     return Promise.reject(new Error(`unexpected: ${path}`))
   })
@@ -587,5 +593,94 @@ describe('MyWorkoutsView — Plans grouping (SB-530)', () => {
     await flushPromises()
     await w.get('[data-testid="tab-plans"]').trigger('click')
     expect(w.get('[data-testid="group-from-coach"]').text()).toContain('From my coach')
+  })
+})
+
+
+describe('MyWorkoutsView — a week that repeats (SB-535)', () => {
+  beforeEach(() => {
+    myAthlete.value = { id: 'ath1', linked_user_id: 'u1' }
+  })
+
+  const rule = (o: Partial<Record<string, unknown>> = {}) => ({
+    id: 'r1',
+    template_id: 't1',
+    athlete_id: 'ath1',
+    created_by: 'coach',
+    byweekday: [1, 4],
+    starts_on: '2026-08-03',
+    ends_on: null,
+    active: true,
+    generated_through: null,
+    ...o,
+  })
+
+  it('says what repeats, on the plan it belongs to', async () => {
+    serve({ templates: [template], recurrence: [rule()] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    await w.get('[data-testid="tab-plans"]').trigger('click')
+    expect(w.get('[data-testid="repeat-line"]').text()).toContain('Every Mon, Thu')
+  })
+
+  it('shows nothing for a plan that does not repeat', async () => {
+    serve({ templates: [template] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    await w.get('[data-testid="tab-plans"]').trigger('click')
+    expect(w.find('[data-testid="repeat-line"]').exists()).toBe(false)
+  })
+
+  it('ignores a pattern that has been turned off', async () => {
+    serve({ templates: [template], recurrence: [rule({ active: false })] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    await w.get('[data-testid="tab-plans"]').trigger('click')
+    expect(w.find('[data-testid="repeat-line"]').exists()).toBe(false)
+  })
+
+  it('stops a repeat by turning it off, not by deleting it', async () => {
+    // Future occasions stop; the ones already on the calendar stay, along with
+    // anything logged against them.
+    serve({ templates: [template], recurrence: [rule()] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    await w.get('[data-testid="tab-plans"]').trigger('click')
+    await w.get('[data-testid="repeat-stop"]').trigger('click')
+    await flushPromises()
+
+    const patch = apiCallMock.mock.calls.find(
+      (c) => c[1] && (c[1] as { method?: string }).method === 'PATCH',
+    )
+    expect(String(patch![0])).toBe('/workouts/recurrence/r1')
+    expect(JSON.parse((patch![1] as { body: string }).body)).toEqual({ active: false })
+    expect(
+      apiCallMock.mock.calls.some((c) => c[1] && (c[1] as { method?: string }).method === 'DELETE'),
+    ).toBe(false)
+  })
+
+  it('a generated occasion reads exactly like a hand-scheduled one', async () => {
+    // Coming up is fed by occasions; nothing there branches on where they came
+    // from, which is the point of generating into the same table.
+    serve({
+      templates: [template],
+      recurrence: [rule()],
+      schedule: [
+        {
+          id: 'sch1',
+          template_id: 't1',
+          athlete_id: 'ath1',
+          created_by: 'coach',
+          scheduled_for: daysFromNow(2),
+          notes: null,
+          recurrence_id: 'r1',
+        },
+      ],
+    })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    const row = w.get('[data-testid="coming-up-row"]')
+    expect(row.text()).toContain('Monday At-Home')
+    expect(row.get('[data-testid="scheduled-by"]').text()).toBe('From Matthew')
   })
 })

--- a/src/shared/models/workout.py
+++ b/src/shared/models/workout.py
@@ -17,7 +17,7 @@ from enum import StrEnum
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class ExerciseCategory(StrEnum):
@@ -337,6 +337,53 @@ class WorkoutSchedule(BaseModel):
     template_id: UUID
     scheduled_for: date
     notes: str | None = None
+    created_at: datetime | None = None
+    # The pattern that produced it (SB-535); None when scheduled by hand. The
+    # screens do not branch on this — a generated occasion is an occasion.
+    recurrence_id: UUID | None = None
+
+
+class WorkoutRecurrenceCreate(BaseModel):
+    """Input for a weekly pattern (SB-535)."""
+
+    template_id: UUID
+    # 0 = Sunday .. 6 = Saturday, the convention the UI produces.
+    byweekday: list[int] = Field(min_length=1, max_length=7)
+    starts_on: date
+    ends_on: date | None = None
+
+    @field_validator("byweekday")
+    @classmethod
+    def _real_weekdays(cls, v: list[int]) -> list[int]:
+        if any(d < 0 or d > 6 for d in v):
+            raise ValueError("byweekday values must be 0 (Sunday) to 6 (Saturday)")
+        return sorted(set(v))
+
+
+class WorkoutRecurrenceUpdate(BaseModel):
+    """Partial patch. Turning a rule off is the common one — it stops future
+    occasions and leaves everything already generated (and logged) alone."""
+
+    byweekday: list[int] | None = None
+    ends_on: date | None = None
+    active: bool | None = None
+
+
+class WorkoutRecurrence(BaseModel):
+    """A stored weekly pattern."""
+
+    id: UUID
+    user_id: UUID
+    athlete_id: UUID | None = None
+    created_by: UUID | None = None
+    template_id: UUID
+    byweekday: list[int]
+    starts_on: date
+    ends_on: date | None = None
+    active: bool = True
+    # Last date already generated. Generation moves forward from here and never
+    # revisits, which is what stops a skipped occasion from coming back.
+    generated_through: date | None = None
     created_at: datetime | None = None
 
 

--- a/src/shared/supabase_ops/__init__.py
+++ b/src/shared/supabase_ops/__init__.py
@@ -23,6 +23,7 @@ from .token_repository import TokenRepository
 from .users_repository import UsersRepository
 from .workout_repository import (
     ExercisesRepository,
+    WorkoutRecurrenceRepository,
     WorkoutScheduleRepository,
     WorkoutSessionsRepository,
     WorkoutTemplatesRepository,
@@ -45,6 +46,7 @@ __all__ = [
     "UsersRepository",
     "ExercisesRepository",
     "WorkoutTemplatesRepository",
+    "WorkoutRecurrenceRepository",
     "WorkoutScheduleRepository",
     "WorkoutSessionsRepository",
     "activity_to_run_dict",

--- a/src/shared/supabase_ops/workout_repository.py
+++ b/src/shared/supabase_ops/workout_repository.py
@@ -17,12 +17,20 @@ from typing import Any, cast
 from uuid import UUID
 
 from src.shared.exercise_matching import find_duplicate_candidates, matches_query
+from src.shared.workout_recurrence import DEFAULT_HORIZON_DAYS, due_dates, horizon_end
 from supabase import Client
 
 
 def slugify(name: str) -> str:
     """Lowercase, non-alnum → underscore. Base for a generated exercise key."""
     return re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_") or "exercise"
+
+
+def _as_date(value: Any) -> Any:
+    """Supabase hands dates back as 'YYYY-MM-DD' strings; the walk wants dates."""
+    if value is None or isinstance(value, date):
+        return value
+    return date.fromisoformat(str(value))
 
 
 def _owner_fields(user_id: UUID, athlete_id: UUID | None) -> dict[str, str]:
@@ -437,6 +445,149 @@ class WorkoutScheduleRepository:
             athlete_id,
         )
         return bool(cast(list[dict[str, Any]], query.execute().data))
+
+
+class WorkoutRecurrenceRepository:
+    """Weekly patterns, and turning them into dated occasions (SB-535).
+
+    A rule generates rows in ``workout_schedule`` and is otherwise invisible:
+    everything downstream reads occasions, so the Start card, the
+    who-scheduled-it line and unscheduling need no knowledge that recurrence
+    exists.
+    """
+
+    def __init__(self, supabase: Client):
+        self.supabase = supabase
+
+    def create(
+        self, user_id: UUID, payload: dict[str, Any], athlete_id: UUID | None = None
+    ) -> dict[str, Any]:
+        owner = _owner_fields(user_id, athlete_id)
+        # As with a one-off occasion, the author is always recorded — the
+        # generated rows inherit it (SB-534).
+        owner.setdefault("created_by", str(user_id))
+        row = self.supabase.table("workout_recurrence").insert({**payload, **owner}).execute()
+        return cast(list[dict[str, Any]], row.data)[0]
+
+    def list(
+        self, user_id: UUID, athlete_id: UUID | None = None, active_only: bool = False
+    ) -> list[dict[str, Any]]:
+        query = _scope(self.supabase.table("workout_recurrence").select("*"), user_id, athlete_id)
+        if active_only:
+            query = query.eq("active", True)
+        return cast(list[dict[str, Any]], query.execute().data)
+
+    def get(
+        self, user_id: UUID, recurrence_id: UUID, athlete_id: UUID | None = None
+    ) -> dict[str, Any] | None:
+        query = _scope(
+            self.supabase.table("workout_recurrence").select("*").eq("id", str(recurrence_id)),
+            user_id,
+            athlete_id,
+        )
+        rows = cast(list[dict[str, Any]], query.execute().data)
+        return rows[0] if rows else None
+
+    def update(
+        self,
+        user_id: UUID,
+        recurrence_id: UUID,
+        payload: dict[str, Any],
+        athlete_id: UUID | None = None,
+    ) -> dict[str, Any] | None:
+        if not payload:
+            return self.get(user_id, recurrence_id, athlete_id)
+        query = _scope(
+            self.supabase.table("workout_recurrence").update(payload).eq("id", str(recurrence_id)),
+            user_id,
+            athlete_id,
+        )
+        if not cast(list[dict[str, Any]], query.execute().data):
+            return None
+        return self.get(user_id, recurrence_id, athlete_id)
+
+    def delete(self, user_id: UUID, recurrence_id: UUID, athlete_id: UUID | None = None) -> bool:
+        query = _scope(
+            self.supabase.table("workout_recurrence").delete().eq("id", str(recurrence_id)),
+            user_id,
+            athlete_id,
+        )
+        return bool(cast(list[dict[str, Any]], query.execute().data))
+
+    def materialise(
+        self,
+        user_id: UUID,
+        today: date,
+        athlete_id: UUID | None = None,
+        horizon_days: int = DEFAULT_HORIZON_DAYS,
+    ) -> int:
+        """Generate the occasions every active rule still owes. Returns how many.
+
+        Called before reading the schedule, so Coming up is always populated
+        without a cron job to forget about. Cheap when there is nothing to do:
+        the watermark means a second call the same day generates nothing.
+
+        Dates already carrying a hand-scheduled occasion for the same template
+        are skipped rather than duplicated — the unique index would reject them,
+        and the athlete's own entry should win over the pattern's.
+        """
+        rules = self.list(user_id, athlete_id=athlete_id, active_only=True)
+        if not rules:
+            return 0
+
+        written = 0
+        for rule in rules:
+            # The query already filters this; checking again is cheap and makes
+            # "turned off means generates nothing" true of this function alone,
+            # rather than of this function plus a WHERE clause elsewhere.
+            if not rule.get("active", True):
+                continue
+            wanted = due_dates(
+                byweekday=[int(d) for d in rule.get("byweekday") or []],
+                starts_on=_as_date(rule["starts_on"]),
+                ends_on=_as_date(rule.get("ends_on")),
+                generated_through=_as_date(rule.get("generated_through")),
+                today=today,
+                horizon_days=horizon_days,
+            )
+            if not wanted:
+                continue
+
+            taken = {
+                str(r["scheduled_for"])
+                for r in _scope(
+                    self.supabase.table("workout_schedule")
+                    .select("scheduled_for")
+                    .eq("template_id", str(rule["template_id"])),
+                    user_id,
+                    athlete_id,
+                )
+                .execute()
+                .data
+            }
+            rows = [
+                {
+                    "user_id": rule["user_id"],
+                    "athlete_id": rule.get("athlete_id"),
+                    "created_by": rule.get("created_by"),
+                    "template_id": rule["template_id"],
+                    "recurrence_id": rule["id"],
+                    "scheduled_for": d.isoformat(),
+                }
+                for d in wanted
+                if d.isoformat() not in taken
+            ]
+            if rows:
+                self.supabase.table("workout_schedule").insert(rows).execute()
+                written += len(rows)
+
+            # Move the watermark whether or not anything was written: the dates
+            # are decided either way, and re-offering a day the athlete already
+            # deleted is exactly what this prevents.
+            self.supabase.table("workout_recurrence").update(
+                {"generated_through": horizon_end(today, horizon_days).isoformat()}
+            ).eq("id", str(rule["id"])).execute()
+        return written
 
 
 class WorkoutSessionsRepository:

--- a/src/shared/workout_recurrence.py
+++ b/src/shared/workout_recurrence.py
@@ -1,0 +1,71 @@
+"""Expanding a weekly pattern into dated occasions (SB-535).
+
+Kept pure and free of the database on purpose: the interesting part is the
+walk — which days a rule owes, and from when — and it is far easier to trust
+when it can be tested without a client at all. The repository does the writing.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+# How far ahead occasions are materialised. Four weeks is enough that Coming up
+# always has the next few sessions in it, and short enough that changing a rule
+# is felt within the month rather than a year from now.
+DEFAULT_HORIZON_DAYS = 28
+
+
+def js_weekday(day: date) -> int:
+    """0 = Sunday .. 6 = Saturday, the convention `byweekday` is stored in.
+
+    Python's own `weekday()` is Monday-based; converting here, once, keeps the
+    off-by-one from being re-derived at every call site.
+    """
+    return (day.weekday() + 1) % 7
+
+
+def due_dates(
+    *,
+    byweekday: list[int],
+    starts_on: date,
+    ends_on: date | None,
+    generated_through: date | None,
+    today: date,
+    horizon_days: int = DEFAULT_HORIZON_DAYS,
+) -> list[date]:
+    """The dates a rule still owes, in order.
+
+    Generation moves forward only. It begins the day after `generated_through`
+    (or at `starts_on` for a rule that has never run), and never before today —
+    so a rule added mid-week does not backfill the days it "should" have
+    produced, and a skipped occasion is never regenerated. That single property
+    is what lets one Thursday be deleted without cancelling Thursdays.
+    """
+    if not byweekday:
+        return []
+
+    first = starts_on
+    if generated_through is not None and generated_through >= first:
+        first = generated_through + timedelta(days=1)
+    # Backfilling the past would put workouts in Coming up that already went by.
+    first = max(first, today)
+
+    last = today + timedelta(days=horizon_days)
+    if ends_on is not None and ends_on < last:
+        last = ends_on
+    if last < first:
+        return []
+
+    wanted = set(byweekday)
+    out: list[date] = []
+    day = first
+    while day <= last:
+        if js_weekday(day) in wanted:
+            out.append(day)
+        day += timedelta(days=1)
+    return out
+
+
+def horizon_end(today: date, horizon_days: int = DEFAULT_HORIZON_DAYS) -> date:
+    """The far edge of the materialisation window, for the watermark."""
+    return today + timedelta(days=horizon_days)

--- a/supabase/migrations/20260802160000_workout_recurrence.sql
+++ b/supabase/migrations/20260802160000_workout_recurrence.sql
@@ -1,0 +1,95 @@
+-- =====================================================
+-- A week that repeats (SB-535)
+-- =====================================================
+-- SB-534 made one occasion schedulable. Matthew's week repeats — Monday
+-- At-Home every Monday, Track Thursday every Thursday — and re-entering that by
+-- hand every week is the kind of chore that stops happening in week three,
+-- after which Coming up is empty again and the screen is back where it started.
+--
+-- A rule GENERATES occasions; it does not replace them. `workout_schedule` stays
+-- the single answer to "what is coming up", so everything built on it in SB-530
+-- and SB-534 — the Start card, the who-scheduled-it line, unscheduling — keeps
+-- working with no knowledge that recurrence exists.
+--
+-- SKIPPING ONE THURSDAY MUST NOT CANCEL THURSDAYS. That is what recurring
+-- calendars are always asked for and rarely support, and it is why generation
+-- carries a watermark rather than reconciling. `generated_through` records the
+-- last date this rule has already produced rows for; generation only ever moves
+-- forward from it. So a generated occasion that gets deleted is simply gone —
+-- there is no reconciliation pass to notice its absence and put it back — while
+-- the rule keeps producing every Thursday after it.
+--
+-- The corollary, deliberately: editing a rule never rewrites the past, and
+-- never revisits dates it has already generated. Changing Thursday to Friday
+-- takes effect from the next ungenerated day forward, which is the only reading
+-- that does not silently rearrange a week the athlete has already seen.
+
+CREATE TABLE workout_recurrence (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,  -- denormalized for RLS
+    template_id UUID NOT NULL REFERENCES workout_templates(id) ON DELETE CASCADE,
+    athlete_id UUID REFERENCES athletes(id) ON DELETE CASCADE,
+    -- Who set the pattern. Carried onto every occasion it generates, so the
+    -- "From Matthew" / "Mine" line on Coming up needs no special case (SB-534).
+    created_by UUID REFERENCES users(user_id) ON DELETE SET NULL,
+    -- Days of the week, 0 = Sunday .. 6 = Saturday — the JavaScript convention,
+    -- because the UI is what produces these. Python converts once, in the
+    -- expansion helper, rather than at every call site.
+    byweekday SMALLINT[] NOT NULL CHECK (
+        array_length(byweekday, 1) BETWEEN 1 AND 7
+        AND byweekday <@ ARRAY[0,1,2,3,4,5,6]::SMALLINT[]
+    ),
+    starts_on DATE NOT NULL,
+    -- NULL = until turned off. An explicit end date covers "in-season"; naming
+    -- seasons as first-class blocks is a bigger idea and not this.
+    ends_on DATE,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    -- The watermark described above. NULL = nothing generated yet.
+    generated_through DATE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_workout_recurrence_athlete ON workout_recurrence (athlete_id, active);
+CREATE INDEX idx_workout_recurrence_user ON workout_recurrence (user_id, active);
+CREATE INDEX idx_workout_recurrence_template ON workout_recurrence (template_id);
+
+COMMENT ON TABLE workout_recurrence IS
+    'A weekly pattern that generates workout_schedule rows (SB-535)';
+COMMENT ON COLUMN workout_recurrence.byweekday IS
+    'Days of week, 0=Sunday..6=Saturday (JS Date.getDay convention)';
+COMMENT ON COLUMN workout_recurrence.generated_through IS
+    'Last date already generated. Generation moves forward only, so a deleted '
+    'occasion never comes back and one skipped Thursday does not cancel Thursdays.';
+
+-- Which rule produced an occasion, if any. NULL = someone scheduled it by hand
+-- (SB-534), and those are untouched by any of this.
+ALTER TABLE workout_schedule
+    ADD COLUMN recurrence_id UUID REFERENCES workout_recurrence(id) ON DELETE SET NULL;
+CREATE INDEX idx_workout_schedule_recurrence ON workout_schedule (recurrence_id);
+
+COMMENT ON COLUMN workout_schedule.recurrence_id IS
+    'The pattern that generated this occasion; NULL when scheduled by hand (SB-535)';
+
+-- =====================================================
+-- RLS — mirrors workout_schedule exactly
+-- =====================================================
+ALTER TABLE workout_recurrence ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "own workout_recurrence select" ON workout_recurrence FOR SELECT
+    USING (user_id = auth.uid());
+CREATE POLICY "own workout_recurrence insert" ON workout_recurrence FOR INSERT
+    WITH CHECK (user_id = auth.uid());
+CREATE POLICY "own workout_recurrence update" ON workout_recurrence FOR UPDATE
+    USING (user_id = auth.uid());
+CREATE POLICY "own workout_recurrence delete" ON workout_recurrence FOR DELETE
+    USING (user_id = auth.uid());
+
+CREATE POLICY "coach workout_recurrence select" ON workout_recurrence FOR SELECT
+    USING (can_coach_athlete(athlete_id));
+CREATE POLICY "coach workout_recurrence insert" ON workout_recurrence FOR INSERT
+    WITH CHECK (can_coach_athlete(athlete_id));
+CREATE POLICY "coach workout_recurrence update" ON workout_recurrence FOR UPDATE
+    USING (can_coach_athlete(athlete_id));
+CREATE POLICY "coach workout_recurrence delete" ON workout_recurrence FOR DELETE
+    USING (can_coach_athlete(athlete_id));

--- a/tests/test_workout_recurrence.py
+++ b/tests/test_workout_recurrence.py
@@ -1,0 +1,176 @@
+"""SB-535: which days a weekly pattern owes, and from when.
+
+The walk is the whole risk in recurrence, so it is tested without a database.
+The property everything else rests on: generation moves forward only. A skipped
+Thursday is never regenerated, and that is what lets one occasion be deleted
+without cancelling the pattern behind it.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from src.shared.workout_recurrence import DEFAULT_HORIZON_DAYS, due_dates, js_weekday
+
+# 2026-08-03 is a Monday.
+MON = date(2026, 8, 3)
+THU = date(2026, 8, 6)
+
+
+def test_js_weekday_matches_the_javascript_convention():
+    """0 = Sunday, because the UI produces these values."""
+    assert js_weekday(date(2026, 8, 2)) == 0  # Sunday
+    assert js_weekday(MON) == 1
+    assert js_weekday(THU) == 4
+    assert js_weekday(date(2026, 8, 8)) == 6  # Saturday
+
+
+def test_expands_a_weekly_pattern_into_dates():
+    days = due_dates(
+        byweekday=[1, 4],  # Monday + Thursday
+        starts_on=MON,
+        ends_on=None,
+        generated_through=None,
+        today=MON,
+        horizon_days=14,
+    )
+    assert days == [
+        date(2026, 8, 3),
+        date(2026, 8, 6),
+        date(2026, 8, 10),
+        date(2026, 8, 13),
+        date(2026, 8, 17),
+    ]
+
+
+def test_never_generates_the_same_day_twice():
+    """The watermark is the whole mechanism: a second pass owes nothing."""
+    first = due_dates(
+        byweekday=[1],
+        starts_on=MON,
+        ends_on=None,
+        generated_through=None,
+        today=MON,
+        horizon_days=14,
+    )
+    again = due_dates(
+        byweekday=[1],
+        starts_on=MON,
+        ends_on=None,
+        generated_through=max(first),
+        today=MON,
+        horizon_days=14,
+    )
+    assert first
+    assert again == []
+
+
+def test_a_skipped_occasion_is_not_regenerated():
+    """Delete one Thursday and the rule keeps producing every Thursday after it
+    — the thing recurring calendars are always asked for."""
+    # The rule has already generated through 2026-08-20; the athlete deleted the
+    # 13th. The next pass must pick up after the watermark, not fill the hole.
+    days = due_dates(
+        byweekday=[4],
+        starts_on=MON,
+        ends_on=None,
+        generated_through=date(2026, 8, 20),
+        today=MON,
+        horizon_days=28,
+    )
+    assert date(2026, 8, 13) not in days
+    assert days == [date(2026, 8, 27)]
+
+
+def test_does_not_backfill_the_past():
+    """A rule added mid-season owes nothing for the days it "should" have
+    produced — those already went by."""
+    days = due_dates(
+        byweekday=[1],
+        starts_on=date(2026, 6, 1),
+        ends_on=None,
+        generated_through=None,
+        today=MON,
+        horizon_days=7,
+    )
+    assert all(d >= MON for d in days)
+    assert days == [date(2026, 8, 3), date(2026, 8, 10)]
+
+
+def test_stops_at_an_end_date():
+    days = due_dates(
+        byweekday=[1, 4],
+        starts_on=MON,
+        ends_on=date(2026, 8, 10),
+        generated_through=None,
+        today=MON,
+        horizon_days=28,
+    )
+    assert days == [date(2026, 8, 3), date(2026, 8, 6), date(2026, 8, 10)]
+
+
+def test_an_ended_rule_owes_nothing():
+    assert (
+        due_dates(
+            byweekday=[1],
+            starts_on=date(2026, 6, 1),
+            ends_on=date(2026, 7, 1),
+            generated_through=None,
+            today=MON,
+            horizon_days=28,
+        )
+        == []
+    )
+
+
+def test_a_rule_that_starts_inside_the_window_begins_there():
+    days = due_dates(
+        byweekday=[1],
+        starts_on=date(2026, 8, 10),
+        ends_on=None,
+        generated_through=None,
+        today=MON,
+        horizon_days=28,
+    )
+    assert days == [date(2026, 8, 10), date(2026, 8, 17), date(2026, 8, 24), date(2026, 8, 31)]
+
+
+def test_a_rule_starting_beyond_the_horizon_owes_nothing_yet():
+    """Not "never" — the window moves, and it will be picked up when it arrives.
+    Materialising a season in advance is what the horizon exists to avoid."""
+    days = due_dates(
+        byweekday=[1],
+        starts_on=date(2026, 9, 14),
+        ends_on=None,
+        generated_through=None,
+        today=MON,
+        horizon_days=28,
+    )
+    assert days == []
+
+
+def test_no_days_selected_owes_nothing():
+    assert (
+        due_dates(
+            byweekday=[],
+            starts_on=MON,
+            ends_on=None,
+            generated_through=None,
+            today=MON,
+        )
+        == []
+    )
+
+
+def test_the_horizon_bounds_how_far_ahead_it_materialises():
+    """Four weeks: enough that Coming up is never empty, short enough that a
+    changed rule is felt this month rather than next year."""
+    days = due_dates(
+        byweekday=[0, 1, 2, 3, 4, 5, 6],
+        starts_on=MON,
+        ends_on=None,
+        generated_through=None,
+        today=MON,
+    )
+    assert len(days) == DEFAULT_HORIZON_DAYS + 1
+    assert max(days) == date(2026, 8, 31)


### PR DESCRIPTION
## Summary

Weekly patterns that fill Coming up without weekly manual work (SB-535). A rule **generates** occasions; it does not replace them — `workout_schedule` stays the single answer to "what is coming up", so the Start card, the who-scheduled-it line and unscheduling keep working with no knowledge that recurrence exists.

- **`workout_recurrence`**: template, `byweekday`, `starts_on`, optional `ends_on`, `active`, `created_by`. `workout_schedule.recurrence_id` marks what a rule produced; NULL is still a hand-scheduled occasion.
- **Generation happens on read.** Listing the schedule materialises whatever the active rules owe, so there is no cron job to forget about. A second read the same day writes nothing.
- **One control, two shapes.** `ScheduleWorkout` gains an Once / Every week toggle and weekday chips — putting repeats behind a separate screen would make the common case (Matthew's in-season week) the hidden one. Still one component for both surfaces.
- **Plans says what repeats** ("Every Mon, Thu") with **Stop repeating**, which patches `active: false` rather than deleting.

### Skipping one Thursday must not cancel Thursdays

The mechanism is a watermark, not reconciliation. `generated_through` records the last date a rule has produced, and generation only ever moves forward from it — so a deleted occasion is simply gone, because nothing looks back to notice it missing. The watermark advances **even on a pass that writes nothing**, otherwise a hand-scheduled day deleted later would let the rule recreate it, which is the same bug through the side door. That case has its own test.

The corollary is deliberate: editing a rule never rewrites the past and never revisits days it already generated. Moving Thursday to Friday takes effect from the next ungenerated day.

### The ticket's open questions

Answered by consistency with what shipped, not by inventing anything:

- **Athlete or coach?** Both — SB-534 already decided scheduling is not a coach-only verb.
- **Turning a rule off**: a patch, not a delete. Future occasions stop; everything already generated, and anything logged against it, stays.
- **Rewriting the past**: no, per the watermark above.
- **End condition**: explicit optional `ends_on`. Seasons as first-class blocks is a bigger idea and out of scope.

Weekday numbering is 0 = Sunday, matching `Date.getDay()`, since the UI produces the values; Python converts once, in the expansion helper.

## Test plan

- [x] `cd frontend && npm run type-check && npx vitest run` — 412 passing, `npm run build`
- [x] `uv run --project backend ruff check/format backend/ && python -m pytest backend/tests/ -q` — 401 passing
- [x] `uv run ruff check/format src/ tests/ && uv run pytest tests/ -q` — 197 passing, coverage 60.4%
- [x] The date walk is a pure module with its own tests — expansion, watermark, no backfill, `ends_on`, horizon
- [x] Mutation-tested (11): watermark ignored, backfilling the past, `ends_on` ignored, weekday off-by-one, duplicate on a hand-scheduled day, inactive rule generating, watermark not advancing on a no-op pass, unsorted description, repeat with no days, repeat posting a one-off, inactive pattern shown as live
- [ ] Migration applies on Supabase
- [ ] Set "every Mon, Thu" on a plan; Coming up fills, rows read "From Matthew"
- [ ] Delete one generated occasion; it does not reappear, later ones stay
- [ ] Stop repeating; future occasions stop and the existing ones remain

Fixes SB-535

🤖 Generated with [Claude Code](https://claude.com/claude-code)