### PR TITLE
fix: the card shows circuits, and stops claiming one round

### DIFF
--- a/frontend/src/components/WorkoutTemplateCard.vue
+++ b/frontend/src/components/WorkoutTemplateCard.vue
@@ -9,7 +9,13 @@
         <h3 class="text-lg font-bold text-gray-900 leading-tight">{{ template.name }}</h3>
         <div class="mt-1.5 flex flex-wrap items-center gap-2">
           <span class="inline-flex items-center gap-1 rounded-full bg-brand-50 px-2 py-0.5 text-xs font-semibold text-brand-700 capitalize">
-            <Repeat class="w-3 h-3" /> {{ template.type }} · {{ template.rounds }} {{ template.rounds === 1 ? 'round' : 'rounds' }}
+            <!-- Rounds only when the template's own count still means something:
+                 a circuit template keeps rounds = 1 while its real counts live
+                 on its blocks, so this read "1 Round" on a workout done twice
+                 (SB-543). -->
+            <Repeat class="w-3 h-3" /> {{ template.type
+            }}<template v-if="showTemplateRounds">
+              · {{ template.rounds }} {{ template.rounds === 1 ? 'round' : 'rounds' }}</template>
           </span>
           <span
             v-if="template.scheduled_for"
@@ -95,8 +101,21 @@
           {{ sec.title }}
           <span class="text-gray-300 font-medium">· {{ sec.items.length }}</span>
         </h4>
+        <!-- Circuits, where the athlete actually looks. They have been data
+             since SB-527 and visible only on the print sheet since SB-528, so
+             the screen has been saying "1 Round" about a workout done twice
+             (SB-543). -->
+        <div v-for="(g, gi) in sec.groups" :key="g.block?.id ?? `loose-${gi}`">
+          <div
+            v-if="g.block"
+            class="mt-2 mb-1 flex items-baseline gap-2 text-[11px] font-bold uppercase tracking-wide text-brand-700"
+            data-testid="circuit-bar"
+          >
+            {{ g.block.label }}
+            <span v-if="g.rounds > 1" class="text-gray-400">×{{ g.rounds }}</span>
+          </div>
         <ul>
-          <template v-for="(row, ri) in sec.rows" :key="row.kind === 'group' ? row.key : row.item.id">
+          <template v-for="(row, ri) in g.rows" :key="row.kind === 'group' ? row.key : row.item.id">
             <!-- Alternatives are one choice, not a checklist (SB-448). -->
             <li
               v-if="row.kind === 'group'"
@@ -153,6 +172,15 @@
           </li>
           </template>
         </ul>
+          <!-- The four-minute water break is prescription, not decoration. -->
+          <p
+            v-if="g.restAfter"
+            class="mt-1 mb-1 text-[11px] font-medium text-gray-400"
+            data-testid="circuit-rest"
+          >
+            Rest {{ fmtRest(g.restAfter) }}
+          </p>
+        </div>
       </section>
     </div>
   </div>
@@ -165,6 +193,7 @@ import type { Exercise, TemplateItem, WorkoutSectionKey, WorkoutTemplate } from 
 import ExerciseDescription from '@/components/ExerciseDescription.vue'
 import { SECTIONS, prettifyKey } from '@/utils/workoutPayload'
 import { groupOptionItems } from '@/utils/optionGroups'
+import { groupByBlock, roundsFor, templateRoundsAreMeaningful } from '@/utils/circuits'
 import { targetPills } from '@/utils/targets'
 import { formatDayMonth, formatRelativeTime } from '@/utils/format'
 
@@ -252,12 +281,35 @@ const sections = computed(() => {
     key,
     title: SECTIONS.find((s) => s.key === key)?.label ?? prettifyKey(key),
     ...(ACCENT[key as WorkoutSectionKey] ?? FALLBACK_ACCENT),
-    rows: groupOptionItems(byKey.get(key)!),
+    // Circuits first, then alternatives within each — the same order the print
+    // sheet resolves them in, via the same helper (SB-543).
+    groups: groupByBlock(byKey.get(key)!, props.template.blocks ?? []).map((g) => ({
+      block: g.block,
+      rounds: roundsFor(g, props.template.rounds),
+      restAfter: g.block?.rest_after_seconds ?? null,
+      rows: groupOptionItems(g.items),
+    })),
     items: byKey.get(key)!,
   }))
 })
 
 const pills = targetPills
