### PR TITLE
feat: your own training is yours to record

### DIFF
--- a/backend/routes/athletes.py
+++ b/backend/routes/athletes.py
@@ -104,14 +104,20 @@ def my_athlete(user_id: UUID = Depends(authenticate_request)) -> Athlete | None:
 
 @me_router.get("/workouts", response_model=list[WorkoutTemplate])
 def my_workouts(user_id: UUID = Depends(authenticate_request)) -> list[WorkoutTemplate]:
-    """The workout templates assigned to the athlete this user IS (via
-    linked_user_id). Empty when the user isn't a linked athlete. Lets an athlete
-    see their coach-assigned workouts without the coach act-as header (SB-332)."""
+    """This user's workout plans, whoever they are.
+
+    For a linked athlete that means the templates assigned to them, reachable
+    without the coach act-as header (SB-332). For everyone else it means their
+    own self-owned templates — ``athlete_id IS NULL``, the shape the repository
+    already writes when no athlete is in play.
+
+    Returning [] for a non-athlete (SB-578) made the training screen a dead end
+    for anyone who is nobody's athlete: they could set a workout goal and never
+    have anywhere to build or log the work that fills it."""
     sb = get_supabase_client()
     athlete = AthletesRepository(sb).get_by_linked_user(user_id)
-    if athlete is None:
-        return []
-    rows = WorkoutTemplatesRepository(sb).list(user_id, athlete_id=UUID(athlete["id"]))
+    athlete_id = UUID(athlete["id"]) if athlete is not None else None
+    rows = WorkoutTemplatesRepository(sb).list(user_id, athlete_id=athlete_id)
     return [WorkoutTemplate(**r) for r in rows]
 
 

--- a/backend/tests/test_my_workouts.py
+++ b/backend/tests/test_my_workouts.py
@@ -1,7 +1,11 @@
-"""SB-332: athlete-facing GET /me/workouts.
+"""SB-332 / SB-578: GET /me/workouts.
 
 An athlete (linked_user_id) sees the templates their coach assigned, scoped by
 the athlete's own athlete_id — no coach act-as header involved.
+
+Everyone else sees their OWN self-owned templates (athlete_id NULL). Returning
+[] for a non-athlete made the training screens a dead end for any user a coach
+had not created first (SB-578).
 """
 
 from __future__ import annotations
@@ -55,16 +59,53 @@ def test_linked_athlete_sees_assigned_templates() -> None:
     templates_repo.list.assert_called_once_with(athlete_user, athlete_id=athlete_id)
 
 
-def test_non_athlete_gets_empty_list() -> None:
+def _self_template_row(user_id) -> dict:
+    # A self-owned template: user_id is the author, athlete_id is NULL.
+    return {
+        "id": str(uuid4()),
+        "user_id": str(user_id),
+        "athlete_id": None,
+        "created_by": None,
+        "name": "My Tuesday circuit",
+        "type": "circuit",
+        "rounds": 1,
+        "source": None,
+        "notes": None,
+        "items": [],
+        "created_at": "2026-08-04T00:00:00+00:00",
+    }
+
+
+def test_non_athlete_sees_their_own_templates() -> None:
+    """SB-578: nobody's athlete still has plans of their own."""
+    from backend.routes.athletes import my_workouts
+
+    user_id = uuid4()
+    athletes_repo = MagicMock()
+    athletes_repo.get_by_linked_user.return_value = None
+    templates_repo = MagicMock()
+    templates_repo.list.return_value = [_self_template_row(user_id)]
+
+    p1, p2, p3 = _patch(athletes_repo, templates_repo)
+    with p1, p2, p3:
+        out = my_workouts(user_id=user_id)
+
+    assert len(out) == 1
+    assert out[0].name == "My Tuesday circuit"
+    # athlete_id=None is what scopes the query to self-owned rows.
+    templates_repo.list.assert_called_once_with(user_id, athlete_id=None)
+
+
+def test_non_athlete_with_nothing_gets_empty_list() -> None:
     from backend.routes.athletes import my_workouts
 
     athletes_repo = MagicMock()
     athletes_repo.get_by_linked_user.return_value = None
     templates_repo = MagicMock()
+    templates_repo.list.return_value = []
 
     p1, p2, p3 = _patch(athletes_repo, templates_repo)
     with p1, p2, p3:
         out = my_workouts(user_id=uuid4())
 
     assert out == []
