### PR TITLE
feat: a completed workout counts toward a goal

### DIFF
--- a/backend/tests/test_metrics_progress.py
+++ b/backend/tests/test_metrics_progress.py
@@ -242,3 +242,58 @@ def test_before_time_excludes_entries_without_timestamp():
     entries = [_entry("running_distance", date(2026, 6, 1), 5.0, at=None)]
     p = compute_progress(goal, RUNNING, entries, date(2026, 6, 1))
     assert p.progress == 0.0  # no precise start time → can't satisfy a time goal
+
+
+# ---- workout-count goals (SB-509) ----
+# The workout_session metric projects one entry per completed session (value 1),
+# so "12 workouts in August" is a month goal over that metric. The two goal kinds
+# answer different questions and the difference shows up on a two-a-day.
+
+WORKOUT = MetricType(
+    key="workout_session",
+    display_name="Workouts",
+    unit="session",
+    aggregation=MetricAggregation.count,
+)
+
+
+def _august_workouts() -> list[MetricEntry]:
+    # Four sessions across three August days — Aug 4 is a two-a-day. Plus one in
+    # July that must stay outside the window.
+    return [
+        _entry("workout_session", date(2026, 7, 31), 1.0),
+        _entry("workout_session", date(2026, 8, 1), 1.0),
+        _entry("workout_session", date(2026, 8, 4), 1.0),
+        _entry("workout_session", date(2026, 8, 4), 1.0),
+        _entry("workout_session", date(2026, 8, 9), 1.0),
+    ]
+
+
+def test_workout_volume_goal_counts_sessions():
+    goal = _goal(metric_key="workout_session", kind=GoalKind.volume, target=12.0)
+    p = compute_progress(goal, WORKOUT, _august_workouts(), date(2026, 8, 9))
+    assert p.window_start == date(2026, 8, 1) and p.window_end == date(2026, 8, 31)
+    assert p.progress == 4.0  # the two-a-day counts twice; July is out of window
+    assert p.met is False
+
+
+def test_workout_frequency_goal_counts_days():
+    goal = _goal(metric_key="workout_session", kind=GoalKind.frequency, target=12.0)
+    p = compute_progress(goal, WORKOUT, _august_workouts(), date(2026, 8, 9))
+    assert p.progress == 3.0  # Aug 1, 4, 9 — the two-a-day is one day
+
+
+def test_workout_goal_met_at_target():
+    entries = [_entry("workout_session", date(2026, 8, d), 1.0) for d in range(1, 13)]
+    goal = _goal(metric_key="workout_session", kind=GoalKind.volume, target=12.0)
+    p = compute_progress(goal, WORKOUT, entries, date(2026, 8, 31))
+    assert p.progress == 12.0
+    assert p.met is True
+    assert p.percent == 100.0
+
+
+def test_workout_goal_starts_empty():
+    goal = _goal(metric_key="workout_session", kind=GoalKind.volume, target=12.0)
+    p = compute_progress(goal, WORKOUT, [], date(2026, 8, 3))
+    assert p.progress == 0.0
+    assert p.met is False

--- a/docs/GOALS_TRACKING.md
+++ b/docs/GOALS_TRACKING.md
@@ -69,6 +69,33 @@ Running entries can be **projected from the existing `runs` table** (a view or a
 sync-time insert) so we don't duplicate the SmashRun pipeline. `runs` already
 carries `body_weight_kg` per run — those become `body_weight` entries for free.
 
+#### Projected metrics
+
+Two metrics are written by database triggers rather than by a person, so a goal
+over them fills in as a side effect of doing the thing:
+
+| metric | source table | trigger migration |
+|--------|--------------|-------------------|
+| `running_distance` | `runs` | `20260603120000_project_runs_to_metric_entries.sql` |
+| `workout_session`  | `workout_sessions` + `exercise_sets` | `20260803000000_project_workouts_to_metric_entries.sql` |
+
+`workout_session` (SB-509) is what makes "complete 12 workouts in August"
+possible. Two details are worth knowing:
+
+- **A session counts once it has at least one `exercise_set`.** An empty session
+  is a shell — scheduled or abandoned — and must not tick a goal. Deleting the
+  last set un-completes it and the count goes back down.
+- **The subject is the athlete, not the logger.** `workout_sessions.user_id` is
+  whoever typed it in; a coach logging for an athlete writes `athlete_id` too.
+  The projection credits `athletes.linked_user_id` in that case, so a coach's own
+  goals never absorb their athlete's work. A managed athlete with no login has
+  nobody to credit and projects nothing — until they link, at which point their
+  history backfills.
+
+Because the metric's aggregation is `count`, the two goal kinds answer different
+questions and a two-a-day is where they diverge: **`volume` counts sessions**
+(two-a-day = 2), **`frequency` counts distinct days** (two-a-day = 1).
+
 ### `metric_goals`
 
 Native, **app-set** goals (not the SmashRun mirror). This is the new capability.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -33,6 +33,22 @@ What's covered:
   `test_auth_routes`), Redis cache with fakeredis (`test_cache`), stats &
   streaks, the goals module/repository/endpoint, sync, publish-status, secrets.
 