+
+/**
+ * Whether to show the template's own round count in the header.
+ *
+ * A template whose rounds live on its blocks keeps `rounds = 1`, so the pill
+ * read "Circuit · 1 Round" on a workout that is two circuits done twice —
+ * stating the opposite of the prescription (SB-543).
+ */
+const showTemplateRounds = computed(() => templateRoundsAreMeaningful(props.template.blocks))
+
+/** "4:00" — the rest between circuits, as the coach wrote it. */
+const fmtRest = (seconds: number): string => {
+  const m = Math.floor(seconds / 60)
+  const s = Math.round(seconds % 60)
+  return m ? `${m}:${String(s).padStart(2, '0')}` : `${s}s`
+}
 
 // Which exercises have their description open. Per-item rather than one at a
 // time: an athlete comparing "Side plank (L)" with "(R)" should be able to see

--- a/frontend/src/components/__tests__/WorkoutTemplateCard.test.ts
+++ b/frontend/src/components/__tests__/WorkoutTemplateCard.test.ts
@@ -318,3 +318,67 @@ describe('WorkoutTemplateCard — exercise descriptions (SB-525)', () => {
     expect(w.get('[data-testid="exercise-description"]').text()).toContain('No description added')
   })
 })
+
+
+// --- SB-543: circuits on the card, not only on the print sheet --------------
+
+const circuitTemplate: WorkoutTemplate = {
+  ...template,
+  // A circuit template keeps rounds = 1; the real counts live on its blocks.
+  rounds: 1,
+  blocks: [
+    { id: 'b1', template_id: 't1', label: 'Circuit A', position: 0, rounds: 2, rest_after_seconds: 240 },
+    { id: 'b2', template_id: 't1', label: 'Circuit B', position: 1, rounds: 1, rest_after_seconds: null },
+  ],
+  items: [
+    ti({ exercise_key: 'easy_jog', section: 'warmup', position: 0, target_duration_seconds: 480 }),
+    ti({ exercise_key: 'lunge', section: 'main', position: 1, block_id: 'b1', target_duration_seconds: 60 }),
+    ti({ exercise_key: 'side_plank', section: 'main', position: 2, block_id: 'b1', target_duration_seconds: 60 }),
+    ti({ exercise_key: 'bird_dog', section: 'main', position: 3, block_id: 'b2', target_duration_seconds: 60 }),
+  ],
+}
+
+describe('WorkoutTemplateCard — circuits (SB-543)', () => {
+  it('shows each circuit by name', () => {
+    // They have been data since SB-527 and visible only on paper since SB-528.
+    const w = mount(WorkoutTemplateCard, { props: { template: circuitTemplate } })
+    const bars = w.findAll('[data-testid="circuit-bar"]').map((b) => b.text())
+    expect(bars).toHaveLength(2)
+    expect(bars[0]).toContain('Circuit A')
+    expect(bars[0]).toContain('×2')
+    expect(bars[1]).toContain('Circuit B')
+  })
+
+  it('does not mark a single-round circuit with a multiplier', () => {
+    const w = mount(WorkoutTemplateCard, { props: { template: circuitTemplate } })
+    expect(w.findAll('[data-testid="circuit-bar"]')[1].text()).not.toContain('×')
+  })
+
+  it('shows the rest between circuits — it is prescription, not decoration', () => {
+    const w = mount(WorkoutTemplateCard, { props: { template: circuitTemplate } })
+    const rests = w.findAll('[data-testid="circuit-rest"]').map((r) => r.text())
+    expect(rests).toHaveLength(1)
+    expect(rests[0]).toContain('4:00')
+  })
+
+  it('never claims "1 Round" about a workout done twice', () => {
+    // The bug: workout_templates.rounds stays 1 once rounds live on blocks, so
+    // the header stated the opposite of the prescription.
+    const w = mount(WorkoutTemplateCard, { props: { template: circuitTemplate } })
+    expect(w.text()).not.toContain('1 round')
+    expect(w.text()).toContain('circuit')
+  })
+
+  it('leaves the warm-up ungrouped', () => {
+    const w = mount(WorkoutTemplateCard, { props: { template: circuitTemplate } })
+    // Four items, two circuit bars — the warm-up gets no bar of its own.
+    expect(w.findAll('[data-testid="circuit-bar"]')).toHaveLength(2)
+    expect(w.text()).toContain('Warm-up')
+  })
+
+  it('renders a blockless template exactly as before', () => {
+    const w = mount(WorkoutTemplateCard, { props: { template } })
+    expect(w.find('[data-testid="circuit-bar"]').exists()).toBe(false)
+    expect(w.text()).toContain('2 rounds')
+  })
+})