-    templates_repo.list.assert_not_called()

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -85,7 +85,10 @@ const navLinks = computed(() => [
   ...(isCoach.value ? [{ name: 'Coach', path: '/coach' }] : []),
   ...(isCoach.value ? [{ name: 'Catalog', path: '/exercises' }] : []),
   ...(isAdmin.value ? [{ name: 'Admin', path: '/admin' }] : []),
-  ...(myAthlete.value ? [{ name: 'My Workouts', path: '/my/workouts' }] : []),
+  // My Workouts is for everyone (SB-578). Training is something a user does for
+  // themselves; requiring an athlete record first meant only people a coach had
+  // created could record any of it — including their own workout-count goal.
+  { name: 'My Workouts', path: '/my/workouts' },
   ...(myAthlete.value ? [{ name: 'My Profile', path: '/profile' }] : []),
   { name: 'Settings', path: '/settings' },
 ])

--- a/frontend/src/components/ScheduleWorkout.vue
+++ b/frontend/src/components/ScheduleWorkout.vue
@@ -104,7 +104,9 @@ import { todayLocalISO } from '@/utils/format'
  * authorises them identically. Two copies of this would drift, which is exactly
  * how the athlete-side bugs of the last week happened.
  */
-const props = defineProps<{ templateId: string; athleteId: string }>()
+// athleteId null = scheduling my own workout (SB-578); the API reads the
+// caller's self-owned rows when no act-as header is sent.
+const props = defineProps<{ templateId: string; athleteId: string | null }>()
 const emit = defineEmits<{ (e: 'scheduled'): void }>()
 
 const open = ref(false)

--- a/frontend/src/composables/useActingAthlete.ts
+++ b/frontend/src/composables/useActingAthlete.ts
@@ -10,6 +10,12 @@
  * `actAs()` header need. The API authorises either caller identically —
  * `can_access_athlete` returns true for the coach *and* for the linked athlete
  * (backend/admin.py) — so nothing else has to branch on who is asking.
+ *
+ * A **null athlete id is a third valid case** (SB-578): a user who is nobody's
+ * athlete, working on their own training. `actAs(null)` sends no header and the
+ * API reads and writes their self-owned rows. Views must not treat null as a
+ * failure to resolve — that turned the training screens into a dead end for
+ * every user a coach had not created first.
  */
 import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'

--- a/frontend/src/composables/useWorkoutRecurrence.ts
+++ b/frontend/src/composables/useWorkoutRecurrence.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue'
 import { apiCall } from '@/config/api'
+import { actAs } from '@/utils/actAs'
 import type { WorkoutRecurrence, WorkoutRecurrenceInput } from '@/types/workout'
 
 /** Sunday-first, matching `Date.getDay()` and the stored `byweekday` values. */
