### PR TITLE
fix: the logger knows what it was asked to do

### DIFF
--- a/frontend/src/types/workout.ts
+++ b/frontend/src/types/workout.ts
@@ -240,6 +240,10 @@ export interface BuilderItem {
 /** One logged set in the API payload. Only the used dimensions are filled. */
 export interface SessionSetInput {
   exercise_key: string
+  // Which prescribed item this set answers (SB-527). Null for an ad-hoc set
+  // with no prescription behind it. Without it "lunge, round 1, 45s" cannot be
+  // attributed — `lunge` appears several times in one template (SB-545).
+  template_item_id?: string | null
   // Measured HR / cadence / speed (SB-447). Speed is canonical kph.
   hr_bpm_avg?: number | null
   hr_bpm_max?: number | null
@@ -276,6 +280,11 @@ export interface WorkoutSessionInput {
  * Loads are entered in lb (US coach), stored as kg.
  */
 export interface LoggerAttempt {
+  // Which round of the circuit this attempt is (SB-545). Rounds live on the
+  // attempt rather than the row because a set is what happens in a round —
+  // one exercise done twice is two sets with different round numbers, which is
+  // exactly the R1/R2 columns the print sheet has always had.
+  round_number: number | null
   reps: number | null
   duration_s: number | null
   load_lb: number | null
@@ -293,7 +302,9 @@ export interface LoggerAttempt {
 export interface LoggerRow {
   uid: number
   exercise: Exercise
-  round_number: number | null
+  // The prescribed item this row answers; null for anything the athlete added
+  // themselves, and for ad-hoc logging with no template behind it (SB-531).
+  template_item_id: string | null
   variant: string | null
   notes: string | null
   attempts: LoggerAttempt[]

--- a/frontend/src/utils/__tests__/sessionPayload.test.ts
+++ b/frontend/src/utils/__tests__/sessionPayload.test.ts
@@ -36,7 +36,7 @@ const attempt = (over: Partial<LoggerAttempt> = {}): LoggerAttempt => ({ ...blan
 const row = (key: string, over: Partial<LoggerRow> = {}): LoggerRow => ({
   uid: uid++,
   exercise: ex(key),
-  round_number: null,
+  template_item_id: null,
   variant: null,
   notes: null,
   attempts: [blankAttempt()],
@@ -127,16 +127,18 @@ describe('buildSessionPayload', () => {
     expect(p.sets).toHaveLength(0)
   })
 
-  it('carries round_number + trims variant, notes on first set only', () => {
+  it('carries each attempt\'s round + trims variant, notes on first set only', () => {
+    // Rounds moved onto the attempt (SB-545): one exercise done twice is two
+    // sets in different rounds, not two sets sharing one round.
     const p = buildSessionPayload(meta, [
       row('pushups', {
-        round_number: 2,
         variant: '  left  ',
         notes: '  felt strong  ',
-        attempts: [attempt({ reps: 10 }), attempt({ reps: 9 })],
+        attempts: [attempt({ reps: 10, round_number: 1 }), attempt({ reps: 9, round_number: 2 })],
       }),
     ])
-    expect(p.sets[0]).toMatchObject({ round_number: 2, variant: 'left', notes: 'felt strong' })
+    expect(p.sets[0]).toMatchObject({ round_number: 1, variant: 'left', notes: 'felt strong' })
+    expect(p.sets[1]).toMatchObject({ round_number: 2 })
     expect(p.sets[1].notes).toBeNull()
   })
 })
@@ -165,7 +167,85 @@ describe('templateToRows', () => {
     expect(rows[0].exercise.measures).toEqual(['reps']) // resolved from catalog
     expect(rows[1].exercise.display_name).toBe('plank') // fallback (not in catalog)
     expect(rows[1].variant).toBe('front') // carried from template item
-    expect(rows.every((r) => r.attempts.length === 1)).toBe(true)
+    // The template says three rounds, so each exercise arrives with three
+    // numbered attempts (SB-545) rather than one empty box and a Round field
+    // nobody filled in.
+    expect(rows.every((r) => r.attempts.length === 3)).toBe(true)
+    expect(rows[0].attempts.map((a) => a.round_number)).toEqual([1, 2, 3])
+    // And every row names the prescribed item it answers (SB-527).
+    expect(rows.map((r) => r.template_item_id)).toEqual(['i1', 'i2'])
+  })
+})
+
+describe('templateToRows — circuits (SB-545)', () => {
+  const circuitTpl: WorkoutTemplate = {
+    id: 't1',
+    name: 'Monday At-Home',
+    type: 'circuit',
+    rounds: 1,
+    source: null,
+    notes: null,
+    created_at: null,
+    blocks: [
+      { id: 'b1', template_id: 't1', label: 'Circuit A', position: 0, rounds: 2, rest_after_seconds: 240 },
+      { id: 'b2', template_id: 't1', label: 'Circuit B', position: 1, rounds: 1, rest_after_seconds: null },
+    ],
+    items: [
+      { id: 'w1', exercise_key: 'easy_jog', section: 'warmup', position: 0, block_id: null, target_reps: null, target_duration_seconds: 480, target_load_kg: null, target_distance_m: null, rest_seconds: null, variant: null, notes: null },
+      { id: 'a1', exercise_key: 'lunge', section: 'main', position: 1, block_id: 'b1', target_reps: null, target_duration_seconds: 60, target_load_kg: null, target_distance_m: null, rest_seconds: null, variant: null, notes: null },
+      { id: 'b1i', exercise_key: 'bird_dog', section: 'main', position: 2, block_id: 'b2', target_reps: null, target_duration_seconds: 60, target_load_kg: null, target_distance_m: null, rest_seconds: null, variant: null, notes: null },
+    ],
+  }
+
+  it('lays out a two-round circuit as two numbered attempts', () => {
+    const rows = templateToRows(circuitTpl, new Map(), 1)
+    const lunge = rows.find((r) => r.exercise.key === 'lunge')!
+    expect(lunge.attempts.map((a) => a.round_number)).toEqual([1, 2])
+  })
+
+  it('leaves a single-round circuit with one unnumbered attempt', () => {
+    // There is no "round 1 of 1" worth stating.
+    const rows = templateToRows(circuitTpl, new Map(), 1)
+    const birdDog = rows.find((r) => r.exercise.key === 'bird_dog')!
+    expect(birdDog.attempts).toHaveLength(1)
+    expect(birdDog.attempts[0].round_number).toBeNull()
+  })
+
+  it('does not give the warm-up the circuit\'s rounds', () => {
+    const rows = templateToRows(circuitTpl, new Map(), 1)
+    const jog = rows.find((r) => r.exercise.key === 'easy_jog')!
+    expect(jog.attempts).toHaveLength(1)
+  })
+
+  it('links every prefilled row to the item it answers', () => {
+    // The whole point: `lunge` appears several times in one template, so a set
+    // is unattributable without this (SB-527).
+    const rows = templateToRows(circuitTpl, new Map(), 1)
+    expect(rows.map((r) => r.template_item_id)).toEqual(['w1', 'a1', 'b1i'])
+  })
+})
+
+describe('buildSessionPayload — the prescribed item (SB-545)', () => {
+  it('sends template_item_id on every set of a prefilled row', () => {
+    const p = buildSessionPayload(meta, [
+      row('lunge', {
+        template_item_id: 'a1',
+        attempts: [attempt({ reps: 10, round_number: 1 }), attempt({ reps: 9, round_number: 2 })],
+      }),
+    ])
+    expect(p.sets.map((s) => s.template_item_id)).toEqual(['a1', 'a1'])
+  })
+
+  it('leaves it null for something the athlete added themselves', () => {
+    const p = buildSessionPayload(meta, [row('pushups', { attempts: [attempt({ reps: 8 })] })])
+    expect(p.sets[0].template_item_id).toBeNull()
+  })
+
+  it('carries it on a tick-box movement too', () => {
+    const p = buildSessionPayload(meta, [
+      { ...row('skywalker', { template_item_id: 'w2' }), exercise: ex('skywalker', []) },
+    ])
+    expect(p.sets[0].template_item_id).toBe('w2')
   })
 })
 

--- a/frontend/src/utils/sessionPayload.ts
+++ b/frontend/src/utils/sessionPayload.ts
@@ -8,6 +8,7 @@ import type {
   WorkoutType,
 } from '@/types/workout'
 import { lbToKg } from '@/utils/workoutPayload'
+import { groupByBlock, roundsFor } from '@/utils/circuits'
 
 /** Felt options: emoji shown to the coach → stored how_felt string. */
 export const FELT_OPTIONS: { emoji: string; value: string; label: string }[] = [
@@ -67,9 +68,10 @@ export function defaultSessionName(dateOnly: string): string {
   return `${WEEKDAYS_LONG[date.getDay()]} ${d} ${MONTHS_SHORT[m - 1]}`
 }
 
-/** A fresh empty attempt (one set of an exercise). */
-export function blankAttempt(): LoggerAttempt {
+/** A fresh empty attempt (one set of an exercise), optionally in a round. */
+export function blankAttempt(round: number | null = null): LoggerAttempt {
   return {
+    round_number: round,
     reps: null,
     duration_s: null,
     load_lb: null,
@@ -84,6 +86,8 @@ export function blankAttempt(): LoggerAttempt {
 
 /** An attempt with no measurable value — dropped from the payload. */
 function isEmptyAttempt(a: LoggerAttempt): boolean {
+  // round_number is structure, not a measurement — an attempt carrying only
+  // its round number is still an attempt nobody filled in.
   return (
     a.reps == null &&
     a.duration_s == null &&
@@ -125,7 +129,8 @@ export function buildSessionPayload(meta: SessionMeta, rows: LoggerRow[]): Worko
     if (filled.length === 0 && row.exercise.measures.length === 0) {
       sets.push({
         exercise_key: row.exercise.key,
-        round_number: row.round_number,
+        template_item_id: row.template_item_id,
+        round_number: row.attempts[0]?.round_number ?? null,
         set_index: null,
         variant: row.variant?.trim() || null,
         notes: row.notes?.trim() || null,
@@ -136,7 +141,10 @@ export function buildSessionPayload(meta: SessionMeta, rows: LoggerRow[]): Worko
     filled.forEach((a, i) => {
       sets.push({
         exercise_key: row.exercise.key,
-        round_number: row.round_number,
+        // The link SB-527 added and nothing ever wrote (SB-545). Without it
+        // "did he do what was prescribed?" is not answerable by query.
+        template_item_id: row.template_item_id,
+        round_number: a.round_number,
         set_index: multi ? i + 1 : null,
         variant: row.variant?.trim() || null,
         reps: a.reps,
@@ -167,26 +175,48 @@ export function buildSessionPayload(meta: SessionMeta, rows: LoggerRow[]): Worko
 }
 
 /**
- * Prefill logger rows from a template's items (ordered by position), one blank
- * attempt each. The coach logs actuals against the prescription. `byKey` maps
- * exercise_key → catalog Exercise (for display name + which measures to show).
+ * Prefill logger rows from a template's items, in position order.
+ *
+ * An exercise in a circuit done twice arrives with two attempts, already
+ * numbered R1 and R2 (SB-545). Before this the athlete got one empty box and an
+ * empty "Round" field, and recording the prescription as written meant tapping
+ * "+ Add set" on eleven cards and typing twenty-two round numbers — so the
+ * rounds simply never got logged.
+ *
+ * Every row carries the `template_item_id` it answers, which is what makes
+ * "did he do what was prescribed?" a query rather than a guess (SB-527).
+ *
+ * `byKey` maps exercise_key → catalog Exercise (display name + which measures
+ * to show).
  */
 export function templateToRows(
   tpl: WorkoutTemplate,
   byKey: Map<string, Exercise>,
   startUid: number,
 ): LoggerRow[] {
-  return tpl.items
-    .slice()
-    .sort((a, b) => a.position - b.position)
-    .map((it, i) => ({
+  const items = [...tpl.items].sort((a, b) => a.position - b.position)
+  const roundsByItem = new Map<string, number>()
+  for (const group of groupByBlock(items, tpl.blocks ?? [])) {
+    const rounds = roundsFor(group, tpl.rounds)
+    for (const it of group.items) roundsByItem.set(it.id, rounds)
+  }
+
+  return items.map((it, i) => {
+    const rounds = roundsByItem.get(it.id) ?? 1
+    return {
       uid: startUid + i,
       exercise:
         byKey.get(it.exercise_key) ??
         ({ key: it.exercise_key, display_name: it.exercise_key, measures: [] } as unknown as Exercise),
-      round_number: null,
+      template_item_id: it.id,
       variant: it.variant,
       notes: null,
-      attempts: [blankAttempt()],
-    }))
+      // One attempt per round, numbered. A single-round exercise keeps a null
+      // round — there is no round 1 of 1 worth stating.
+      attempts:
+        rounds > 1
+          ? Array.from({ length: rounds }, (_, r) => blankAttempt(r + 1))
+          : [blankAttempt()],
+    }
+  })
 }

--- a/frontend/src/views/WorkoutSessionLoggerView.vue
+++ b/frontend/src/views/WorkoutSessionLoggerView.vue
@@ -75,10 +75,22 @@
       />
     </div>
 
-    <!-- Logged exercises -->
+    <!-- Logged exercises, under the circuit that prescribed them (SB-545).
+         The card and the print sheet both say "Circuit A ×2"; this screen said
+         nothing, so the structure of the workout vanished at the moment of
+         doing it. -->
+    <template v-for="(row, ri) in rows" :key="row.uid">
+      <div
+        v-if="circuitLabelAt(ri)"
+        class="mt-4 flex items-baseline gap-2 text-[11px] font-bold uppercase tracking-wide text-brand-700"
+        data-testid="logger-circuit-bar"
+      >
+        {{ circuitLabelAt(ri)!.label }}
+        <span v-if="circuitLabelAt(ri)!.rounds > 1" class="text-gray-400">
+          ×{{ circuitLabelAt(ri)!.rounds }}
+        </span>
+      </div>
     <div
-      v-for="row in rows"
-      :key="row.uid"
       class="bg-white rounded-xl border border-gray-200 p-3 mt-3"
       :data-testid="`row-${row.exercise.key}`"
     >
@@ -107,11 +119,10 @@
       <ExerciseDescription v-if="isOpen(row.uid)" class="mt-2" :exercise="row.exercise" />
 
       <div class="mt-2 flex flex-wrap gap-2 text-xs">
-        <label class="field">
-          Round
-          <input v-model.number="row.round_number" type="number" min="1" class="w-14 num"
-            :data-testid="`round-${row.exercise.key}`" />
-        </label>
+        <!-- The "Round" box is gone (SB-545). It was empty on every row, so
+             recording a two-round circuit as written meant typing twenty-two
+             round numbers — which is why no round ever got logged. Rounds now
+             arrive on the attempts, from the circuit that prescribed them. -->
         <label class="field">
           Variant
           <input v-model="row.variant" placeholder="e.g. left" class="w-20 num"
@@ -136,7 +147,11 @@
         class="mt-2 flex flex-wrap items-center gap-2 text-xs"
         :data-testid="`attempt-${row.exercise.key}-${i}`"
       >
-        <span v-if="row.attempts.length > 1" class="w-8 text-gray-400 tabular-nums">#{{ i + 1 }}</span>
+        <span
+          v-if="row.attempts.length > 1"
+          class="w-8 text-gray-400 tabular-nums"
+          :data-testid="`attempt-label-${row.exercise.key}-${i}`"
+        >{{ a.round_number ? `R${a.round_number}` : `#${i + 1}` }}</span>
         <label v-for="f in fieldsFor(row)" :key="f.model" class="field">
           {{ f.label }}
           <input
@@ -175,6 +190,7 @@
         + Add set
       </button>
     </div>
+    </template>
 
     <!-- Add exercise -->
     <div class="mt-4">
@@ -284,7 +300,13 @@ import {
   templateToRows,
   todayISO,
 } from '@/utils/sessionPayload'
-import type { Exercise, LoggerRow, WorkoutTemplateInput, WorkoutType } from '@/types/workout'
+import type {
+  Exercise,
+  LoggerRow,
+  TemplateBlock,
+  WorkoutTemplateInput,
+  WorkoutType,
+} from '@/types/workout'
 import { useActingAthlete } from '@/composables/useActingAthlete'
 import { explainStatus, statusOf } from '@/utils/apiErrors'
 
@@ -304,6 +326,14 @@ const howFelt = ref<string | null>(null)
 const notes = ref<string | null>(null)
 const rows = ref<LoggerRow[]>([])
 const templateName = ref<string | null>(null)
+// The prescription's circuits, kept so the logger can show what the card and
+// the sheet show (SB-545).
+const blocks = ref<TemplateBlock[]>([])
+const itemBlockIds = ref<Record<string, string | null>>({})
+const blockForItem = (itemId: string): TemplateBlock | null => {
+  const blockId = itemBlockIds.value[itemId]
+  return blocks.value.find((b) => b.id === blockId) ?? null
+}
 const sessionType = ref<WorkoutType>('circuit')
 const picking = ref(false)
 const saving = ref(false)
@@ -356,11 +386,30 @@ const onPick = (ex: Exercise): void => {
   rows.value.push({
     uid: nextUid++,
     exercise: ex,
-    round_number: null,
+    // Added by hand: it answers no prescribed item, so the link stays null.
+    template_item_id: null,
     variant: null,
     notes: null,
     attempts: [blankAttempt()],
   })
+}
+
+/**
+ * The circuit heading to show above row `index`, or null.
+ *
+ * Derived from the prescription rather than stored on the row: the logger's
+ * rows are the athlete's working state and may be added to or removed, while
+ * the circuits belong to the template.
+ */
+const circuitLabelAt = (index: number): { label: string; rounds: number } | null => {
+  const row = rows.value[index]
+  if (!row?.template_item_id) return null
+  const block = blockForItem(row.template_item_id)
+  if (!block) return null
+  const prev = rows.value[index - 1]
+  const prevBlock = prev?.template_item_id ? blockForItem(prev.template_item_id) : null
+  if (prevBlock?.id === block.id) return null
+  return { label: block.label, rounds: block.rounds }
 }
 
 const removeRow = (row: LoggerRow): void => {
@@ -468,6 +517,8 @@ const prefillFrom = (id: string): Promise<void> =>
   getTemplate(id, athleteId.value!).then((tpl) => {
     templateName.value = tpl.name
     sessionType.value = tpl.type
+    blocks.value = tpl.blocks ?? []
+    itemBlockIds.value = Object.fromEntries(tpl.items.map((i) => [i.id, i.block_id ?? null]))
     const byKey = new Map(exercises.value.map((e) => [e.key, e]))
     rows.value = templateToRows(tpl, byKey, nextUid)
     nextUid += rows.value.length

--- a/frontend/src/views/__tests__/WorkoutSessionLoggerView.test.ts
+++ b/frontend/src/views/__tests__/WorkoutSessionLoggerView.test.ts
@@ -375,3 +375,96 @@ describe('WorkoutSessionLoggerView — ad-hoc workout (SB-531)', () => {
     expect(h.push).toHaveBeenCalledWith('/coach/ath1')
   })
 })
+
+
+// --- SB-545: the logger finally knows what it was asked to do ---------------
+
+const ITEM = (id: string, key: string, block_id: string | null, position: number) => ({
+  id,
+  exercise_key: key,
+  section: 'main',
+  position,
+  block_id,
+  target_reps: null,
+  target_duration_seconds: 60,
+  target_load_kg: null,
+  target_distance_m: null,
+  rest_seconds: null,
+  variant: null,
+  notes: null,
+})
+
+const CIRCUIT_TEMPLATE = {
+  id: 't5',
+  name: 'Monday At-Home',
+  type: 'circuit',
+  rounds: 1,
+  source: 'Matthew',
+  notes: null,
+  created_at: null,
+  blocks: [
+    { id: 'b1', template_id: 't5', label: 'Circuit A', position: 0, rounds: 2, rest_after_seconds: 240 },
+    { id: 'b2', template_id: 't5', label: 'Circuit B', position: 1, rounds: 1, rest_after_seconds: null },
+  ],
+  items: [
+    ITEM('a1', 'pushups', 'b1', 0),
+    ITEM('a2', 'farmers_carry', 'b1', 1),
+    ITEM('b1i', 'pushups', 'b2', 2),
+  ],
+}
+
+describe('WorkoutSessionLoggerView — circuits and the prescription (SB-545)', () => {
+  const openCircuit = async () => {
+    h.params = { athleteId: 'ath1', templateId: 't5' }
+    h.getTemplate.mockResolvedValue(CIRCUIT_TEMPLATE)
+    return mountLogger()
+  }
+
+  it('shows the circuits the card and the sheet already show', async () => {
+    const w = await openCircuit()
+    const bars = w.findAll('[data-testid="logger-circuit-bar"]').map((b) => b.text())
+    expect(bars).toHaveLength(2)
+    expect(bars[0]).toContain('Circuit A')
+    expect(bars[0]).toContain('×2')
+    expect(bars[1]).toContain('Circuit B')
+  })
+
+  it('lays a two-round circuit out as R1 and R2, already numbered', async () => {
+    // Before this, recording the prescription meant tapping "+ Add set" on
+    // eleven cards and typing twenty-two round numbers.
+    const w = await openCircuit()
+    expect(w.get('[data-testid="attempt-label-farmers_carry-0"]').text()).toBe('R1')
+    expect(w.get('[data-testid="attempt-label-farmers_carry-1"]').text()).toBe('R2')
+  })
+
+  it('no longer asks the athlete to type a round number', async () => {
+    const w = await openCircuit()
+    expect(w.find('[data-testid="round-farmers_carry"]').exists()).toBe(false)
+  })
+
+  it('sends the prescribed item each set answers', async () => {
+    // `pushups` appears in both circuits — without the link the two are
+    // indistinguishable, which is the whole reason SB-527 added the column.
+    const w = await openCircuit()
+    await w.find('[data-testid="duration_s-farmers_carry-0"]').setValue(60)
+    await w.find('[data-testid="save"]').trigger('click')
+    await flushPromises()
+
+    const [payload] = h.createSession.mock.calls[0]
+    const set = payload.sets.find(
+      (s: { exercise_key: string }) => s.exercise_key === 'farmers_carry',
+    )
+    expect(set.template_item_id).toBe('a2')
+    expect(set.round_number).toBe(1)
+  })
+
+  it('leaves an exercise the athlete adds unlinked', async () => {
+    const w = await openCircuit()
+    await w.find('[data-testid="add-exercise"]').trigger('click')
+    await w.find('[data-testid="ex-pushups"]').trigger('click')
+    // Toggling adds a row with no prescription behind it; the existing
+    // prefilled pushups rows keep theirs.
+    await flushPromises()
+    expect(w.findAll('[data-testid="logger-circuit-bar"]').length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary

The logger was the third surface that didn't know circuits exist — and the only one where it cost more than looks.

Starting Monday At-Home gave a flat stack of cards, each with an empty **Round** box and one set. The prescription is eleven movements twice through, a four-minute break, then six more. Recording that faithfully meant tapping **+ Add set** on eleven cards and typing twenty-two round numbers, having worked out unprompted that this is what the empty field wanted. So it never happened.

- An exercise in a two-round circuit arrives with **two attempts, already numbered R1 and R2**, under a heading naming the circuit — the same thing the card and the print sheet say.
- The manual Round box is **gone**. Rounds are prescription, not something to retype while doing the work.
- A single-round exercise keeps one unnumbered attempt — there is no "round 1 of 1" worth stating.
- Rounds moved from the row **onto the attempt**, which is where they belong: a set is what happens in a round, so one exercise done twice is two sets with different round numbers. Exactly the R1/R2 columns the sheet has always had.
- Grouping reuses `utils/circuits.ts` from SB-543 — three copies of that logic is where it stops being funny.

### The larger half

**`exercise_sets.template_item_id` was never written.** Not once, anywhere in the frontend. SB-527 added that column with a stated purpose:

> `lunge` appears five times in one template, so "lunge, round 1, 45s" was unattributable. **"Did he do what was prescribed?" was not answerable by query.**

The migration shipped, the print sheet learned blocks, and the only thing in the system that creates sets never populated the link. Every session logged so far records *what was done* with no way back to *what was asked for*.

Prefilled rows now carry the item they answer. Anything the athlete adds by hand, and anything logged with no template behind it (SB-531), keeps a null link.

That is the same failure as logging, athlete-authoring and ad-hoc sessions: built, migrated, never reached. Four instances of one pattern — a good argument for SB-540.

## Test plan

- [x] `cd frontend && npm run type-check && npx vitest run` — 440 passing, `npm run build`
- [x] `uv run --project backend ruff check backend/ && python -m pytest backend/tests/ -q` — 401 passing
- [x] `uv run ruff check src/ tests/ && uv run pytest tests/ -q` — 197 passing
- [x] Mutation-tested (5): link never sent, rounds ignored, round taken from the wrong attempt, single-round numbered anyway, circuit heading suppressed
- [x] Updated the existing prefill test rather than deleting it — a blockless template with `rounds: 3` now correctly yields three numbered attempts
- [ ] Start Monday At-Home: circuit headings, R1/R2 laid out, no Round box
- [ ] Save it and confirm the sets carry `template_item_id` and their round
- [ ] Ad-hoc logging (no template) is unchanged

Fixes SB-545

🤖 Generated with [Claude Code](https://claude.com/claude-code)