--- a/frontend/src/utils/__tests__/circuits.test.ts
+++ b/frontend/src/utils/__tests__/circuits.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import {
+  groupByBlock,
+  roundsFor,
+  templateRoundsAreMeaningful,
+} from '@/utils/circuits'
+import type { TemplateBlock, TemplateItem } from '@/types/workout'
+
+const item = (id: string, position: number, block_id: string | null = null): TemplateItem =>
+  ({
+    id,
+    exercise_key: id,
+    section: 'main',
+    position,
+    block_id,
+    target_reps: null,
+    target_duration_seconds: null,
+    target_load_kg: null,
+    target_distance_m: null,
+    rest_seconds: null,
+    variant: null,
+    notes: null,
+  }) as TemplateItem
+
+const block = (id: string, rounds: number, rest: number | null = null): TemplateBlock => ({
+  id,
+  template_id: 't1',
+  label: `Circuit ${id.toUpperCase()}`,
+  position: 0,
+  rounds,
+  rest_after_seconds: rest,
+})
+
+describe('groupByBlock (SB-543)', () => {
+  it('splits a section into its circuits, in order', () => {
+    const groups = groupByBlock(
+      [item('a', 0, 'b1'), item('b', 1, 'b1'), item('c', 2, 'b2')],
+      [block('b1', 2), block('b2', 1)],
+    )
+    expect(groups).toHaveLength(2)
+    expect(groups[0].block?.id).toBe('b1')
+    expect(groups[0].items.map((i) => i.id)).toEqual(['a', 'b'])
+    expect(groups[1].items.map((i) => i.id)).toEqual(['c'])
+  })
+
+  it('keeps items outside any circuit in their own group', () => {
+    // The warm-up is not a circuit and must render as it always did.
+    const groups = groupByBlock([item('warm', 0), item('a', 1, 'b1')], [block('b1', 2)])
+    expect(groups[0].block).toBeNull()
+    expect(groups[0].items.map((i) => i.id)).toEqual(['warm'])
+    expect(groups[1].block?.id).toBe('b1')
+  })
+
+  it('partitions rather than buckets, so a circuit stays contiguous', () => {
+    // Same block id either side of a loose item: three groups, not two. The
+    // coach's order is the prescription — reordering it would be a rewrite.
+    const groups = groupByBlock(
+      [item('a', 0, 'b1'), item('loose', 1), item('b', 2, 'b1')],
+      [block('b1', 2)],
+    )
+    expect(groups.map((g) => g.items.map((i) => i.id))).toEqual([['a'], ['loose'], ['b']])
+  })
+
+  it('treats an item pointing at a missing block as loose', () => {
+    const groups = groupByBlock([item('a', 0, 'gone')], [])
+    expect(groups[0].block).toBeNull()
+  })
+
+  it('has nothing to group when there are no items', () => {
+    expect(groupByBlock([], [block('b1', 2)])).toEqual([])
+  })
+})
+
+describe('roundsFor (SB-543)', () => {
+  it('takes the rounds from the circuit', () => {
+    const [g] = groupByBlock([item('a', 0, 'b1')], [block('b1', 2)])
+    expect(roundsFor(g, 1)).toBe(2)
+  })
+
+  it('falls back to the template for a blockless group', () => {
+    const [g] = groupByBlock([item('a', 0)], [])
+    expect(roundsFor(g, 3)).toBe(3)
+  })
+
+  it('is one when neither says otherwise', () => {
+    const [g] = groupByBlock([item('a', 0)], [])
+    expect(roundsFor(g, undefined)).toBe(1)
+  })
+})
+
+describe('templateRoundsAreMeaningful (SB-543)', () => {
+  it('is false once rounds live on blocks', () => {
+    // `workout_templates.rounds` stays 1 for a circuit template, so showing it
+    // says "1 Round" on a workout done twice.
+    expect(templateRoundsAreMeaningful([block('b1', 2)])).toBe(false)
+  })
+
+  it('is true for a simple template', () => {
+    expect(templateRoundsAreMeaningful([])).toBe(true)
+    expect(templateRoundsAreMeaningful(undefined)).toBe(true)
+  })
+})