@@ -29,12 +30,12 @@ export function describeRecurrence(byweekday: number[]): string {
  */
 export async function createRecurrence(
   payload: WorkoutRecurrenceInput,
-  athleteId: string,
+  athleteId: string | null,
 ): Promise<WorkoutRecurrence> {
   return apiCall<WorkoutRecurrence>('/workouts/recurrence', {
     method: 'POST',
     body: JSON.stringify(payload),
-    headers: { 'X-Act-As-Athlete': athleteId },
+    headers: actAs(athleteId),
   })
 }
 
@@ -42,12 +43,12 @@ export async function createRecurrence(
  *  and anything logged against it — is left alone. */
 export async function stopRecurrence(
   recurrenceId: string,
-  athleteId: string,
+  athleteId: string | null,
 ): Promise<WorkoutRecurrence> {
   return apiCall<WorkoutRecurrence>(`/workouts/recurrence/${recurrenceId}`, {
     method: 'PATCH',
     body: JSON.stringify({ active: false }),
-    headers: { 'X-Act-As-Athlete': athleteId },
+    headers: actAs(athleteId),
   })
 }
 
@@ -56,12 +57,12 @@ export function useWorkoutRecurrence() {
   const loading = ref(false)
   const error = ref<string | null>(null)
 
-  const load = async (athleteId: string): Promise<void> => {
+  const load = async (athleteId: string | null): Promise<void> => {
     loading.value = true
     error.value = null
     try {
       recurrences.value = await apiCall<WorkoutRecurrence[]>('/workouts/recurrence', {
-        headers: { 'X-Act-As-Athlete': athleteId },
+        headers: actAs(athleteId),
       })
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to load repeats'

--- a/frontend/src/composables/useWorkoutSchedule.ts
+++ b/frontend/src/composables/useWorkoutSchedule.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue'
 import { apiCall } from '@/config/api'
+import { actAs } from '@/utils/actAs'
 import type { WorkoutScheduleEntry, WorkoutScheduleInput } from '@/types/workout'
 
 /**
@@ -12,19 +13,19 @@ import type { WorkoutScheduleEntry, WorkoutScheduleInput } from '@/types/workout
  */
 export async function createSchedule(
   payload: WorkoutScheduleInput,
-  athleteId: string,
+  athleteId: string | null,
 ): Promise<WorkoutScheduleEntry> {
   return apiCall<WorkoutScheduleEntry>('/workouts/schedule', {
     method: 'POST',
     body: JSON.stringify(payload),
-    headers: { 'X-Act-As-Athlete': athleteId },
+    headers: actAs(athleteId),
   })
 }
 
-export async function deleteSchedule(scheduleId: string, athleteId: string): Promise<void> {
+export async function deleteSchedule(scheduleId: string, athleteId: string | null): Promise<void> {
   await apiCall(`/workouts/schedule/${scheduleId}`, {
     method: 'DELETE',
-    headers: { 'X-Act-As-Athlete': athleteId },
+    headers: actAs(athleteId),
   })
 }
 
@@ -34,13 +35,13 @@ export function useWorkoutSchedule() {
   const error = ref<string | null>(null)
 
   /** Occasions from `from` onwards, soonest first. Coming up asks from today. */
-  const load = async (athleteId: string, from?: string): Promise<void> => {
+  const load = async (athleteId: string | null, from?: string): Promise<void> => {
     loading.value = true
     error.value = null
     try {
       const query = from ? `?date_from=${from}` : ''
       schedule.value = await apiCall<WorkoutScheduleEntry[]>(`/workouts/schedule${query}`, {
-        headers: { 'X-Act-As-Athlete': athleteId },
+        headers: actAs(athleteId),
       })
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to load the schedule'

--- a/frontend/src/composables/useWorkoutSessions.ts
+++ b/frontend/src/composables/useWorkoutSessions.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue'
 import { apiCall } from '@/config/api'
+import { actAs } from '@/utils/actAs'
 import type { WorkoutSession } from '@/types/coach'
 import type { WorkoutSessionInput } from '@/types/workout'
 
@@ -15,23 +16,23 @@ import type { WorkoutSessionInput } from '@/types/workout'
 export async function renameSession(
   sessionId: string,
   name: string | null,
-  athleteId: string,
+  athleteId: string | null,
 ): Promise<WorkoutSession> {
   return apiCall<WorkoutSession>(`/workouts/sessions/${sessionId}`, {
     method: 'PATCH',
     body: JSON.stringify({ name }),
-    headers: { 'X-Act-As-Athlete': athleteId },
+    headers: actAs(athleteId),
   })
 }
 
 export async function createSession(
   payload: WorkoutSessionInput,
-  athleteId: string,
+  athleteId: string | null,
 ): Promise<{ id: string }> {
   return apiCall<{ id: string }>('/workouts/sessions', {
     method: 'POST',
     body: JSON.stringify(payload),
-    headers: { 'X-Act-As-Athlete': athleteId },
+    headers: actAs(athleteId),
   })
 }
 
@@ -52,12 +53,12 @@ export function useWorkoutSessions() {
   const loading = ref(false)
   const error = ref<string | null>(null)
 
-  const load = async (athleteId: string, limit = 100): Promise<void> => {
+  const load = async (athleteId: string | null, limit = 100): Promise<void> => {
     loading.value = true
     error.value = null
     try {
       sessions.value = await apiCall<WorkoutSession[]>(`/workouts/sessions?limit=${limit}`, {
-        headers: { 'X-Act-As-Athlete': athleteId },
+        headers: actAs(athleteId),
       })
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to load sessions'

--- a/frontend/src/composables/useWorkoutTemplates.ts
+++ b/frontend/src/composables/useWorkoutTemplates.ts
@@ -1,4 +1,5 @@
 import { apiCall } from '@/config/api'
+import { actAs } from '@/utils/actAs'
 import type { WorkoutTemplate, WorkoutTemplateInput } from '@/types/workout'
 
 /**
@@ -8,36 +9,36 @@ import type { WorkoutTemplate, WorkoutTemplateInput } from '@/types/workout'
  */
 export async function createTemplate(
   payload: WorkoutTemplateInput,
-  athleteId: string,
+  athleteId: string | null,
 ): Promise<{ id: string }> {
   return apiCall<{ id: string }>('/workouts/templates', {
     method: 'POST',
     body: JSON.stringify(payload),
-    headers: { 'X-Act-As-Athlete': athleteId },
+    headers: actAs(athleteId),
   })
 }
 
-export async function getTemplate(templateId: string, athleteId: string): Promise<WorkoutTemplate> {
+export async function getTemplate(templateId: string, athleteId: string | null): Promise<WorkoutTemplate> {
   return apiCall<WorkoutTemplate>(`/workouts/templates/${templateId}`, {
-    headers: { 'X-Act-As-Athlete': athleteId },
+    headers: actAs(athleteId),
   })
 }
 
 export async function updateTemplate(
   templateId: string,
   payload: WorkoutTemplateInput,
-  athleteId: string,
+  athleteId: string | null,
 ): Promise<WorkoutTemplate> {
   return apiCall<WorkoutTemplate>(`/workouts/templates/${templateId}`, {
     method: 'PATCH',
     body: JSON.stringify(payload),
-    headers: { 'X-Act-As-Athlete': athleteId },
+    headers: actAs(athleteId),
   })
 }
 
-export async function deleteTemplate(templateId: string, athleteId: string): Promise<void> {
+export async function deleteTemplate(templateId: string, athleteId: string | null): Promise<void> {
   await apiCall(`/workouts/templates/${templateId}`, {
     method: 'DELETE',
-    headers: { 'X-Act-As-Athlete': athleteId },
+    headers: actAs(athleteId),
   })
 }

--- a/frontend/src/utils/actAs.ts
+++ b/frontend/src/utils/actAs.ts
@@ -1,0 +1,16 @@
+/**
+ * Who a workout request is about (SB-578).
+ *
+ * Workout routes take an optional `X-Act-As-Athlete` header. Present, it names
+ * the athlete the caller is acting for; the backend verifies they may. **Absent,
+ * the request is about the caller themselves** — `acting_athlete` returns None
+ * and the repositories write self-owned rows (`athlete_id` NULL), which is the
+ * shape `workout_sessions` has supported since it was created.
+ *
+ * So a null athlete is not a missing value to guard against — it is the ordinary
+ * "this is mine" case. Sending the header with an empty or "null" string would
+ * be a 422; omitting it is the whole mechanism.
+ */
+export function actAs(athleteId: string | null | undefined): Record<string, string> {
+  return athleteId ? { 'X-Act-As-Athlete': athleteId } : {}
+}

--- a/frontend/src/views/MyWorkoutsView.vue
+++ b/frontend/src/views/MyWorkoutsView.vue
@@ -350,7 +350,6 @@
               </button>
             </div>
             <ScheduleWorkout
-              v-if="athleteId"
               class="mt-2"
               :template-id="t.id"
               :athlete-id="athleteId"
@@ -407,7 +406,6 @@
               </button>
             </div>
             <ScheduleWorkout
-              v-if="athleteId"
               class="mt-2"
               :template-id="t.id"
               :athlete-id="athleteId"
@@ -483,11 +481,24 @@ const tab = ref<'training' | 'plans'>('training')
  * of a Pinia dependency it otherwise would not need.
  */
 const isMine = (t: WorkoutTemplate): boolean =>
-  !!t.created_by && t.created_by === myAthlete.value?.linked_user_id
+  isSelf.value || (!!t.created_by && t.created_by === myAthlete.value?.linked_user_id)
 
-/** The athlete this screen is about — read once rather than reached through
- *  `myAthlete` in the template, which relies on ref unwrapping. */
+/**
+ * The athlete this screen is about, or **null when it is about the user
+ * themselves** (SB-578). Null is not a missing value here: it omits the
+ * act-as header, and the API then reads and writes the caller's own
+ * self-owned rows. A user who is nobody's athlete uses this screen exactly
+ * as a linked athlete does.
+ */
 const athleteId = computed(() => myAthlete.value?.id ?? null)
+
+/**
+ * No athlete record → this screen is about the user themselves, and every row
+ * it can see is their own: `/me/workouts` and the act-as-less reads return only
+ * self-owned rows. So authorship needs no comparison in that mode — there is
+ * nobody else's work in the list to distinguish it from.
+ */
+const isSelf = computed(() => athleteId.value === null)
 
 const mine = computed(() => templates.value.filter(isMine))
 const fromCoach = computed(() => templates.value.filter((t) => !isMine(t)))
@@ -541,7 +552,7 @@ const upcoming = computed<Occasion[]>(() => {
     .filter((s) => s.scheduled_for >= today && templatesById.value[s.template_id])
     .sort((a, b) => (a.scheduled_for < b.scheduled_for ? -1 : 1))
     .map((s) => {
-      const mine = !!s.created_by && s.created_by === linked
+      const mine = isSelf.value || (!!s.created_by && s.created_by === linked)
       return {
         id: s.id,
         template: templatesById.value[s.template_id],
@@ -561,11 +572,10 @@ const laterUp = computed(() => upcoming.value.filter((o) => o.id !== dueToday.va
 const nextUp = computed(() => laterUp.value[0] ?? null)
 
 const reloadSchedule = async (): Promise<void> => {
-  if (!myAthlete.value) return
   // Both: a new pattern generates occasions, so the schedule changed too.
   await Promise.all([
-    loadSchedule(myAthlete.value.id, todayLocalISO()),
-    loadRecurrence(myAthlete.value.id),
+    loadSchedule(athleteId.value, todayLocalISO()),
+    loadRecurrence(athleteId.value),
   ])
 }
 
@@ -576,16 +586,14 @@ const repeatFor = (templateId: string) =>
 const describeRepeat = describeRecurrence
 
 const stopRepeat = async (recurrenceId: string): Promise<void> => {
-  if (!myAthlete.value) return
   // Turning it off stops future occasions and leaves the ones already on the
   // calendar — and anything logged against them — alone.
-  await stopRecurrence(recurrenceId, myAthlete.value.id)
+  await stopRecurrence(recurrenceId, athleteId.value)
   await reloadSchedule()
 }
 
 const unschedule = async (o: Occasion): Promise<void> => {
-  if (!myAthlete.value) return
-  await deleteSchedule(o.id, myAthlete.value.id)
+  await deleteSchedule(o.id, athleteId.value)
   await reloadSchedule()
 }
 
@@ -666,38 +674,34 @@ const startRename = (row: CompletedRow): void => {
  * cleared — an empty label on the Completed list would read as nothing.
  */
 const saveRename = async (row: CompletedRow): Promise<void> => {
-  if (!myAthlete.value) return
   const session = sessions.value.find((s) => s.id === row.id)
   const next =
     renameText.value.trim() || defaultSessionName(session?.session_date ?? todayLocalISO())
   renamingId.value = null
-  await renameSession(row.id, next, myAthlete.value.id)
+  await renameSession(row.id, next, athleteId.value)
   if (session) session.name = next
 }
 
 const remove = async (t: WorkoutTemplate): Promise<void> => {
-  if (!myAthlete.value) return
   if (!window.confirm(`Delete "${t.name}"?`)) return
-  await deleteTemplate(t.id, myAthlete.value.id)
+  await deleteTemplate(t.id, athleteId.value)
   await load()
 }
 
 onMounted(async () => {
+  // No athlete record is not a dead end (SB-578): the screen is then about the
+  // user themselves, and `athleteId` stays null so every call omits the act-as
+  // header and reads their own self-owned rows.
   await loadMyAthlete(true)
-  // Not a linked athlete → no workouts to show here.
-  if (!myAthlete.value) {
-    router.replace('/dashboard')
-    return
-  }
   // Sessions and the schedule load alongside the plans, not on tab switch:
   // Coming up and Completed are what the Training tab shows, and it is the
   // default tab. Only occasions from today forward — the past is Completed's
   // job, and an unmet Thursday lingering is a decision nobody has made.
   await Promise.all([
     load(),
-    loadSessions(myAthlete.value.id),
-    loadSchedule(myAthlete.value.id, todayLocalISO()),
-    loadRecurrence(myAthlete.value.id),
+    loadSessions(athleteId.value),
+    loadSchedule(athleteId.value, todayLocalISO()),
+    loadRecurrence(athleteId.value),
   ])
 })
 </script>

--- a/frontend/src/views/WorkoutBuilderView.vue
+++ b/frontend/src/views/WorkoutBuilderView.vue
@@ -202,8 +202,8 @@ const save = async (): Promise<void> => {
       items.value,
       scheduledFor.value,
     )
-    if (editingId) await updateTemplate(editingId, payload, athleteId.value!)
-    else await createTemplate(payload, athleteId.value!)
+    if (editingId) await updateTemplate(editingId, payload, athleteId.value)
+    else await createTemplate(payload, athleteId.value)
     router.push(homePath.value)
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Failed to save workout'
@@ -214,7 +214,7 @@ const save = async (): Promise<void> => {
 
 // Load an existing template into the builder state (kg → lb, key → Exercise).
 const prefillFrom = (templateId: string): Promise<void> =>
-  getTemplate(templateId, athleteId.value!).then((tpl) => {
+  getTemplate(templateId, athleteId.value).then((tpl) => {
     name.value = tpl.name
     type.value = tpl.type
     rounds.value = tpl.rounds
@@ -238,13 +238,9 @@ const prefillFrom = (templateId: string): Promise<void> =>
   })
 
 onMounted(async () => {
-  // Coach or athlete — the gate is having an athlete to build for, not a role.
-  // Athletes author their own workouts too (SB-486).
+  // Coach, linked athlete, or a user building their own plan — all three are
+  // valid here. A null athlete id means the last one (SB-578).
   await resolveAthlete()
-  if (!athleteId.value) {
-    router.replace('/dashboard')
-    return
-  }
   await load()
   if (editingId) await prefillFrom(editingId)
 })

--- a/frontend/src/views/WorkoutPrintView.vue
+++ b/frontend/src/views/WorkoutPrintView.vue
@@ -149,6 +149,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { useRoute, RouterLink } from 'vue-router'
 import { apiCall } from '@/config/api'
+import { actAs } from '@/utils/actAs'
 import type { Exercise, TemplateBlock, TemplateItem, WorkoutTemplate } from '@/types/workout'
 import type { Athlete } from '@/types/coach'
 import { groupOptionItems } from '@/utils/optionGroups'
@@ -350,15 +351,11 @@ const load = async () => {
   errorStatus.value = null
   try {
     // On the athlete route the scope id is not in the URL — resolve it first.
-    if (scopeAthleteId.value === null) {
-      await resolveAthlete()
-      if (scopeAthleteId.value === null) {
-        throw Object.assign(new Error('No athlete profile is linked to this account.'), {
-          status: 404,
-        })
-      }
-    }
-    const headers = { 'X-Act-As-Athlete': scopeAthleteId.value as string }
+    // Still null afterwards means the caller is printing their own plan and is
+    // nobody's athlete (SB-578); actAs omits the header and the API serves
+    // their self-owned template.
+    if (scopeAthleteId.value === null) await resolveAthlete()
+    const headers = actAs(scopeAthleteId.value)
     const [tpl, catalog] = await Promise.all([
       apiCall<WorkoutTemplate>(`/workouts/templates/${templateId}`, { headers }),
       apiCall<Exercise[]>('/workouts/exercises'),

--- a/frontend/src/views/WorkoutSessionLoggerView.vue
+++ b/frontend/src/views/WorkoutSessionLoggerView.vue
@@ -461,7 +461,7 @@ const save = async (): Promise<void> => {
   error.value = null
   errorStatus.value = null
   try {
-    await createSession(payload.value, athleteId.value!)
+    await createSession(payload.value, athleteId.value)
     // An ad-hoc session is the one moment he might want to keep the workout:
     // he just did it and liked it. Nobody opens an empty builder cold, which is
     // why every plan he has is his coach's (SB-531).
@@ -496,7 +496,7 @@ const keepAsPlan = async (): Promise<void> => {
           position: i,
         })),
       } as WorkoutTemplateInput,
-      athleteId.value!,
+      athleteId.value,
     )
     router.push(homePath.value)
   } catch {
@@ -514,7 +514,7 @@ const keepAsPlan = async (): Promise<void> => {
 const defaultName = computed(() => defaultSessionName(sessionDate.value))
 
 const prefillFrom = (id: string): Promise<void> =>
-  getTemplate(id, athleteId.value!).then((tpl) => {
+  getTemplate(id, athleteId.value).then((tpl) => {
     templateName.value = tpl.name
     sessionType.value = tpl.type
     blocks.value = tpl.blocks ?? []
@@ -525,13 +525,10 @@ const prefillFrom = (id: string): Promise<void> =>
   })
 
 onMounted(async () => {
-  // Coach or athlete — the gate is having an athlete to act on, not a role.
-  // A user who is neither has nothing to log here (SB-486).
+  // Coach, linked athlete, or a user logging their own workout — all three are
+  // valid here. A null athlete id means the last one (SB-578), so it is resolved
+  // for the header and never treated as a reason to leave.
   await resolveAthlete()
-  if (!athleteId.value) {
-    router.replace('/dashboard')
-    return
-  }
   await load()
   if (templateId) await prefillFrom(templateId)
 })

--- a/frontend/src/views/__tests__/MyWorkoutsView.test.ts
+++ b/frontend/src/views/__tests__/MyWorkoutsView.test.ts
@@ -89,12 +89,45 @@ beforeEach(() => {
 })
 
 describe('MyWorkoutsView (SB-332)', () => {
-  it('redirects a non-athlete to the dashboard without fetching', async () => {
+  // Being nobody's athlete used to bounce you to the dashboard, which made
+  // training something only a coach's creation could record — including the
+  // workout-count goal every user can set (SB-578).
+  it('lets a user who is nobody’s athlete use the screen', async () => {
     myAthlete.value = null
+    serve({ templates: [{ ...template, athlete_id: null, created_by: null }] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+
+    expect(replaceMock).not.toHaveBeenCalled()
+    expect(w.find('[data-testid="log-adhoc"]').exists()).toBe(true)
+    await w.get('[data-testid="tab-plans"]').trigger('click')
+    expect(w.text()).toContain('Monday At-Home')
+  })
+
+  it('sends no act-as header when the workouts are the user’s own', async () => {
+    myAthlete.value = null
+    serve()
     mount(MyWorkoutsView)
     await flushPromises()
-    expect(replaceMock).toHaveBeenCalledWith('/dashboard')
-    expect(apiCallMock).not.toHaveBeenCalled()
+
+    // An athlete id it does not have must not be invented — omitting the header
+    // is what tells the API the rows are the caller's own.
+    for (const [, opts] of apiCallMock.mock.calls) {
+      const headers = (opts as { headers?: Record<string, string> } | undefined)?.headers ?? {}
+      expect(headers['X-Act-As-Athlete']).toBeUndefined()
+    }
+  })
+
+  it('calls a self-owned plan mine, not the coach’s', async () => {
+    // Nothing in the list can belong to anyone else, so authorship needs no
+    // comparison — and created_by is null on a self-owned row anyway.
+    myAthlete.value = null
+    serve({ templates: [{ ...template, athlete_id: null, created_by: null }] })
+    const w = mount(MyWorkoutsView)
+    await flushPromises()
+    await w.get('[data-testid="tab-plans"]').trigger('click')
+    expect(w.text()).toContain('Mine')
+    expect(w.text()).not.toContain('From my coach')
   })
 
   it('renders assigned workouts for a linked athlete', async () => {

--- a/frontend/src/views/__tests__/WorkoutBuilderView.test.ts
+++ b/frontend/src/views/__tests__/WorkoutBuilderView.test.ts
@@ -65,14 +65,16 @@ async function mountBuilder() {
 }
 
 describe('WorkoutBuilderView', () => {
-  it('redirects when there is no athlete to act on', async () => {
-    // Since SB-486 the gate is "do we have an athlete", not "are you a coach" —
-    // an athlete opens this view for themselves with no route param.
+  it('builds a plan for a user who is nobody’s athlete', async () => {
+    // SB-486 made the gate "do we have an athlete" rather than "are you a
+    // coach". SB-578 removes the gate: with no athlete record the plan is the
+    // user's own, and a null athlete id is how that is expressed.
     h.isCoach.value = false
     h.params = {}
     h.myAthlete.value = null
-    await mountBuilder()
-    expect(h.replace).toHaveBeenCalledWith('/dashboard')
+    const w = await mountBuilder()
+    expect(h.replace).not.toHaveBeenCalled()
+    expect(w.find('[data-testid="add-main"]').exists()).toBe(true)
   })
 
   it('adds an exercise to a section via the picker', async () => {

--- a/frontend/src/views/__tests__/WorkoutPrintView.test.ts
+++ b/frontend/src/views/__tests__/WorkoutPrintView.test.ts
@@ -118,16 +118,18 @@ describe('WorkoutPrintView on /my/workouts/print (SB-522)', () => {
     expect(call?.[1]?.headers).toEqual({ 'X-Act-As-Athlete': 'my-athlete-row' })
   })
 
-  it('says so when the account has no linked athlete row', async () => {
+  it('prints the caller’s own plan when they have no athlete row', async () => {
+    // Used to refuse with "No athlete profile". A user who is nobody's athlete
+    // still has plans of their own (SB-578) — the template is fetched with no
+    // act-as header, which is what asks for their self-owned row.
     routeParams = { ...OWN_ROUTE }
     myAthlete.value = null
-    const w = mount(WorkoutPrintView)
+    mount(WorkoutPrintView)
     await flushPromises()
-    expect(w.get('[data-testid="print-error"]').text()).toContain('No athlete profile')
-    // Nothing athlete-scoped should have been attempted.
-    expect(apiCallMock.mock.calls.some((c) => String(c[0]).includes('/workouts/templates/'))).toBe(
-      false,
-    )
+
+    const call = apiCallMock.mock.calls.find((c) => c[0] === '/workouts/templates/t1')
+    expect(call).toBeDefined()
+    expect(call?.[1]?.headers).toEqual({})
   })
 
   it('never sends the string "undefined" anywhere', async () => {

--- a/frontend/src/views/__tests__/WorkoutSessionLoggerView.test.ts
+++ b/frontend/src/views/__tests__/WorkoutSessionLoggerView.test.ts
@@ -94,14 +94,16 @@ describe('WorkoutSessionLoggerView', () => {
     expect(h.createSession.mock.calls[0][1]).toBe('ath1')
   })
 
-  it('redirects when there is no athlete to act on', async () => {
-    // Since SB-486 the gate is "do we have an athlete", not "are you a coach" —
-    // an athlete opens this view for themselves with no route param.
+  it('logs a workout for a user who is nobody’s athlete', async () => {
+    // SB-486 made the gate "do we have an athlete" rather than "are you a
+    // coach". SB-578 removes the gate: a user with no athlete record is logging
+    // their own workout, and a null athlete id is how that is expressed.
     h.isCoach.value = false
     h.params = {}
     h.myAthlete.value = null
-    await mountLogger()
-    expect(h.replace).toHaveBeenCalledWith('/dashboard')
+    const w = await mountLogger()
+    expect(h.replace).not.toHaveBeenCalled()
+    expect(w.find('[data-testid="save"]').exists()).toBe(true)
   })
 
   it('adds an exercise via the picker', async () => {


### PR DESCRIPTION
## Summary

SB-509 put a **Workouts** metric in the goal picker, so any user can set "complete 3 workouts this month". Nothing let most of them fill it — the training screens required an athlete record, and only a coach creates those. `silverbeer.io@gmail.com` set the goal, watched it sit at 0/3, and had no door to walk through.

**The gate was never in the data.** `workout_sessions` has supported self-owned rows since it was created — `user_id` set, `athlete_id` NULL — and `_owner_fields` already writes that shape when no athlete is in play. The API agrees: `acting_athlete` returns `None` when the act-as header is absent, and every read and write scopes to the caller. SB-509's projection handles it too (`workout_metric_subject` credits `user_id` directly when `athlete_id IS NULL`), so a self-logged workout counts toward the logger's own goal with no further work.

Only the frontend insisted on an athlete — and `/me/workouts` returned `[]` without one.

### What changed

A null athlete id stops being a failure to resolve and becomes the third valid case: *this is mine*.

- **`utils/actAs.ts`** (new) — one helper, omits `X-Act-As-Athlete` when there is no athlete. Replaces the header literal inlined across five composables and a view.
- **Workout composables** take `string | null`.
- **Three views** (`MyWorkouts`, `WorkoutBuilder`, `WorkoutSessionLogger`) no longer `router.replace('/dashboard')` when the caller has no athlete record; `WorkoutPrintView` no longer refuses with "No athlete profile".
- **`GET /me/workouts`** returns self-owned templates for a non-athlete instead of `[]`.
- **`AppHeader`** shows **My Workouts** to every authenticated user.

Authorship needed no user id to compare against: in the self case every row the screen can see is the caller's own, so "Mine" is simply what they all are. (An earlier attempt reached for the Pinia auth store for this — unnecessary, and it broke 40 tests that mount the view without a Pinia instance.)

## Test plan

- [x] `pytest backend/tests/` — 406 passed. `/me/workouts` gained two cases: a non-athlete gets their own templates scoped `athlete_id=None`, and an empty list when they have none.
- [x] `npm test` — 448 passed, `npm run type-check` clean
- [x] `ruff check` / `ruff format --check` clean
- [x] Four tests that asserted the old redirect were rewritten to assert the new behavior rather than deleted — including one that pins **no act-as header is ever sent** in the self case, since inventing an athlete id there would 422 at the header type

**Not yet verified in a browser.** The contract is covered by unit tests on both sides, but nobody has clicked through building and logging a self-owned workout end to end. Worth doing on prod once deployed — that also confirms the SB-509 goal moves, which is the whole point.

Fixes SB-578

🤖 Generated with [Claude Code](https://claude.com/claude-code)