+## Database tests (`supabase/tests/`)
+
+Triggers and RLS live in SQL, so the Python suites — which run against a fake
+Supabase client — cannot reach them. These scripts run against local Postgres
+inside a transaction and `ROLLBACK`, so they leave nothing behind and are safe to
+re-run against a database with real data in it.
+
+```bash
+DB=$(supabase status -o env | grep ^DB_URL | cut -d= -f2- | tr -d '"')
+for f in supabase/tests/*.sql; do psql "$DB" -v ON_ERROR_STOP=1 -f "$f"; done
+```
+
+A failed `ASSERT` aborts with a message naming the case. **Not run by CI** — the
+migrations workflow only pushes migrations; run these locally when you touch a
+trigger or a policy.
+
 ## Frontend tests
 
 ```bash

--- a/frontend/src/components/__tests__/ScheduleWorkout.test.ts
+++ b/frontend/src/components/__tests__/ScheduleWorkout.test.ts
@@ -6,10 +6,19 @@ vi.mock('@/config/api', () => ({ apiCall: (...a: unknown[]) => apiCallMock(...a)
 
 import ScheduleWorkout from '../ScheduleWorkout.vue'
 
-const todayISO = (): string => {
+const isoDaysFromNow = (n: number): string => {
   const d = new Date()
+  d.setDate(d.getDate() + n)
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 }
+const todayISO = (): string => isoDaysFromNow(0)
+
+// Dates must be derived, never written down. The component refuses to schedule
+// into the past, so a hardcoded date silently stops being savable the morning it
+// expires — and the failure surfaces in the WRONG test, because of the shared
+// mock below. That is exactly how this suite broke in CI (a UTC runner had
+// already rolled over to the next day while the author's machine had not).
+const SOON = isoDaysFromNow(3)
 
 const mountIt = () =>
   mount(ScheduleWorkout, { props: { templateId: 't1', athleteId: 'ath1' } })
@@ -17,6 +26,14 @@ const mountIt = () =>
 // No shared mock reset: clearing a vi.fn between tests drops Vitest's handle on
 // a promise it recorded, and the rejection below is then reported as unhandled
 // even though the component catches it. Each test sets its own implementation.
+//
+// The cost is that `mock.calls` accumulates across tests, so a test asserting on
+// the last call must first prove its OWN call happened — otherwise it reads the
+// previous test's and reports a confusing mismatch instead of "nothing posted".
+const lastCallAfter = (before: number): unknown[] => {
+  expect(apiCallMock.mock.calls.length).toBeGreaterThan(before)
+  return apiCallMock.mock.calls.at(-1)!
+}
 describe('ScheduleWorkout (SB-534)', () => {
   it('will not schedule into the past', async () => {
     const w = mountIt()
@@ -34,13 +51,13 @@ describe('ScheduleWorkout (SB-534)', () => {
     apiCallMock.mockResolvedValue({ id: 'sch1' })
     const w = mountIt()
     await w.get('[data-testid="schedule-open"]').trigger('click')
-    await w.get('[data-testid="schedule-date"]').setValue('2026-08-06')
+    await w.get('[data-testid="schedule-date"]').setValue(SOON)
     await w.get('[data-testid="schedule-save"]').trigger('click')
     await flushPromises()
 
     expect(apiCallMock).toHaveBeenCalledWith('/workouts/schedule', {
       method: 'POST',
-      body: JSON.stringify({ template_id: 't1', scheduled_for: '2026-08-06' }),
+      body: JSON.stringify({ template_id: 't1', scheduled_for: SOON }),
       headers: { 'X-Act-As-Athlete': 'ath1' },
     })
     expect(w.emitted('scheduled')).toHaveLength(1)
@@ -50,20 +67,21 @@ describe('ScheduleWorkout (SB-534)', () => {
   it('repeats weekly on the days picked, starting from the date', async () => {
     apiCallMock.mockImplementation(async () => ({ id: 'r1' }))
     const w = mountIt()
+    const before = apiCallMock.mock.calls.length
     await w.get('[data-testid="schedule-open"]').trigger('click')
     await w.get('[data-testid="mode-repeat"]').trigger('click')
-    await w.get('[data-testid="schedule-date"]').setValue('2026-08-03')
+    await w.get('[data-testid="schedule-date"]').setValue(SOON)
     await w.get('[data-testid="weekday-1"]').trigger('click') // Monday
     await w.get('[data-testid="weekday-4"]').trigger('click') // Thursday
     await w.get('[data-testid="schedule-save"]').trigger('click')
     await flushPromises()
 
-    const post = apiCallMock.mock.calls.at(-1)!
+    const post = lastCallAfter(before)
     expect(String(post[0])).toBe('/workouts/recurrence')
     expect(JSON.parse((post[1] as { body: string }).body)).toEqual({
       template_id: 't1',
       byweekday: [1, 4],
-      starts_on: '2026-08-03',
+      starts_on: SOON,
     })
     expect(w.emitted('scheduled')).toHaveLength(1)
   })
@@ -73,7 +91,7 @@ describe('ScheduleWorkout (SB-534)', () => {
     const w = mountIt()
     await w.get('[data-testid="schedule-open"]').trigger('click')
     await w.get('[data-testid="mode-repeat"]').trigger('click')
-    await w.get('[data-testid="schedule-date"]').setValue('2026-08-03')
+    await w.get('[data-testid="schedule-date"]').setValue(SOON)
     expect(w.get('[data-testid="schedule-save"]').attributes('disabled')).toBeDefined()
   })
 
@@ -90,12 +108,13 @@ describe('ScheduleWorkout (SB-534)', () => {
   it('stays a one-off unless repeating is chosen', async () => {
     apiCallMock.mockImplementation(async () => ({ id: 'sch1' }))
     const w = mountIt()
+    const before = apiCallMock.mock.calls.length
     await w.get('[data-testid="schedule-open"]').trigger('click')
     expect(w.find('[data-testid="weekday-chips"]').exists()).toBe(false)
-    await w.get('[data-testid="schedule-date"]').setValue('2026-08-03')
+    await w.get('[data-testid="schedule-date"]').setValue(SOON)
     await w.get('[data-testid="schedule-save"]').trigger('click')
     await flushPromises()
-    expect(String(apiCallMock.mock.calls.at(-1)![0])).toBe('/workouts/schedule')
+    expect(String(lastCallAfter(before)[0])).toBe('/workouts/schedule')
   })
 
   it('explains a day that already has this plan on it', async () => {
@@ -105,7 +124,7 @@ describe('ScheduleWorkout (SB-534)', () => {
     })
     const w = mountIt()
     await w.get('[data-testid="schedule-open"]').trigger('click')
-    await w.get('[data-testid="schedule-date"]').setValue('2026-08-06')
+    await w.get('[data-testid="schedule-date"]').setValue(SOON)
     await w.get('[data-testid="schedule-save"]').trigger('click')
     await flushPromises()
 

--- a/frontend/src/utils/__tests__/metrics.test.ts
+++ b/frontend/src/utils/__tests__/metrics.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { displayDecimals, displayUnit, toDisplay, toStored } from '@/utils/metrics'
+
+describe('displayUnit', () => {
+  it('converts stored units to what the user reads', () => {
+    expect(displayUnit('km')).toBe('mi')
+    expect(displayUnit('kg')).toBe('lb')
+  })
+
+  it('reads a workout count as workouts, not "session" (SB-509)', () => {
+    expect(displayUnit('session')).toBe('workouts')
+  })
+
+  it('passes through units that need no translation', () => {
+    expect(displayUnit('reps')).toBe('reps')
+  })
+})
+
+describe('toDisplay / toStored', () => {
+  it('round-trips distance and weight', () => {
+    expect(toStored('km', toDisplay('km', 10))).toBeCloseTo(10, 6)
+    expect(toStored('kg', toDisplay('kg', 80))).toBeCloseTo(80, 6)
+  })
+
+  it('leaves counted units alone — a workout is a workout in any locale', () => {
+    expect(toDisplay('session', 12)).toBe(12)
+    expect(toStored('session', 12)).toBe(12)
+    expect(toDisplay('reps', 50)).toBe(50)
+  })
+})
+
+describe('displayDecimals', () => {
+  it('shows counts whole and measurements to one place', () => {
+    expect(displayDecimals('session')).toBe(0)
+    expect(displayDecimals('reps')).toBe(0)
+    expect(displayDecimals('km')).toBe(1)
+  })
+})

--- a/frontend/src/utils/metrics.ts
+++ b/frontend/src/utils/metrics.ts
@@ -8,6 +8,8 @@ const KG_TO_LB = 2.20462
 export function displayUnit(storedUnit: string): string {
   if (storedUnit === 'km') return 'mi'
   if (storedUnit === 'kg') return 'lb'
+  // A workout-count goal reads "4 / 12 workouts", not "12 session" (SB-509).
+  if (storedUnit === 'session') return 'workouts'
   return storedUnit
 }
 

--- a/supabase/migrations/20260803000000_project_workouts_to_metric_entries.sql
+++ b/supabase/migrations/20260803000000_project_workouts_to_metric_entries.sql
@@ -1,0 +1,247 @@
+-- =====================================================
+-- Project completed workouts → metric_entries (SB-509)
+-- =====================================================
+-- "Complete 12 workouts in August" needs no new goal kind: `frequency`, `month`
+-- and the `count` aggregation all already exist. What was missing is anything to
+-- count — metric_types seeded only running_distance, body_weight and pushups
+-- (20260602120000), and workout_sessions landed a fortnight later
+-- (20260620000000) without the projection runs got in 20260603120000.
+--
+-- This adds the missing half: a `workout_session` metric, and a trigger that
+-- mirrors each COMPLETED session into metric_entries as value 1.
+--
+--   one metric_entry per completed session
+--   source      = 'workout'
+--   external_id = workout_sessions.id (dedup key — partial-unique index)
+--   value       = 1   (metric_entries.value is documented as "1 for a session")
+--   occurred_on = workout_sessions.session_date
+--
+-- Two goal shapes fall out of the one metric row, and they differ:
+--
+--   volume    + count aggregation  → counts SESSIONS  (a two-a-day counts 2)
+--   frequency                      → counts DISTINCT DAYS (a two-a-day counts 1)
+--
+-- Both are selectable in the goal form; see backend/metrics_progress.py.
+--
+-- occurred_at is deliberately left NULL: a session records a date, not a start
+-- time, so it cannot honour a `before_time` goal and must not pretend to.
+--
+-- =====================================================
+-- WHAT COUNTS AS COMPLETED
+-- =====================================================
+-- A session row with at least one exercise_set. A session with no sets is an
+-- empty shell — scheduled, abandoned, or half-created by the logger — and must
+-- not tick a goal. That makes exercise_sets part of the trigger surface: the
+-- first set completes a session, deleting the last one un-completes it.
+--
+-- =====================================================
+-- WHOSE GOAL IT COUNTS TOWARD
+-- =====================================================
+-- workout_sessions.user_id is the ACTOR, not the subject. A coach logging for an
+-- athlete writes user_id = the coach and athlete_id = the athlete (see
+-- _owner_fields in src/shared/supabase_ops/workout_repository.py). Projecting on
+-- user_id would credit the coach's own goals with their athlete's work.
+--
+-- So the subject is:
+--   athlete_id IS NULL  → user_id             (a self-logged workout)
+--   athlete_id set      → athletes.linked_user_id
+--
+-- A managed athlete with no login has linked_user_id NULL — there is no user to
+-- credit, so nothing projects. If that athlete links later, the trigger on
+-- athletes below backfills their history rather than leaving the goal at zero.
+
+-- =====================================================
+-- The metric
+-- =====================================================
+INSERT INTO metric_types (key, display_name, unit, aggregation, higher_is_better) VALUES
+    ('workout_session', 'Workouts', 'session', 'count', TRUE)
+ON CONFLICT (key) DO NOTHING;
+
+-- =====================================================
+-- Subject resolution
+-- =====================================================
+CREATE OR REPLACE FUNCTION workout_metric_subject(p_user_id UUID, p_athlete_id UUID)
+RETURNS UUID
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+    SELECT CASE
+        WHEN p_athlete_id IS NULL THEN p_user_id
+        ELSE (SELECT linked_user_id FROM athletes WHERE id = p_athlete_id)
+    END;
+$$;
+
+COMMENT ON FUNCTION workout_metric_subject IS
+    'Whose goals a workout counts toward: the linked athlete, else the logging user (SB-509)';
+
+-- =====================================================
+-- Sync one session's metric entry
+-- =====================================================
+-- Recompute-from-scratch rather than incremental: every trigger below calls this
+-- with a session id and it decides whether an entry should exist. That makes
+-- insert, edit, un-completion and deletion the same code path, and makes the
+-- whole thing idempotent.
+--
+-- SECURITY DEFINER because metric_entries RLS is strict (user_id = auth.uid())
+-- with no anon escape. A coach logging sets through the anon key would otherwise
+-- have the trigger's insert of the ATHLETE's entry rejected, failing their write.
+-- The backend's service-role key is RLS-exempt and unaffected either way.
+CREATE OR REPLACE FUNCTION sync_workout_session_metric_entry(p_session_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    s        workout_sessions%ROWTYPE;
+    subject  UUID;
+    has_sets BOOLEAN := FALSE;
+    exists_  BOOLEAN;
+BEGIN
+    SELECT * INTO s FROM workout_sessions WHERE id = p_session_id;
+    -- Capture FOUND immediately: the next SELECT INTO would overwrite it.
+    exists_ := FOUND;
+
+    IF exists_ THEN
+        subject := workout_metric_subject(s.user_id, s.athlete_id);
+        SELECT EXISTS (SELECT 1 FROM exercise_sets WHERE session_id = p_session_id)
+          INTO has_sets;
+    END IF;
+
+    -- Gone, empty, or unattributable → no entry should exist.
+    IF NOT exists_ OR subject IS NULL OR NOT has_sets THEN
+        DELETE FROM metric_entries
+         WHERE metric_key = 'workout_session'
+           AND source = 'workout'
+           AND external_id = p_session_id::TEXT;
+        RETURN;
+    END IF;
+
+    -- The subject can change (an athlete links a login, or a session is
+    -- reassigned), so drop any entry now credited to the wrong user.
+    DELETE FROM metric_entries
+     WHERE metric_key = 'workout_session'
+       AND source = 'workout'
+       AND external_id = p_session_id::TEXT
+       AND user_id <> subject;
+
+    INSERT INTO metric_entries (
+        user_id, metric_key, occurred_on, value, source, external_id
+    )
+    VALUES (
+        subject, 'workout_session', s.session_date, 1, 'workout', p_session_id::TEXT
+    )
+    ON CONFLICT (user_id, metric_key, source, external_id) WHERE external_id IS NOT NULL
+    DO UPDATE SET
+        occurred_on = EXCLUDED.occurred_on,
+        updated_at = NOW();
+END;
+$$;
+
+COMMENT ON FUNCTION sync_workout_session_metric_entry IS
+    'Recomputes the metric_entries row for one workout session (SB-509)';
+
+-- =====================================================
+-- Triggers
+-- =====================================================
+
+-- The session itself: created, its date or owner edited, or deleted.
+CREATE OR REPLACE FUNCTION trg_workout_session_metric_entry()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        PERFORM sync_workout_session_metric_entry(OLD.id);
+        RETURN OLD;
+    END IF;
+    PERFORM sync_workout_session_metric_entry(NEW.id);
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER workout_session_metric_entry_trigger
+    AFTER INSERT OR UPDATE OR DELETE ON workout_sessions
+    FOR EACH ROW EXECUTE FUNCTION trg_workout_session_metric_entry();
+
+-- The sets: the first one completes a session, the last one removed un-completes
+-- it. An UPDATE that moves a set between sessions has to resync both.
+CREATE OR REPLACE FUNCTION trg_exercise_set_metric_entry()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        PERFORM sync_workout_session_metric_entry(NEW.session_id);
+    ELSIF TG_OP = 'DELETE' THEN
+        PERFORM sync_workout_session_metric_entry(OLD.session_id);
+    ELSE  -- UPDATE OF session_id: both sides may change completeness
+        PERFORM sync_workout_session_metric_entry(OLD.session_id);
+        IF NEW.session_id IS DISTINCT FROM OLD.session_id THEN
+            PERFORM sync_workout_session_metric_entry(NEW.session_id);
+        END IF;
+    END IF;
+    RETURN NULL;  -- AFTER trigger; return value is ignored
+END;
+$$;
+
+CREATE TRIGGER exercise_set_metric_entry_trigger
+    AFTER INSERT OR UPDATE OF session_id OR DELETE ON exercise_sets
+    FOR EACH ROW EXECUTE FUNCTION trg_exercise_set_metric_entry();
+
+-- Linking an athlete to a login makes their whole history attributable at once.
+CREATE OR REPLACE FUNCTION trg_athlete_link_metric_entries()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    sid UUID;
+BEGIN
+    FOR sid IN SELECT id FROM workout_sessions WHERE athlete_id = NEW.id LOOP
+        PERFORM sync_workout_session_metric_entry(sid);
+    END LOOP;
+    RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER athlete_link_metric_entries_trigger
+    AFTER UPDATE OF linked_user_id ON athletes
+    FOR EACH ROW
+    WHEN (NEW.linked_user_id IS DISTINCT FROM OLD.linked_user_id)
+    EXECUTE FUNCTION trg_athlete_link_metric_entries();
+
+-- =====================================================
+-- Backfill
+-- =====================================================
+-- A monthly goal that only counts from the day the feature shipped is a broken
+-- monthly goal: progress is computed over the goal's window, so August workouts
+-- logged before this migration have to be there. Idempotent via the same
+-- conflict target as the trigger.
+INSERT INTO metric_entries (
+    user_id, metric_key, occurred_on, value, source, external_id
+)
+SELECT
+    subj.uid,
+    'workout_session',
+    s.session_date,
+    1,
+    'workout',
+    s.id::TEXT
+FROM workout_sessions s
+CROSS JOIN LATERAL (
+    SELECT workout_metric_subject(s.user_id, s.athlete_id) AS uid
+) subj
+WHERE subj.uid IS NOT NULL
+  AND EXISTS (SELECT 1 FROM exercise_sets es WHERE es.session_id = s.id)
+ON CONFLICT (user_id, metric_key, source, external_id) WHERE external_id IS NOT NULL
+DO UPDATE SET
+    occurred_on = EXCLUDED.occurred_on,
+    updated_at = NOW();

--- a/supabase/tests/sb509_workout_metric_projection.sql
+++ b/supabase/tests/sb509_workout_metric_projection.sql
@@ -1,0 +1,192 @@
+-- =====================================================
+-- SB-509 — workout → metric_entries projection, verified against a real database
+-- =====================================================
+-- The projection is triggers and SQL, so the backend's fake-Supabase unit tests
+-- cannot reach it. This exercises it against local Postgres and rolls back, so
+-- it leaves no rows behind and is safe to re-run.
+--
+--   psql "$(supabase status -o env | grep ^DB_URL | cut -d= -f2- | tr -d '"')" \
+--        -v ON_ERROR_STOP=1 -f supabase/tests/sb509_workout_metric_projection.sql
+--
+-- Prints "SB-509 projection: all assertions passed" on success; any failed
+-- ASSERT aborts with the message naming the case.
+
+BEGIN;
+
+DO $$
+DECLARE
+    runner_id   UUID := gen_random_uuid();
+    coach_id    UUID := gen_random_uuid();
+    athlete_uid UUID := gen_random_uuid();
+    linked_ath  UUID;
+    managed_ath UUID;
+    self_sess   UUID;
+    ath_sess    UUID;
+    mgd_sess    UUID;
+    dup_sess    UUID;
+    set_id      UUID;
+    ex_key      TEXT;
+    d           DATE := DATE '2026-08-05';
+    n           INT;
+    owner       UUID;
+    got_date    DATE;
+BEGIN
+    SELECT key INTO ex_key FROM exercises LIMIT 1;
+    ASSERT ex_key IS NOT NULL, 'fixture: exercise catalog is empty';
+
+    INSERT INTO users (user_id, email) VALUES
+        (runner_id,   'sb509-runner@test.local'),
+        (coach_id,    'sb509-coach@test.local'),
+        (athlete_uid, 'sb509-athlete@test.local');
+
+    INSERT INTO athletes (display_name, linked_user_id, created_by)
+        VALUES ('SB509 Linked', athlete_uid, coach_id) RETURNING id INTO linked_ath;
+    INSERT INTO athletes (display_name, linked_user_id, created_by)
+        VALUES ('SB509 Managed', NULL, coach_id) RETURNING id INTO managed_ath;
+
+    -- ---------------------------------------------------------------
+    -- 1. An empty session is not a completed workout
+    -- ---------------------------------------------------------------
+    INSERT INTO workout_sessions (user_id, session_date)
+        VALUES (runner_id, d) RETURNING id INTO self_sess;
+
+    SELECT COUNT(*) INTO n FROM metric_entries
+     WHERE user_id = runner_id AND metric_key = 'workout_session';
+    ASSERT n = 0, format('empty session projected an entry (got %s)', n);
+
+    -- ---------------------------------------------------------------
+    -- 2. The first set completes it
+    -- ---------------------------------------------------------------
+    INSERT INTO exercise_sets (user_id, session_id, exercise_key, reps)
+        VALUES (runner_id, self_sess, ex_key, 10) RETURNING id INTO set_id;
+
+    SELECT COUNT(*) INTO n FROM metric_entries
+     WHERE user_id = runner_id AND metric_key = 'workout_session';
+    ASSERT n = 1, format('first set did not project exactly one entry (got %s)', n);
+
+    SELECT value, occurred_on INTO n, got_date FROM metric_entries
+     WHERE metric_key = 'workout_session' AND external_id = self_sess::TEXT;
+    ASSERT n = 1, format('entry value should be 1, got %s', n);
+    ASSERT got_date = d, format('occurred_on should be the session date, got %s', got_date);
+
+    -- A second set on the same session must not double-count.
+    INSERT INTO exercise_sets (user_id, session_id, exercise_key, reps)
+        VALUES (runner_id, self_sess, ex_key, 12);
+    SELECT COUNT(*) INTO n FROM metric_entries
+     WHERE user_id = runner_id AND metric_key = 'workout_session';
+    ASSERT n = 1, format('a second set double-counted the session (got %s)', n);
+
+    -- ---------------------------------------------------------------
+    -- 3. Editing the session date moves the entry
+    -- ---------------------------------------------------------------
+    UPDATE workout_sessions SET session_date = d + 1 WHERE id = self_sess;
+    SELECT occurred_on INTO got_date FROM metric_entries
+     WHERE metric_key = 'workout_session' AND external_id = self_sess::TEXT;
+    ASSERT got_date = d + 1, format('occurred_on did not follow the session date, got %s', got_date);
+
+    -- ---------------------------------------------------------------
+    -- 4. Two sessions on one day are two entries (volume+count = 2,
+    --    frequency = 1 day — see backend/metrics_progress.py)
+    -- ---------------------------------------------------------------
+    INSERT INTO workout_sessions (user_id, session_date)
+        VALUES (runner_id, d + 1) RETURNING id INTO dup_sess;
+    INSERT INTO exercise_sets (user_id, session_id, exercise_key, reps)
+        VALUES (runner_id, dup_sess, ex_key, 8);
+
+    SELECT COUNT(*) INTO n FROM metric_entries
+     WHERE user_id = runner_id AND metric_key = 'workout_session';
+    ASSERT n = 2, format('two-a-day should be two entries (got %s)', n);
+    SELECT COUNT(DISTINCT occurred_on) INTO n FROM metric_entries
+     WHERE user_id = runner_id AND metric_key = 'workout_session';
+    ASSERT n = 1, format('two-a-day should be one distinct day (got %s)', n);
+
+    DELETE FROM workout_sessions WHERE id = dup_sess;
+
+    -- ---------------------------------------------------------------
+    -- 5. A coach logging for a linked athlete credits the ATHLETE
+    -- ---------------------------------------------------------------
+    INSERT INTO workout_sessions (user_id, athlete_id, created_by, session_date)
+        VALUES (coach_id, linked_ath, coach_id, d) RETURNING id INTO ath_sess;
+    INSERT INTO exercise_sets (user_id, athlete_id, session_id, exercise_key, reps)
+        VALUES (coach_id, linked_ath, ath_sess, ex_key, 10);
+
+    SELECT user_id INTO owner FROM metric_entries
+     WHERE metric_key = 'workout_session' AND external_id = ath_sess::TEXT;
+    ASSERT owner = athlete_uid,
+        format('athlete session credited to %s, expected the athlete %s', owner, athlete_uid);
+
+    SELECT COUNT(*) INTO n FROM metric_entries
+     WHERE user_id = coach_id AND metric_key = 'workout_session';
+    ASSERT n = 0, format('coach absorbed %s of their athlete''s workouts', n);
+
+    -- ---------------------------------------------------------------
+    -- 6. A managed athlete has nobody to credit — until they link
+    -- ---------------------------------------------------------------
+    INSERT INTO workout_sessions (user_id, athlete_id, created_by, session_date)
+        VALUES (coach_id, managed_ath, coach_id, d) RETURNING id INTO mgd_sess;
+    INSERT INTO exercise_sets (user_id, athlete_id, session_id, exercise_key, reps)
+        VALUES (coach_id, managed_ath, mgd_sess, ex_key, 10);
+
+    SELECT COUNT(*) INTO n FROM metric_entries
+     WHERE metric_key = 'workout_session' AND external_id = mgd_sess::TEXT;
+    ASSERT n = 0, format('unlinked athlete projected %s entries', n);
+
+    UPDATE athletes SET linked_user_id = runner_id WHERE id = managed_ath;
+    SELECT COUNT(*) INTO n FROM metric_entries
+     WHERE user_id = runner_id AND metric_key = 'workout_session'
+       AND external_id = mgd_sess::TEXT;
+    ASSERT n = 1, format('linking an athlete did not backfill their history (got %s)', n);
+
+    -- Re-linking to someone else must not leave the old credit behind.
+    UPDATE athletes SET linked_user_id = athlete_uid WHERE id = managed_ath;
+    SELECT COUNT(*) INTO n FROM metric_entries
+     WHERE user_id = runner_id AND external_id = mgd_sess::TEXT;
+    ASSERT n = 0, format('re-linking left %s stale entries on the old user', n);
+
+    -- ---------------------------------------------------------------
+    -- 7. Removing the last set un-completes the session
+    -- ---------------------------------------------------------------
+    DELETE FROM exercise_sets WHERE session_id = self_sess AND id <> set_id;
+    SELECT COUNT(*) INTO n FROM metric_entries
+     WHERE metric_key = 'workout_session' AND external_id = self_sess::TEXT;
+    ASSERT n = 1, format('removing one of two sets dropped the entry (got %s)', n);
+
+    DELETE FROM exercise_sets WHERE id = set_id;
+    SELECT COUNT(*) INTO n FROM metric_entries
+     WHERE metric_key = 'workout_session' AND external_id = self_sess::TEXT;
+    ASSERT n = 0, format('removing the last set left %s entries', n);
+
+    -- ---------------------------------------------------------------
+    -- 8. Deleting the session removes its entry (cascade included)
+    -- ---------------------------------------------------------------
+    DELETE FROM workout_sessions WHERE id = ath_sess;
+    SELECT COUNT(*) INTO n FROM metric_entries
+     WHERE metric_key = 'workout_session' AND external_id = ath_sess::TEXT;
+    ASSERT n = 0, format('deleting a session left %s entries', n);
+
+    -- ---------------------------------------------------------------
+    -- 9. The backfill is idempotent — re-running it changes no counts
+    -- ---------------------------------------------------------------
+    INSERT INTO workout_sessions (user_id, session_date)
+        VALUES (runner_id, d) RETURNING id INTO self_sess;
+    INSERT INTO exercise_sets (user_id, session_id, exercise_key, reps)
+        VALUES (runner_id, self_sess, ex_key, 5);
+
+    SELECT COUNT(*) INTO n FROM metric_entries WHERE metric_key = 'workout_session';
+
+    INSERT INTO metric_entries (user_id, metric_key, occurred_on, value, source, external_id)
+    SELECT subj.uid, 'workout_session', s.session_date, 1, 'workout', s.id::TEXT
+      FROM workout_sessions s
+      CROSS JOIN LATERAL (SELECT workout_metric_subject(s.user_id, s.athlete_id) AS uid) subj
+     WHERE subj.uid IS NOT NULL
+       AND EXISTS (SELECT 1 FROM exercise_sets es WHERE es.session_id = s.id)
+    ON CONFLICT (user_id, metric_key, source, external_id) WHERE external_id IS NOT NULL
+    DO UPDATE SET occurred_on = EXCLUDED.occurred_on, updated_at = NOW();
+
+    ASSERT (SELECT COUNT(*) FROM metric_entries WHERE metric_key = 'workout_session') = n,
+        'backfill is not idempotent — re-running it changed the entry count';
+
+    RAISE NOTICE 'SB-509 projection: all assertions passed';
+END $$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary

"Complete 12 workouts in August" needed no new goal kind — `frequency`, `month` and the `count` aggregation all already existed. The gap was that nothing was countable: `metric_types` seeded only `running_distance`, `body_weight` and `pushups`, and `workout_sessions` landed a fortnight after runs got their projection without ever getting the equivalent.

This adds the missing half — a `workout_session` metric plus triggers mirroring each completed session into `metric_entries` as value 1.

**What counts as completed.** A session with at least one `exercise_set`. That puts `exercise_sets` on the trigger surface: the first set completes a session, removing the last one un-completes it. An empty session is a shell — scheduled or abandoned — and must not tick a goal.

**Whose goal it counts toward.** `workout_sessions.user_id` is the *actor*, not the subject: a coach logging for an athlete writes `athlete_id` too, so projecting on `user_id` would credit the coach's own goals with their athlete's work. Athlete-scoped sessions credit `athletes.linked_user_id`. A managed athlete with no login has nobody to credit and projects nothing — until they link, at which point a trigger backfills their history.

**Backfill.** Existing sessions are projected on migration. A monthly goal that only counts from the day the feature shipped is a broken monthly goal.

**Two kinds, one metric.** They diverge on a two-a-day: `volume` counts sessions (2), `frequency` counts distinct days (1). Both documented and tested.

No frontend work was needed to make the goal selectable — `metric_types` is DB-driven and `NewGoalForm` renders whatever it receives. The one UI change is `displayUnit('session') → 'workouts'`, so a goal reads "4 / 12 workouts" instead of "12 session".

### Files

- `supabase/migrations/20260803000000_project_workouts_to_metric_entries.sql` — metric, subject resolution, three triggers, backfill
- `supabase/tests/sb509_workout_metric_projection.sql` — new: DB-level test harness (transaction + `ROLLBACK`)
- `backend/tests/test_metrics_progress.py` — workout-count goal progress
- `frontend/src/utils/metrics.ts` + new unit test
- `docs/GOALS_TRACKING.md`, `docs/TESTING.md`

## Test plan

- [x] `psql -f supabase/tests/sb509_workout_metric_projection.sql` — 9 cases: empty session excluded, first set completes, no double-count, date edits follow, two-a-day = 2 entries / 1 day, coach credits athlete not self, unlinked athlete projects nothing then backfills on link, re-link clears stale credit, last-set and session deletion decrement, backfill idempotent
- [x] `pytest backend/tests/` — 405 passed (4 new: volume counts sessions, frequency counts days, met-at-target, empty start)
- [x] `npm test` — 446 passed (44 files), `npm run type-check` clean
- [x] `ruff check` / `ruff format --check` clean
- [x] Migration applied via `supabase migration up` in true order against local Postgres

Note: triggers and RLS are not reachable from the Python suites (they run against a fake Supabase client), and CI's migrations workflow only pushes migrations — so `supabase/tests/*.sql` is run locally, as documented in `docs/TESTING.md`.

Fixes SB-509

🤖 Generated with [Claude Code](https://claude.com/claude-code)