--- a/frontend/src/utils/circuits.ts
+++ b/frontend/src/utils/circuits.ts
@@ -1,0 +1,53 @@
+import type { TemplateBlock, TemplateItem } from '@/types/workout'
+
+export interface BlockGroup {
+  /** The circuit these items belong to, or null for items outside any. */
+  block: TemplateBlock | null
+  items: TemplateItem[]
+}
+
+/**
+ * Split a section's items into circuits, in position order (SB-527).
+ *
+ * Partitioned rather than bucketed: a circuit stays contiguous, so the order
+ * the coach wrote survives and an item that sits between two circuits does not
+ * get swept into either. Items outside any block form an unlabelled group that
+ * renders exactly as it did before circuits existed.
+ *
+ * Extracted from the print sheet (SB-528) when the card had to learn the same
+ * shape (SB-543) — two copies of this would drift, and the screen disagreeing
+ * with the paper about what the workout is, is the bug being fixed.
+ */
+export function groupByBlock(items: TemplateItem[], blocks: TemplateBlock[]): BlockGroup[] {
+  const byId = new Map(blocks.map((b) => [b.id, b]))
+  const groups: BlockGroup[] = []
+  for (const item of items) {
+    const block = (item.block_id && byId.get(item.block_id)) || null
+    const last = groups[groups.length - 1]
+    if (last && last.block?.id === block?.id) last.items.push(item)
+    else groups.push({ block, items: [item] })
+  }
+  return groups
+}
+
+/**
+ * How many rounds this group is done for.
+ *
+ * Rounds live on the circuit (SB-527); the template's own `rounds` is the
+ * fallback for the blockless case — every template until that migration
+ * backfilled, and any simple one since.
+ */
+export function roundsFor(group: BlockGroup, templateRounds: number | undefined): number {
+  return group.block?.rounds ?? templateRounds ?? 1
+}
+
+/**
+ * True when a template's own `rounds` still means something.
+ *
+ * Once its rounds live on blocks, `workout_templates.rounds` stays 1 and
+ * showing it reads as "1 Round" on a workout done twice — the card stated the
+ * opposite of the prescription for as long as circuits have existed (SB-543).
+ */
+export function templateRoundsAreMeaningful(blocks: TemplateBlock[] | undefined): boolean {
+  return !blocks?.length
+}

--- a/frontend/src/views/WorkoutPrintView.vue
+++ b/frontend/src/views/WorkoutPrintView.vue
@@ -152,6 +152,7 @@ import { apiCall } from '@/config/api'
 import type { Exercise, TemplateBlock, TemplateItem, WorkoutTemplate } from '@/types/workout'
 import type { Athlete } from '@/types/coach'
 import { groupOptionItems } from '@/utils/optionGroups'
+import { groupByBlock, roundsFor } from '@/utils/circuits'
 import { fmtRange, hrZoneText, restText } from '@/utils/targets'
 import { useActingAthlete } from '@/composables/useActingAthlete'
 
@@ -208,7 +209,6 @@ const SECTION_LABELS: Record<string, string> = {
  */
 const sections = computed(() => {
   const items = [...(template.value?.items ?? [])].sort((a, b) => a.position - b.position)
-  const blocksById = new Map((template.value?.blocks ?? []).map((b) => [b.id, b]))
 
   const order: string[] = []
   const by: Record<string, TemplateItem[]> = {}
@@ -222,23 +222,17 @@ const sections = computed(() => {
   }
 
   return order.map((key) => {
-    // Partition in position order, so a circuit stays contiguous on the page.
-    const groups: { block: TemplateBlock | null; items: TemplateItem[] }[] = []
-    for (const item of by[key]) {
-      const block = (item.block_id && blocksById.get(item.block_id)) || null
-      const last = groups[groups.length - 1]
-      if (last && last.block?.id === block?.id) last.items.push(item)
-      else groups.push({ block, items: [item] })
-    }
+    // Partitioned in position order so a circuit stays contiguous on the page.
+    // Shared with the card, which has to agree with the paper about what the
+    // workout is (SB-543).
+    const groups = groupByBlock(by[key], template.value?.blocks ?? [])
     return {
       key,
       label: SECTION_LABELS[key] ?? key.replace(/_/g, ' '),
       items: by[key],
       groups: groups.map((g) => ({
         block: g.block,
-        // Rounds live on the circuit; fall back to the template for the
-        // blockless case, which is every template until SB-527 backfilled.
-        rounds: g.block?.rounds ?? (template.value?.rounds ?? 1),
+        rounds: roundsFor(g, template.value?.rounds),
         restAfter: g.block?.rest_after_seconds ?? null,
         // "Pick one of N" alternatives fold into a single row (SB-448) —
         // printed flat, the aerobic day told Gabe to do all three.


### PR DESCRIPTION
## Summary

Circuits have been data since SB-527, and SB-528 taught the **print sheet** to render them. The card — what the athlete and the coach actually look at on screen — never learned.

Gabe's Monday workout is two circuits: eleven movements done twice with a four-minute water break, then six more. On the card it read as a flat `MAIN · 17`.

Worse, the header said **`Circuit · 1 Round`**. That is `workout_templates.rounds`, which stays 1 precisely because a circuit template's real counts live on its blocks. The screen was stating the opposite of the prescription while the paper had it right — a strange place to end up, given paper was meant to be the fallback.

- Items group by circuit on the card, in position order, with the label and `×2` when a circuit repeats.
- Trailing rest renders ("Rest 4:00") — it is prescription, not decoration.
- The rounds pill disappears when a template's own `rounds` no longer means anything. Blockless templates are untouched.
- **Grouping extracted, not copied** (`utils/circuits.ts`). Two implementations of "which items belong to which circuit" would drift, and the screen disagreeing with the sheet is the bug being fixed — `WorkoutPrintView` now reads from the same helper.

## How this came up

Checking whether Gabe's Monday template needed deleting and rebuilding. Most of what looked like bad data was the card not showing what the data already said. The mis-mapped exercises on that template ("Jump rope · Left" where the card says "1-leg jump rope", "Lunges · Left" where it says "Side-step lunge (L)") are real and separate — three of those movements have no catalog entry yet.

## Test plan

- [x] `cd frontend && npm run type-check && npx vitest run` — 428 passing, `npm run build`
- [x] `uv run --project backend ruff check backend/ && python -m pytest backend/tests/ -q` — 401 passing
- [x] `uv run ruff check src/ tests/ && uv run pytest tests/ -q` — 197 passing
- [x] Mutation-tested (5): circuit bar suppressed, multiplier on a single round, rest dropped, header rounds always shown, grouping bucketed instead of partitioned — the last one is caught by the print view's own tests too, which is the point of sharing the helper
- [ ] Gabe's Monday template on screen: two circuits, "Circuit A ×2", the 4:00 rest, and no "1 Round"
- [ ] The print sheet is unchanged

Fixes SB-543

🤖 Generated with [Claude Code](https://claude.com/claude-code)