### PR TITLE
feat(import): single-run file import (GPX/TCX/SmashRun JSON)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -7,6 +7,7 @@ from backend.routes import (
     athletes,
     auth_routes,
     coach,
+    imports,
     invites,
     metrics,
     plan,
@@ -63,6 +64,7 @@ def create_app() -> FastAPI:
     app.include_router(athletes.router)
     app.include_router(athletes.me_router)
     app.include_router(coach.router)
+    app.include_router(imports.router)
 
     return app
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,6 +20,8 @@ dependencies = [
     "pytz>=2024.1",
     "structlog>=24.0.0",
     "google-cloud-storage>=3.10.1",
+    "python-multipart>=0.0.9",  # multipart/form-data for activity-file upload (SB-99)
+    "defusedxml>=0.7.1",  # GPX/TCX are user uploads; xml.etree is entity-bomb prone
 ]
 
 [project.optional-dependencies]

--- a/backend/routes/imports.py
+++ b/backend/routes/imports.py
@@ -1,0 +1,166 @@
+"""/import/activity — import one run from an uploaded activity file (SB-99).
+
+Synchronous by design: a single GPX/TCX/JSON parses in milliseconds, so it
+answers in the request rather than behind a job. Bulk zip import (SB-419) is
+the one that needs a background job.
+
+The upload is scoped to the authenticated user throughout — the source row, the
+run and the track are all written under their user_id, never a caller-supplied one.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID
+
+from backend.auth import authenticate_request
+from backend.cache import invalidate_user
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from src.shared.geo import simplify_and_encode
+from src.shared.importers import (
+    ALLOWED_EXTENSIONS,
+    DEFAULT_TIMEZONE,
+    MAX_UPLOAD_BYTES,
+    ActivityParseError,
+    FileTooLargeError,
+    UnsupportedFileError,
+    parse_activity_file,
+)
+from src.shared.supabase_client import get_supabase_client
+from src.shared.supabase_ops import RunsRepository, UsersRepository, activity_to_run_dict
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/import", tags=["import"])
+
+# The source_type imported runs are filed under (see the 20260814000000
+# migration). One row per user, created on their first upload.
+IMPORT_SOURCE_TYPE = "import"
+IMPORT_SOURCE_LABEL = "file-import"
+
+_READ_CHUNK = 64 * 1024
+
+
+async def _read_capped(upload: UploadFile) -> bytes:
+    """Read the upload, refusing anything over the cap.
+
+    Read in chunks and stop at the first byte past the limit, so an oversized
+    file costs one chunk of memory rather than its full size.
+    """
+    chunks: list[bytes] = []
+    total = 0
+    while chunk := await upload.read(_READ_CHUNK):
+        total += len(chunk)
+        if total > MAX_UPLOAD_BYTES:
+            limit_mb = MAX_UPLOAD_BYTES // (1024 * 1024)
+            raise FileTooLargeError(f"File is larger than the {limit_mb} MB limit.")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+@router.post("/activity")
+async def import_activity(
+    user_id: UUID = Depends(authenticate_request),
+    file: UploadFile = File(...),
+    timezone: str = Form(DEFAULT_TIMEZONE),
+) -> dict[str, Any]:
+    """Import a single activity file (GPX, TCX or SmashRun JSON).
+
+    Idempotent: re-uploading a file that is already imported reports
+    ``status: "duplicate"`` and touches nothing.
+
+    Returns:
+        {status: imported|duplicate, activity_id, run_id, distance_km,
+         duration_seconds, start_date_time_local, has_track}
+    """
+    filename = file.filename or ""
+    if not filename:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No file name supplied, so the format can't be determined.",
+        )
+
+    try:
+        content = await _read_capped(file)
+        parsed = parse_activity_file(filename, content, timezone=timezone)
+    except UnsupportedFileError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, detail=str(exc)
+        ) from exc
+    except FileTooLargeError as exc:
+        raise HTTPException(status_code=status.HTTP_413_CONTENT_TOO_LARGE, detail=str(exc)) from exc
+    except ActivityParseError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
+        ) from exc
+
+    activity = parsed.activity
+    supabase = get_supabase_client()
+    runs_repo = RunsRepository(supabase)
+    users_repo = UsersRepository(supabase)
+
+    existing = runs_repo.get_run_by_activity_id(user_id, activity.activity_id)
+    if existing:
+        # Already imported. Reported as a normal outcome, not an error — a
+        # re-upload is a reasonable thing for someone to do, and the UI needs
+        # to say "already imported" rather than show a failure (SB-418).
+        return {
+            "status": "duplicate",
+            "activity_id": activity.activity_id,
+            "run_id": existing["id"],
+            "distance_km": float(existing["distance_km"]),
+            "duration_seconds": float(existing["duration_seconds"]),
+            "start_date_time_local": existing["start_date_time_local"],
+            "has_track": bool(existing.get("has_gps_data")),
+        }
+
+    source_id = users_repo.get_or_create_source(
+        user_id, IMPORT_SOURCE_TYPE, source_username=IMPORT_SOURCE_LABEL
+    )
+
+    run_dict = activity_to_run_dict(activity, user_id, source_id)
+    # Record the zone the timestamps were read into, so a later re-derivation
+    # of the local date doesn't have to guess what import assumed.
+    run_dict["timezone"] = timezone
+    run = runs_repo.upsert_run(user_id, source_id, run_dict)
+    run_id = UUID(run["id"])
+
+    stored_track = False
+    if parsed.has_track:
+        polyline, point_count = simplify_and_encode(parsed.latitudes, parsed.longitudes)
+        if polyline:
+            runs_repo.upsert_track(run_id, polyline, point_count)
+            stored_track = True
+
+    # Streak and totals are read from the aggregation row, which stays frozen
+    # until recalculated — the same call the SmashRun sync makes after upserting.
+    try:
+        runs_repo.recalculate_user_stats(user_id, timezone=timezone)
+    except Exception as exc:  # noqa: BLE001 - stats refresh must not fail the import
+        logger.warning(f"recalculate_user_stats failed after import for {user_id}: {exc}")
+
+    await invalidate_user(user_id)
+
+    logger.info(f"Imported {filename} for user {user_id} as run {run_id}")
+    return {
+        "status": "imported",
+        "activity_id": activity.activity_id,
+        "run_id": str(run_id),
+        "distance_km": round(activity.distance, 3),
+        "duration_seconds": round(activity.duration, 2),
+        "start_date_time_local": activity.start_date_time_local.isoformat(),
+        "has_track": stored_track,
+    }
+
+
+@router.get("/formats")
+async def import_formats(
+    _user_id: UUID = Depends(authenticate_request),
+) -> dict[str, Any]:
+    """What the importer accepts — so the UI states one set of limits, not its own copy."""
+    return {
+        "extensions": list(ALLOWED_EXTENSIONS),
+        "max_bytes": MAX_UPLOAD_BYTES,
+        "default_timezone": DEFAULT_TIMEZONE,
+    }

--- a/backend/tests/test_import_route.py
+++ b/backend/tests/test_import_route.py
@@ -1,0 +1,227 @@
+"""SB-99: POST /import/activity — single activity file import."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from backend.routes import imports as imports_module
+from fastapi import HTTPException
+
+USER = uuid4()
+SOURCE_ID = uuid4()
+RUN_ID = uuid4()
+
+GPX = b"""<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="Test" xmlns="http://www.topografix.com/GPX/1/1">
+  <trk><name>Morning Run</name><trkseg>
+    <trkpt lat="42.2400" lon="-71.6500"><time>2026-08-10T11:00:00Z</time></trkpt>
+    <trkpt lat="42.2410" lon="-71.6500"><time>2026-08-10T11:01:00Z</time></trkpt>
+    <trkpt lat="42.2420" lon="-71.6500"><time>2026-08-10T11:02:00Z</time></trkpt>
+  </trkseg></trk>
+</gpx>
+"""
+
+SMASHRUN = json.dumps(
+    {
+        "activityId": 4242,
+        "startDateTimeLocal": "2026-08-10T07:15:00-04:00",
+        "distance": 8.05,
+        "duration": 2700.0,
+    }
+).encode()
+
+
+class _Upload:
+    """Enough of starlette's UploadFile for the route: a name and async read."""
+
+    def __init__(self, filename: str | None, data: bytes) -> None:
+        self.filename = filename
+        self._data = data
+        self._offset = 0
+
+    async def read(self, size: int = -1) -> bytes:
+        if size < 0:
+            chunk, self._offset = self._data[self._offset :], len(self._data)
+            return chunk
+        chunk = self._data[self._offset : self._offset + size]
+        self._offset += len(chunk)
+        return chunk
+
+
+class _RunsRepo:
+    def __init__(self, existing: dict[str, Any] | None = None) -> None:
+        self.existing = existing
+        self.upserted: dict[str, Any] | None = None
+        self.tracks: list[tuple[UUID, str, int]] = []
+        self.stats_calls: list[str] = []
+
+    def __call__(self, _sb: Any) -> _RunsRepo:
+        return self
+
+    def get_run_by_activity_id(self, _uid: UUID, _aid: str) -> dict[str, Any] | None:
+        return self.existing
+
+    def upsert_run(self, _uid: UUID, _sid: UUID, run_data: dict[str, Any]) -> dict[str, Any]:
+        self.upserted = run_data
+        return {"id": str(RUN_ID), **run_data}
+
+    def upsert_track(self, run_id: UUID, polyline: str, point_count: int) -> None:
+        self.tracks.append((run_id, polyline, point_count))
+
+    def recalculate_user_stats(self, _uid: UUID, timezone: str = "UTC") -> None:
+        self.stats_calls.append(timezone)
+
+
+class _UsersRepo:
+    def __init__(self) -> None:
+        self.created: list[tuple[UUID, str, str | None]] = []
+
+    def __call__(self, _sb: Any) -> _UsersRepo:
+        return self
+
+    def get_or_create_source(
+        self, user_id: UUID, source_type: str, source_username: str | None = None
+    ) -> UUID:
+        self.created.append((user_id, source_type, source_username))
+        return SOURCE_ID
+
+
+@pytest.fixture
+def repos(monkeypatch: Any) -> tuple[_RunsRepo, _UsersRepo]:
+    runs_repo, users_repo = _RunsRepo(), _UsersRepo()
+    monkeypatch.setattr(imports_module, "get_supabase_client", lambda: object())
+    monkeypatch.setattr(imports_module, "RunsRepository", runs_repo)
+    monkeypatch.setattr(imports_module, "UsersRepository", users_repo)
+
+    async def _no_cache(_uid: UUID) -> int:
+        return 0
+
+    monkeypatch.setattr(imports_module, "invalidate_user", _no_cache)
+    return runs_repo, users_repo
+
+
+async def _import(
+    filename: str | None,
+    data: bytes,
+    timezone: str = "America/New_York",
+) -> dict[str, Any]:
+    return await imports_module.import_activity(
+        user_id=USER, file=_Upload(filename, data), timezone=timezone
+    )
+
+
+async def test_gpx_upload_creates_a_run_and_a_track(repos: tuple[_RunsRepo, _UsersRepo]) -> None:
+    runs_repo, users_repo = repos
+    out = await _import("run.gpx", GPX)
+
+    assert out["status"] == "imported"
+    assert out["run_id"] == str(RUN_ID)
+    assert out["has_track"] is True
+    assert users_repo.created == [(USER, "import", "file-import")]
+    assert runs_repo.tracks and runs_repo.tracks[0][0] == RUN_ID
+
+
+async def test_imported_run_is_scoped_to_the_caller(repos: tuple[_RunsRepo, _UsersRepo]) -> None:
+    runs_repo, _ = repos
+    await _import("run.gpx", GPX)
+    assert runs_repo.upserted is not None
+    assert runs_repo.upserted["user_id"] == str(USER)
+    assert runs_repo.upserted["source_id"] == str(SOURCE_ID)
+
+
+async def test_local_date_comes_from_the_requested_timezone(
+    repos: tuple[_RunsRepo, _UsersRepo],
+) -> None:
+    runs_repo, _ = repos
+    # 11:00 UTC is 04:00 in Los Angeles — still the 10th, but a different hour,
+    # and the stored zone has to say which reading produced the date.
+    await _import("run.gpx", GPX, timezone="America/Los_Angeles")
+    assert runs_repo.upserted is not None
+    assert runs_repo.upserted["start_date"] == "2026-08-10"
+    assert runs_repo.upserted["start_hour"] == 4
+    assert runs_repo.upserted["timezone"] == "America/Los_Angeles"
+    assert runs_repo.stats_calls == ["America/Los_Angeles"]
+
+
+async def test_reupload_is_reported_as_duplicate_not_an_error(monkeypatch: Any) -> None:
+    existing = {
+        "id": str(RUN_ID),
+        "distance_km": "0.222",
+        "duration_seconds": "120",
+        "start_date_time_local": "2026-08-10T07:00:00-04:00",
+        "has_gps_data": True,
+    }
+    runs_repo, users_repo = _RunsRepo(existing=existing), _UsersRepo()
+    monkeypatch.setattr(imports_module, "get_supabase_client", lambda: object())
+    monkeypatch.setattr(imports_module, "RunsRepository", runs_repo)
+    monkeypatch.setattr(imports_module, "UsersRepository", users_repo)
+
+    out = await _import("run.gpx", GPX)
+
+    assert out["status"] == "duplicate"
+    assert out["run_id"] == str(RUN_ID)
+    # Nothing was written: no source created, no upsert, no track.
+    assert users_repo.created == []
+    assert runs_repo.upserted is None
+    assert runs_repo.tracks == []
+
+
+async def test_smashrun_json_upload_has_no_track(repos: tuple[_RunsRepo, _UsersRepo]) -> None:
+    runs_repo, _ = repos
+    out = await _import("export.json", SMASHRUN)
+    assert out["status"] == "imported"
+    assert out["has_track"] is False
+    assert runs_repo.tracks == []
+
+
+async def test_wrong_file_type_is_415(repos: tuple[_RunsRepo, _UsersRepo]) -> None:
+    with pytest.raises(HTTPException) as err:
+        await _import("photo.png", b"\x89PNG")
+    assert err.value.status_code == 415
+    assert "Supported formats" in err.value.detail
+
+
+async def test_oversized_upload_is_413_and_stops_reading(
+    repos: tuple[_RunsRepo, _UsersRepo],
+) -> None:
+    oversized = b"x" * (imports_module.MAX_UPLOAD_BYTES + 1024)
+    with pytest.raises(HTTPException) as err:
+        await _import("run.gpx", oversized)
+    assert err.value.status_code == 413
+
+
+async def test_unparseable_file_is_422_with_a_readable_reason(
+    repos: tuple[_RunsRepo, _UsersRepo],
+) -> None:
+    with pytest.raises(HTTPException) as err:
+        await _import("run.gpx", b"<gpx><trk>")
+    assert err.value.status_code == 422
+    assert "not valid XML" in err.value.detail
+
+
+async def test_missing_filename_is_400(repos: tuple[_RunsRepo, _UsersRepo]) -> None:
+    with pytest.raises(HTTPException) as err:
+        await _import(None, GPX)
+    assert err.value.status_code == 400
+
+
+async def test_stats_failure_does_not_fail_the_import(
+    repos: tuple[_RunsRepo, _UsersRepo], monkeypatch: Any
+) -> None:
+    runs_repo, _ = repos
+
+    def _boom(_uid: UUID, timezone: str = "UTC") -> None:
+        raise RuntimeError("rpc down")
+
+    monkeypatch.setattr(runs_repo, "recalculate_user_stats", _boom)
+    out = await _import("run.gpx", GPX)
+    assert out["status"] == "imported"
+
+
+async def test_formats_endpoint_states_the_limits() -> None:
+    out = await imports_module.import_formats(_user_id=USER)
+    assert out["extensions"] == [".gpx", ".json", ".tcx"]
+    assert out["max_bytes"] == imports_module.MAX_UPLOAD_BYTES

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -386,6 +386,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "deprecation"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1025,6 +1034,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "authlib" },
     { name = "boto3" },
+    { name = "defusedxml" },
     { name = "fastapi" },
     { name = "google-cloud-storage" },
     { name = "httpx" },
@@ -1032,6 +1042,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-dateutil" },
+    { name = "python-multipart" },
     { name = "pytz" },
     { name = "redis" },
     { name = "structlog" },
@@ -1054,6 +1065,7 @@ dev = [
 requires-dist = [
     { name = "authlib", specifier = ">=1.3.0" },
     { name = "boto3", specifier = ">=1.35.0" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "fakeredis", marker = "extra == 'dev'", specifier = ">=2.20.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "google-cloud-storage", specifier = ">=3.10.1" },
@@ -1067,6 +1079,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "python-dateutil", specifier = ">=2.9.0" },
+    { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "pytz", specifier = ">=2024.1" },
     { name = "redis", specifier = ">=5.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.0" },
@@ -1554,6 +1567,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]

--- a/docs/SOURCES_AND_IMPORT.md
+++ b/docs/SOURCES_AND_IMPORT.md
@@ -1,6 +1,7 @@
 # Data Sources, BYOK & Import — Design
 
-**Status:** Proposed (2026-06-01)
+**Status:** Partly shipped — single-run file import live (SB-99, 2026-08-14);
+provider abstraction and bulk zip import still proposed (2026-06-01)
 **Owner:** @silverbeer
 **Related:** `docs/GOALS_TRACKING.md`, `docs/SMASHRUN_OAUTH.md`
 
@@ -103,10 +104,37 @@ A first-class ingestion path for sources without a live API, for backfill, and
 as a manual fallback. Modeled as an **import provider** (add `import` to the
 `source_type` enum, or reuse `other` with a marker).
 
-### Single-run import
-Upload one activity file → parse → `Activity` → upsert into `runs`. Idempotent
-via dedup key (`source_activity_id` or a content hash) so re-uploads don't
-duplicate.
+### Single-run import — **shipped (SB-99)**
+
+`POST /import/activity` (multipart: `file`, optional `timezone`). Upload one
+activity file → parse → `Activity` → upsert into `runs`. Synchronous: a single
+file parses in milliseconds, so it answers in the request.
+
+- **Parsers** live in `src/shared/importers/` — one module per format, all
+  producing the same `Activity` the SmashRun sync produces, so imported runs
+  are stored, deduped and displayed exactly like synced ones.
+- **Source row.** Imported runs hang off a `user_sources` row of type
+  `import`, created lazily on a user's first upload
+  (`UsersRepository.get_or_create_source`). Provenance is then a type, not a
+  naming convention: a run came from a file iff its source is `import`.
+- **Dedup key** (`source_activity_id`, prefixed by format):
+  - TCX → `tcx-<Activity/Id>`; the id is stable across re-exports of the run.
+  - SmashRun JSON → `smashrun-<activityId>`. Prefixed so an imported run can
+    never collide with the same activity arriving later over OAuth sync.
+  - GPX → `gpx-<sha256(file)[:24]>`; GPX states no id, so the bytes are the key.
+- **GPS track.** GPX/TCX trackpoints are simplified and stored in `run_tracks`
+  (`simplify_and_encode` → `upsert_track`), so an imported run gets a route map.
+- **Timezone.** GPX and TCX record UTC. The request's `timezone` (default
+  `America/New_York`) is what their timestamps are read into, and it is stored
+  on the run — without it a 9pm run lands on tomorrow and breaks the streak.
+  SmashRun JSON already states local time with an offset and is left alone.
+- **Distance/duration.** TCX's stated lap totals win over the track. GPX has
+  neither, so distance is summed over the trackpoints and duration excludes
+  gaps longer than 60s (a paused watch, not a slow kilometre).
+- **CLI:** `stk import <file> [--timezone ZONE]`, ahead of the upload UI (SB-418).
+
+Re-uploading an already-imported file returns `status: "duplicate"` and writes
+nothing — a re-upload is a reasonable thing to do, not an error.
 
 ### Bulk zip import
 Upload a `.zip` (a full SmashRun/Strava data export, or many activity files) →
@@ -114,8 +142,8 @@ unzip → iterate → batch upsert with per-file results (imported / skipped-dup
 failed). This is the migration/backfill path; safe to re-run.
 
 ### Formats (phase the parsers)
-- **Phase A:** GPX + TCX (XML, simplest) and SmashRun export JSON.
-- **Phase B:** FIT (binary — needs `fitparse` / Garmin FIT SDK), Strava export.
+- **Phase A (shipped, SB-99):** GPX + TCX (XML, simplest) and SmashRun export JSON.
+- **Phase B (SB-421):** FIT (binary — needs `fitparse` / Garmin FIT SDK), Strava export.
 
 ### Processing model
 - Small single file → synchronous parse + upsert in the request.
@@ -128,6 +156,12 @@ failed). This is the migration/backfill path; safe to re-run.
   (entry-count + uncompressed-size caps).
 - File-type allowlist (`.gpx`/`.tcx`/`.fit`/`.json`/`.zip`); reject everything
   else. Scope all writes to the authenticated user.
+
+Single-file import enforces this today: extension checked before any parsing
+(415), 10 MB cap applied while streaming the upload so an oversized file costs
+one 64 KB chunk rather than its full size (413), and XML parsed through
+`defusedxml` — `xml.etree` is entity-bomb prone, and a size cap does not help
+when a few hundred bytes of nested entities can exhaust memory.
 
 ## Strava specifics
 
@@ -175,6 +209,11 @@ how we integrate. Key points, from the June 2026 Strava API Team announcement:
   a free account against a dev build, and (2) emailing `api@smashrun.com`.**
   (Primary target is Pro users either way.)
 - Encryption approach for stored tokens / keys: pgcrypto vs. app-level envelope.
-- `import` as a new `source_type` enum value vs. reuse `other` + a flag.
-- Where do uploaded raw files live — ephemeral (parse-and-discard) vs. retained
-  in object storage for re-processing? Retention has privacy implications.
+- **Answered (SB-99):** `import` is its own `source_type` enum value
+  (migration `20260814000000_add_import_source_type.sql`), not `other` + a flag.
+- **Answered (SB-99):** uploaded files are parse-and-discard. Nothing is
+  retained, so there is no new privacy surface; re-processing means
+  re-uploading. Revisit only if bulk zip import (SB-419) needs resumability.
+- **Open:** a run imported from a file and later synced from SmashRun lands as
+  two rows — different `source_id`, so the upsert key can't see the collision.
+  Cross-source dedup (same start time + distance) is not built.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pydantic-settings>=2.5.0",
 
     # Utilities
+    "defusedxml>=0.7.1",  # GPX/TCX import parses user uploads (SB-99)
     "python-dateutil>=2.9.0",
     "pytz>=2024.1",  # Required by DuckDB for timezone operations
 ]
@@ -106,5 +107,6 @@ disallow_untyped_calls = false
 [dependency-groups]
 dev = [
     "pre-commit>=4.6.0",
+    "types-defusedxml>=0.7",
     "types-python-dateutil>=2.9.0.20251115",
 ]

--- a/src/shared/geo.py
+++ b/src/shared/geo.py
@@ -125,3 +125,27 @@ def simplify_and_encode(
     pts = list(zip(lat, lon, strict=True))
     simplified = douglas_peucker(pts, tolerance_m)
     return encode_polyline(simplified), len(simplified)
+
+
+_EARTH_RADIUS_KM = 6371.0088
+
+
+def haversine_km(a: tuple[float, float], b: tuple[float, float]) -> float:
+    """Great-circle distance in km between two (lat, lon) points."""
+    lat1, lon1 = math.radians(a[0]), math.radians(a[1])
+    lat2, lon2 = math.radians(b[0]), math.radians(b[1])
+    dlat, dlon = lat2 - lat1, lon2 - lon1
+    h = math.sin(dlat / 2) ** 2 + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2) ** 2
+    return 2 * _EARTH_RADIUS_KM * math.asin(math.sqrt(h))
+
+
+def path_length_km(points: list[tuple[float, float]]) -> float:
+    """Total length of a (lat, lon) path in km.
+
+    Used by file import (SB-99): GPX carries trackpoints but no distance field,
+    so the run's distance has to come from the track itself. Summing raw
+    consecutive fixes slightly over-reads distance because GPS noise adds
+    length, which is why this is only a fallback for formats that state no
+    distance of their own — TCX does, and that stated value wins.
+    """
+    return sum(haversine_km(points[i - 1], points[i]) for i in range(1, len(points)))

--- a/src/shared/importers/__init__.py
+++ b/src/shared/importers/__init__.py
@@ -1,0 +1,38 @@
+"""Activity-file import: parse GPX / TCX / SmashRun JSON into an ``Activity`` (SB-99).
+
+One parser per format, all funnelling into the same canonical model the
+SmashRun sync already produces — so imported runs are stored, deduped and
+displayed exactly like synced ones.
+"""
+
+from .dispatch import (
+    ALLOWED_EXTENSIONS,
+    DEFAULT_TIMEZONE,
+    MAX_UPLOAD_BYTES,
+    parse_activity_file,
+)
+from .errors import (
+    ActivityParseError,
+    FileTooLargeError,
+    NoRunFoundError,
+    UnsupportedFileError,
+)
+from .gpx import parse_gpx
+from .models import ParsedActivityFile
+from .smashrun_json import parse_smashrun_json
+from .tcx import parse_tcx
+
+__all__ = [
+    "ALLOWED_EXTENSIONS",
+    "DEFAULT_TIMEZONE",
+    "MAX_UPLOAD_BYTES",
+    "ActivityParseError",
+    "FileTooLargeError",
+    "NoRunFoundError",
+    "ParsedActivityFile",
+    "UnsupportedFileError",
+    "parse_activity_file",
+    "parse_gpx",
+    "parse_smashrun_json",
+    "parse_tcx",
+]

--- a/src/shared/importers/dispatch.py
+++ b/src/shared/importers/dispatch.py
@@ -1,0 +1,93 @@
+"""Entry point for activity-file import: pick a parser, enforce upload safety (SB-99).
+
+The size cap and the extension allowlist are checked *before* any parsing, so a
+200 MB or wrong-format upload is rejected without ever reaching an XML or JSON
+decoder.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import PurePosixPath
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from .errors import ActivityParseError, FileTooLargeError, UnsupportedFileError
+from .gpx import parse_gpx
+from .models import ParsedActivityFile
+from .smashrun_json import parse_smashrun_json
+from .tcx import parse_tcx
+
+# A GPX with per-second fixes runs ~100 KB/hour; 10 MB is a very long ultra with
+# room to spare, while still bounding what one request can hold in memory.
+MAX_UPLOAD_BYTES = 10 * 1024 * 1024
+
+# The timezone GPX/TCX timestamps are read into when the caller states none.
+# Matches the default already used for streak/date boundaries elsewhere.
+DEFAULT_TIMEZONE = "America/New_York"
+
+PARSERS: dict[str, Callable[[bytes], ParsedActivityFile]] = {
+    ".gpx": parse_gpx,
+    ".tcx": parse_tcx,
+    ".json": parse_smashrun_json,
+}
+
+ALLOWED_EXTENSIONS = tuple(sorted(PARSERS))
+
+
+def _extension(filename: str) -> str:
+    return PurePosixPath(filename.strip()).suffix.lower()
+
+
+def parse_activity_file(
+    filename: str,
+    content: bytes,
+    timezone: str = DEFAULT_TIMEZONE,
+) -> ParsedActivityFile:
+    """Parse one uploaded activity file.
+
+    Args:
+        filename: Original file name — only its extension is used, never as a path.
+        content: Raw file bytes.
+        timezone: IANA zone the run happened in; applied to formats that record
+            in UTC so the run lands on the right local date.
+
+    Returns:
+        The parsed activity plus its GPS track, if any.
+
+    Raises:
+        UnsupportedFileError: extension not in the allowlist.
+        FileTooLargeError: content exceeds MAX_UPLOAD_BYTES.
+        ActivityParseError: unparseable file, unknown timezone, or no usable run.
+    """
+    extension = _extension(filename)
+    parser = PARSERS.get(extension)
+    if parser is None:
+        allowed = ", ".join(ALLOWED_EXTENSIONS)
+        raise UnsupportedFileError(
+            f"{extension or 'This file'} can't be imported. Supported formats: {allowed}."
+        )
+
+    if len(content) > MAX_UPLOAD_BYTES:
+        limit_mb = MAX_UPLOAD_BYTES // (1024 * 1024)
+        raise FileTooLargeError(f"File is larger than the {limit_mb} MB limit.")
+    if not content.strip():
+        raise ActivityParseError("File is empty.")
+
+    try:
+        zone = ZoneInfo(timezone)
+    except (ZoneInfoNotFoundError, ValueError) as exc:
+        raise ActivityParseError(f"Unknown timezone '{timezone}'.") from exc
+
+    parsed = parser(content)
+    if not parsed.times_are_utc:
+        return parsed
+
+    localized = parsed.activity.model_copy(
+        update={"start_date_time_local": parsed.activity.start_date_time_local.astimezone(zone)}
+    )
+    return ParsedActivityFile(
+        activity=localized,
+        latitudes=parsed.latitudes,
+        longitudes=parsed.longitudes,
+        times_are_utc=False,
+    )

--- a/src/shared/importers/errors.py
+++ b/src/shared/importers/errors.py
@@ -1,0 +1,24 @@
+"""Errors raised while parsing an uploaded activity file (SB-99).
+
+Every message here is user-facing: it is returned verbatim by the import
+endpoint, so it must say what is wrong with *their* file, not what went wrong
+inside the parser.
+"""
+
+from __future__ import annotations
+
+
+class ActivityParseError(ValueError):
+    """The file could not be turned into an activity."""
+
+
+class UnsupportedFileError(ActivityParseError):
+    """The file's extension is not one we can parse."""
+
+
+class FileTooLargeError(ActivityParseError):
+    """The upload exceeds the size cap."""
+
+
+class NoRunFoundError(ActivityParseError):
+    """The file parsed, but holds no runnable activity (empty, or not a run)."""

--- a/src/shared/importers/gpx.py
+++ b/src/shared/importers/gpx.py
@@ -1,0 +1,137 @@
+"""GPX parser (SB-99).
+
+GPX is a track format, not an activity format: it states where you were and
+when, and nothing else. Distance and duration are therefore *derived* from the
+trackpoints. Heart rate and cadence, when present, live in the Garmin
+TrackPointExtension namespace that most watches and apps write.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime
+from xml.etree.ElementTree import Element
+
+from src.shared.geo import path_length_km
+from src.shared.models import Activity
+
+from .errors import NoRunFoundError
+from .models import ParsedActivityFile
+from .xml_common import child_text, find_all, mean, parse_timestamp, parse_xml
+
+# GPS fixes 60s+ apart are a paused watch, not a slow kilometre. Elapsed time
+# includes such gaps; the run's duration should not, so they are subtracted —
+# this keeps an imported pace comparable with a SmashRun-synced one, whose
+# duration already excludes pauses.
+PAUSE_GAP_SECONDS = 60.0
+
+
+def _trackpoints(root: Element) -> list[Element]:
+    return find_all(root, "trkpt")
+
+
+def _point_values(
+    points: list[Element],
+) -> tuple[
+    list[float],
+    list[float],
+    list[datetime],
+    list[float],
+    list[float],
+]:
+    """(lats, lons, times, heart rates, cadences) — each list only as long as
+    the data actually present, since a fix may carry coordinates but no HR."""
+    lats: list[float] = []
+    lons: list[float] = []
+    times: list[datetime] = []
+    heart_rates: list[float] = []
+    cadences: list[float] = []
+
+    for point in points:
+        lat, lon = point.get("lat"), point.get("lon")
+        if lat is None or lon is None:
+            continue
+        try:
+            lats.append(float(lat))
+            lons.append(float(lon))
+        except ValueError:
+            continue
+
+        when = parse_timestamp(child_text(point, "time"))
+        if when is not None:
+            times.append(when)
+
+        # TrackPointExtension: <gpxtpx:hr>, <gpxtpx:cad>. Namespace-agnostic
+        # lookup — Garmin, Strava and Apple all write different URIs here.
+        for name, sink in (("hr", heart_rates), ("cad", cadences)):
+            raw = child_text(point, name)
+            if raw is None:
+                continue
+            try:
+                sink.append(float(raw))
+            except ValueError:
+                continue
+
+    return lats, lons, times, heart_rates, cadences
+
+
+def _moving_seconds(times: list[datetime]) -> float:
+    """Elapsed time minus paused gaps."""
+    total = 0.0
+    for i in range(1, len(times)):
+        gap = (times[i] - times[i - 1]).total_seconds()
+        if 0 < gap <= PAUSE_GAP_SECONDS:
+            total += gap
+    return total
+
+
+def parse_gpx(content: bytes) -> ParsedActivityFile:
+    """Parse GPX bytes into a ParsedActivityFile.
+
+    Raises:
+        ActivityParseError: file is not valid XML.
+        NoRunFoundError: no usable track (no points, no time, or zero distance).
+    """
+    root = parse_xml(content)
+    points = _trackpoints(root)
+    if not points:
+        raise NoRunFoundError("No GPS trackpoints found — is this an empty or route-only GPX?")
+
+    lats, lons, times, heart_rates, cadences = _point_values(points)
+    if len(lats) < 2:
+        raise NoRunFoundError("Track has fewer than two GPS points, so it has no distance.")
+    if len(times) < 2:
+        raise NoRunFoundError("Trackpoints carry no timestamps, so the run has no duration.")
+
+    distance_km = path_length_km(list(zip(lats, lons, strict=True)))
+    duration_seconds = _moving_seconds(times)
+    if distance_km <= 0 or duration_seconds <= 0:
+        raise NoRunFoundError("Track covers no distance or no time.")
+
+    # GPX states no activity id of its own, so the file's own bytes are the
+    # dedup key: re-uploading the same export is then a no-op, which is the
+    # idempotency the endpoint promises.
+    digest = hashlib.sha256(content).hexdigest()[:24]
+
+    # <trk><name> is the run's title in most writers ("Morning Run"). It is a
+    # label, not an identifier, so it lands in notes rather than external_id.
+    track = find_all(root, "trk")
+    title = child_text(track[0], "name") if track else None
+
+    activity = Activity(
+        activityId=f"gpx-{digest}",
+        startDateTimeLocal=min(times),
+        distance=distance_km,
+        duration=duration_seconds,
+        notes=title[:800] if title else None,
+        startLatitude=lats[0],
+        startLongitude=lons[0],
+        hasDetailsGPS=True,
+        heartRateAverage=mean(heart_rates),
+        heartRateMin=min(heart_rates) if heart_rates else None,
+        heartRateMax=max(heart_rates) if heart_rates else None,
+        cadenceAverage=mean(cadences),
+        cadenceMin=min(cadences) if cadences else None,
+        cadenceMax=max(cadences) if cadences else None,
+    )
+    return ParsedActivityFile(activity=activity, latitudes=lats, longitudes=lons)

--- a/src/shared/importers/models.py
+++ b/src/shared/importers/models.py
@@ -1,0 +1,31 @@
+"""What a parsed activity file yields (SB-99)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from src.shared.models import Activity
+
+
+@dataclass(frozen=True)
+class ParsedActivityFile:
+    """One activity file, normalized.
+
+    ``activity`` is the canonical model every source already funnels into, so
+    the import path reuses ``activity_to_run_dict`` + ``upsert_run`` unchanged.
+    ``latitudes``/``longitudes`` carry the GPS track when the file has one —
+    stored separately in ``run_tracks``, exactly as the SmashRun sync does.
+    """
+
+    activity: Activity
+    latitudes: list[float] = field(default_factory=list)
+    longitudes: list[float] = field(default_factory=list)
+    # GPX and TCX record in UTC, so their timestamps have to be moved into the
+    # runner's zone before the run's *date* is taken — a 9pm run would
+    # otherwise land on tomorrow and break the streak. SmashRun's export
+    # already states local time with an offset, and must be left alone.
+    times_are_utc: bool = True
+
+    @property
+    def has_track(self) -> bool:
+        return len(self.latitudes) >= 2 and len(self.latitudes) == len(self.longitudes)

--- a/src/shared/importers/smashrun_json.py
+++ b/src/shared/importers/smashrun_json.py
@@ -1,0 +1,80 @@
+"""SmashRun export JSON parser (SB-99).
+
+SmashRun's export is the same shape its API returns, which is the shape the
+``Activity`` model already speaks — so this parser is mostly validation plus
+pulling the GPS track out of the parallel ``recordingKeys`` /
+``recordingValues`` arrays.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from src.shared.models import Activity
+
+from .errors import ActivityParseError, NoRunFoundError
+from .models import ParsedActivityFile
+
+
+def _extract_track(payload: dict[str, Any]) -> tuple[list[float], list[float]]:
+    """Latitude/longitude series out of the recording arrays, if present."""
+    keys = payload.get("recordingKeys")
+    values = payload.get("recordingValues")
+    if not isinstance(keys, list) or not isinstance(values, list):
+        return [], []
+    if "latitude" not in keys or "longitude" not in keys:
+        return [], []
+
+    lat_index, lon_index = keys.index("latitude"), keys.index("longitude")
+    if lat_index >= len(values) or lon_index >= len(values):
+        return [], []
+
+    lats = [float(v) for v in values[lat_index]]
+    lons = [float(v) for v in values[lon_index]]
+    # A truncated export can leave the series ragged; the shorter one wins
+    # rather than failing the whole import over a few trailing fixes.
+    size = min(len(lats), len(lons))
+    return lats[:size], lons[:size]
+
+
+def parse_smashrun_json(content: bytes) -> ParsedActivityFile:
+    """Parse a SmashRun activity JSON export into a ParsedActivityFile.
+
+    Raises:
+        ActivityParseError: not valid JSON, or not a single activity object.
+        NoRunFoundError: the payload holds no activity.
+    """
+    try:
+        payload = json.loads(content)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ActivityParseError(f"File is not valid JSON: {exc}") from exc
+
+    if isinstance(payload, list):
+        if not payload:
+            raise NoRunFoundError("The JSON file holds no activities.")
+        if len(payload) > 1:
+            raise ActivityParseError(
+                f"This file holds {len(payload)} activities. "
+                "Single-file import takes one run at a time."
+            )
+        payload = payload[0]
+
+    if not isinstance(payload, dict):
+        raise ActivityParseError("Expected a JSON object describing one activity.")
+
+    try:
+        activity = Activity.model_validate(payload)
+    except Exception as exc:  # pydantic ValidationError, surfaced to the user
+        raise ActivityParseError(f"Activity is missing required fields: {exc}") from exc
+
+    lats, lons = _extract_track(payload)
+    # Re-key so an imported run can never collide with the same activity
+    # arriving later over the SmashRun OAuth sync, which owns the bare id.
+    activity = activity.model_copy(update={"activity_id": f"smashrun-{activity.activity_id}"})
+    return ParsedActivityFile(
+        activity=activity,
+        latitudes=lats,
+        longitudes=lons,
+        times_are_utc=False,  # startDateTimeLocal is already local, with offset
+    )

--- a/src/shared/importers/tcx.py
+++ b/src/shared/importers/tcx.py
@@ -1,0 +1,124 @@
+"""TCX parser (SB-99).
+
+Unlike GPX, TCX is an *activity* format: each lap states its own distance and
+elapsed time, and the activity states an id and a sport. Those stated values
+are trusted over anything derived from the trackpoints — the watch knows its
+own wheel/stride calibration, and summing raw GPS fixes over-reads distance.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from xml.etree.ElementTree import Element
+
+from src.shared.geo import path_length_km
+from src.shared.models import Activity
+
+from .errors import NoRunFoundError
+from .models import ParsedActivityFile
+from .xml_common import child_float, child_text, find_all, mean, parse_timestamp, parse_xml
+
+# TCX Sport attribute values we accept. Biking/Other files parse fine but are
+# not runs, and the runs table is running-only (ActivityType has one member).
+RUN_SPORTS = {"running", "run"}
+
+
+def _track_series(
+    activity_el: Element,
+) -> tuple[
+    list[float],
+    list[float],
+    list[float],
+    list[float],
+]:
+    """(lats, lons, heart rates, cadences) across every trackpoint."""
+    lats: list[float] = []
+    lons: list[float] = []
+    heart_rates: list[float] = []
+    cadences: list[float] = []
+
+    for point in find_all(activity_el, "Trackpoint"):
+        lat = child_float(point, "LatitudeDegrees")
+        lon = child_float(point, "LongitudeDegrees")
+        if lat is not None and lon is not None:
+            lats.append(lat)
+            lons.append(lon)
+
+        # <HeartRateBpm><Value>N</Value></HeartRateBpm> — the nested lookup
+        # finds Value wherever the writer nested it.
+        heart_rate = child_float(point, "HeartRateBpm")
+        if heart_rate is None:
+            hr_el = find_all(point, "HeartRateBpm")
+            heart_rate = child_float(hr_el[0], "Value") if hr_el else None
+        if heart_rate is not None:
+            heart_rates.append(heart_rate)
+
+        # Plain <Cadence>, or <Extensions><TPX><RunCadence> on Garmin.
+        cadence = child_float(point, "Cadence")
+        if cadence is None:
+            cadence = child_float(point, "RunCadence")
+        if cadence is not None:
+            cadences.append(cadence)
+
+    return lats, lons, heart_rates, cadences
+
+
+def parse_tcx(content: bytes) -> ParsedActivityFile:
+    """Parse TCX bytes into a ParsedActivityFile.
+
+    Raises:
+        ActivityParseError: file is not valid XML.
+        NoRunFoundError: no activity, not a run, or zero distance/duration.
+    """
+    root = parse_xml(content)
+    activities = find_all(root, "Activity")
+    if not activities:
+        raise NoRunFoundError("No activity found in the TCX file.")
+
+    activity_el = activities[0]
+    sport = (activity_el.get("Sport") or "").strip().lower()
+    if sport and sport not in RUN_SPORTS:
+        raise NoRunFoundError(f"This file is a {sport} activity, and only runs can be imported.")
+
+    laps = find_all(activity_el, "Lap")
+    distance_km = sum(child_float(lap, "DistanceMeters") or 0.0 for lap in laps) / 1000
+    duration_seconds = sum(child_float(lap, "TotalTimeSeconds") or 0.0 for lap in laps)
+
+    lats, lons, heart_rates, cadences = _track_series(activity_el)
+
+    # Some exporters write laps without distance; fall back to the track.
+    if distance_km <= 0 and len(lats) >= 2:
+        distance_km = path_length_km(list(zip(lats, lons, strict=True)))
+
+    if distance_km <= 0 or duration_seconds <= 0:
+        raise NoRunFoundError("Activity states no distance or no elapsed time.")
+
+    started = parse_timestamp(child_text(activity_el, "Id")) or parse_timestamp(
+        child_text(activity_el, "Time")
+    )
+    if started is None:
+        raise NoRunFoundError("Activity has no start time.")
+
+    # <Id> is TCX's activity identifier (the start timestamp, per the schema).
+    # It is stable across re-exports of the same run, which makes it a better
+    # dedup key than the file bytes — those change when the exporter changes.
+    raw_id = child_text(activity_el, "Id")
+    identity = raw_id or hashlib.sha256(content).hexdigest()[:24]
+
+    activity = Activity(
+        activityId=f"tcx-{identity}",
+        startDateTimeLocal=started,
+        distance=distance_km,
+        duration=duration_seconds,
+        startLatitude=lats[0] if lats else None,
+        startLongitude=lons[0] if lons else None,
+        hasDetailsGPS=len(lats) >= 2,
+        isTreadmill=not lats,
+        heartRateAverage=mean(heart_rates),
+        heartRateMin=min(heart_rates) if heart_rates else None,
+        heartRateMax=max(heart_rates) if heart_rates else None,
+        cadenceAverage=mean(cadences),
+        cadenceMin=min(cadences) if cadences else None,
+        cadenceMax=max(cadences) if cadences else None,
+    )
+    return ParsedActivityFile(activity=activity, latitudes=lats, longitudes=lons)

--- a/src/shared/importers/xml_common.py
+++ b/src/shared/importers/xml_common.py
@@ -1,0 +1,92 @@
+"""Shared XML helpers for the GPX/TCX parsers (SB-99).
+
+Parsing is done with ``defusedxml``: these files are user uploads, and
+``xml.etree`` is documented as vulnerable to entity-expansion ("billion
+laughs") and quadratic-blowup attacks. A size cap alone does not help — a few
+hundred bytes of nested entities is enough to exhaust memory.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from xml.etree.ElementTree import Element
+
+from defusedxml.ElementTree import ParseError, fromstring
+
+from .errors import ActivityParseError
+
+
+def parse_xml(content: bytes) -> Element:
+    """Safely parse XML bytes into an element tree root."""
+    try:
+        root: Element = fromstring(content)
+    except ParseError as exc:
+        raise ActivityParseError(f"File is not valid XML: {exc}") from exc
+    return root
+
+
+def local_name(tag: str) -> str:
+    """``{http://ns}trkpt`` -> ``trkpt``.
+
+    GPX and TCX both namespace every element, and the namespace URI varies by
+    the app that wrote the file (and by schema version). Matching on the local
+    name keeps the parsers working across writers instead of hard-coding one
+    vendor's URI.
+    """
+    return tag.rsplit("}", 1)[-1]
+
+
+def find_all(element: Element, name: str) -> list[Element]:
+    """Every descendant whose local name matches, namespace ignored."""
+    return [el for el in element.iter() if local_name(el.tag) == name]
+
+
+def find_first(element: Element, name: str) -> Element | None:
+    for el in element.iter():
+        if local_name(el.tag) == name:
+            return el
+    return None
+
+
+def child_text(element: Element, name: str) -> str | None:
+    """Text of the first *direct or nested* child with this local name."""
+    found = find_first(element, name)
+    if found is None or found.text is None:
+        return None
+    text = found.text.strip()
+    return text or None
+
+
+def child_float(element: Element, name: str) -> float | None:
+    raw = child_text(element, name)
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        return None
+
+
+def parse_timestamp(raw: str | None) -> datetime | None:
+    """ISO-8601 timestamp as written by GPX/TCX (``...Z`` or with an offset)."""
+    if not raw:
+        return None
+    text = raw.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    # A file that states no offset is UTC by both specs.
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+
+def mean(values: list[float]) -> float | None:
+    return sum(values) / len(values) if values else None
+
+
+def as_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/src/shared/supabase_ops/users_repository.py
+++ b/src/shared/supabase_ops/users_repository.py
@@ -206,6 +206,68 @@ class UsersRepository:
 
         return data_list[0]
 
+    def get_or_create_source(
+        self,
+        user_id: UUID,
+        source_type: str,
+        source_username: str | None = None,
+    ) -> UUID:
+        """Source id for (user, source_type), creating the row if it's absent.
+
+        Used by file import (SB-99), where there is no connect flow to create
+        the source up front — the first upload creates it. ``user_sources`` is
+        UNIQUE on (user_id, source_type), so a concurrent first upload loses
+        the insert race and re-reads the winner's row rather than failing.
+
+        Args:
+            user_id: User UUID
+            source_type: Source type (e.g. 'import')
+            source_username: Human-readable label for the source
+
+        Returns:
+            The user_source UUID
+        """
+        existing = (
+            self.supabase.table("user_sources")
+            .select("id")
+            .eq("user_id", str(user_id))
+            .eq("source_type", source_type)
+            .limit(1)
+            .execute()
+        )
+        rows = cast(list[dict[str, Any]], existing.data)
+        if rows:
+            return UUID(rows[0]["id"])
+
+        try:
+            created = (
+                self.supabase.table("user_sources")
+                .insert(
+                    {
+                        "user_id": str(user_id),
+                        "source_type": source_type,
+                        "source_username": source_username,
+                    }
+                )
+                .execute()
+            )
+            inserted = cast(list[dict[str, Any]], created.data)
+            logger.info(f"Created {source_type} source for user {user_id}")
+            return UUID(inserted[0]["id"])
+        except Exception:
+            retry = (
+                self.supabase.table("user_sources")
+                .select("id")
+                .eq("user_id", str(user_id))
+                .eq("source_type", source_type)
+                .limit(1)
+                .execute()
+            )
+            rows = cast(list[dict[str, Any]], retry.data)
+            if rows:
+                return UUID(rows[0]["id"])
+            raise
+
     def get_user_sources(self, user_id: UUID, active_only: bool = True) -> list[dict[str, Any]]:
         """
         Get all data sources for a user.

--- a/stk/src/cli/api.py
+++ b/stk/src/cli/api.py
@@ -295,6 +295,56 @@ def post_request(
     return _write_request("POST", endpoint, data, params, timeout)
 
 
+def post_file(
+    endpoint: str,
+    filename: str,
+    content: bytes,
+    form: dict[str, str] | None = None,
+    timeout: float | None = None,
+) -> dict[str, Any]:
+    """Authenticated multipart POST of a single file (SB-99: activity import).
+
+    Separate from ``_write_request`` because that one always sends JSON, and a
+    file upload has to go as multipart/form-data.
+    """
+    s = _ensure_fresh(_require_session())
+    url = f"{get_api_url()}/{endpoint.lstrip('/')}"
+    request_timeout = timeout if timeout else TIMEOUT
+
+    def _send(sess: Any) -> httpx.Response:
+        return httpx.post(
+            url,
+            files={"file": (filename, content, "application/octet-stream")},
+            data=form or {},
+            headers=_auth_headers(sess),
+            timeout=request_timeout,
+        )
+
+    try:
+        response = _send(s)
+    except httpx.TimeoutException:
+        display_error(f"Request timed out after {request_timeout}s")
+        sys.exit(1)
+    except httpx.RequestError as e:
+        display_error(f"Request failed: {e}")
+        sys.exit(1)
+
+    if response.status_code == 401:
+        refreshed = _refresh_session(s)
+        if refreshed is None:
+            display_error("Session expired")
+            display_info("Run 'stk auth login' to sign in again")
+            sys.exit(1)
+        response = _send(refreshed)
+
+    if response.status_code >= 400:
+        _exit_with_error(response)
+
+    cache_mod.invalidate_scope(s.email or "anon")
+    result: dict[str, Any] = response.json()
+    return result
+
+
 def patch_request(
     endpoint: str,
     data: dict[str, Any] | None = None,

--- a/stk/src/cli/commands/import_file.py
+++ b/stk/src/cli/commands/import_file.py
@@ -1,0 +1,65 @@
+"""Import a run from an activity file (SB-99)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from cli.api import post_file
+from cli.display import display_error
+
+console = Console()
+
+# Kept in step with the server's allowlist; the endpoint is still the authority
+# and rejects anything else with a 415.
+SUPPORTED = (".gpx", ".tcx", ".json")
+
+
+def import_activity(
+    path: Path = typer.Argument(..., help="Activity file: .gpx, .tcx or SmashRun .json"),
+    timezone: str = typer.Option(
+        "America/New_York",
+        "--timezone",
+        "-z",
+        help="Zone the run happened in — GPX/TCX record UTC, so this decides the run's date",
+    ),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
+) -> None:
+    """Import one run from a GPX, TCX or SmashRun JSON file.
+
+    Idempotent: importing the same file twice reports it as already imported
+    rather than creating a second run.
+    """
+    if not path.is_file():
+        display_error(f"No such file: {path}")
+        raise typer.Exit(1)
+    if path.suffix.lower() not in SUPPORTED:
+        display_error(f"{path.suffix or 'That file'} isn't supported. Try: {', '.join(SUPPORTED)}")
+        raise typer.Exit(1)
+
+    result = post_file(
+        "import/activity",
+        filename=path.name,
+        content=path.read_bytes(),
+        form={"timezone": timezone},
+        timeout=60.0,
+    )
+
+    if json_output:
+        print(json.dumps(result, indent=2))
+        return
+
+    distance = result.get("distance_km", 0.0)
+    minutes = round(float(result.get("duration_seconds", 0)) / 60, 1)
+    started = str(result.get("start_date_time_local", ""))[:16].replace("T", " ")
+
+    if result["status"] == "duplicate":
+        console.print(f"[yellow]Already imported[/yellow] — {started}, {distance} km")
+        console.print("[dim]Nothing was changed.[/dim]")
+        return
+
+    track = "with GPS track" if result.get("has_track") else "no GPS track"
+    console.print(f"[green]Imported[/green] {started} — {distance} km in {minutes} min ({track})")

--- a/stk/src/cli/main.py
+++ b/stk/src/cli/main.py
@@ -14,6 +14,7 @@ Usage:
     stk summary          # Aggregate of a filtered set vs overall
     stk goals            # Distance-goal progress
     stk sync             # Sync runs from SmashRun
+    stk import run.gpx   # Import one run from a GPX/TCX/JSON file
     stk auth login       # Authenticate with SmashRun
 """
 
@@ -26,6 +27,7 @@ from cli.commands import (
     athlete,
     auth,
     cache,
+    import_file,
     invite,
     plan,
     runs,
@@ -151,6 +153,7 @@ app.command(name="map", rich_help_panel=_PANEL_RUNS)(runs.territory_map)
 app.command(name="audio", rich_help_panel=_PANEL_RUNS)(runs.audio)
 app.command(name="summary", rich_help_panel=_PANEL_RUNS)(runs.summary)
 app.command(name="sync", rich_help_panel=_PANEL_RUNS)(sync.sync_runs)
+app.command(name="import", rich_help_panel=_PANEL_RUNS)(import_file.import_activity)
 app.command(name="verify", rich_help_panel=_PANEL_RUNS)(verify.verify)
 app.command(name="goals", rich_help_panel=_PANEL_PLANNING)(stats.goals)
 

--- a/stk/tests/test_import_command.py
+++ b/stk/tests/test_import_command.py
@@ -1,0 +1,84 @@
+"""Tests for `stk import` — single activity file upload (SB-99)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import typer
+
+from cli.commands import import_file
+
+IMPORTED = {
+    "status": "imported",
+    "activity_id": "gpx-abc123",
+    "run_id": "3f0d0f6e-0000-0000-0000-000000000000",
+    "distance_km": 8.05,
+    "duration_seconds": 2700.0,
+    "start_date_time_local": "2026-08-10T07:15:00-04:00",
+    "has_track": True,
+}
+
+
+def _capture(monkeypatch: Any, result: dict[str, Any]) -> list[dict[str, Any]]:
+    """Swap the HTTP call for a recorder; returns the list of calls made."""
+    calls: list[dict[str, Any]] = []
+
+    def _post_file(
+        endpoint: str,
+        filename: str,
+        content: bytes,
+        form: dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
+        calls.append({"endpoint": endpoint, "filename": filename, "content": content, "form": form})
+        return result
+
+    monkeypatch.setattr(import_file, "post_file", _post_file)
+    return calls
+
+
+def test_import_uploads_the_file_and_timezone(tmp_path: Path, monkeypatch: Any) -> None:
+    calls = _capture(monkeypatch, IMPORTED)
+    gpx = tmp_path / "run.gpx"
+    gpx.write_bytes(b"<gpx/>")
+
+    import_file.import_activity(path=gpx, timezone="America/Denver", json_output=False)
+
+    assert calls == [
+        {
+            "endpoint": "import/activity",
+            "filename": "run.gpx",
+            "content": b"<gpx/>",
+            "form": {"timezone": "America/Denver"},
+        }
+    ]
+
+
+def test_import_reports_a_duplicate_without_erroring(tmp_path: Path, monkeypatch: Any) -> None:
+    _capture(monkeypatch, {**IMPORTED, "status": "duplicate"})
+    gpx = tmp_path / "run.gpx"
+    gpx.write_bytes(b"<gpx/>")
+
+    # A re-upload is a normal outcome, so it must not exit non-zero.
+    import_file.import_activity(path=gpx, timezone="America/New_York", json_output=False)
+
+
+def test_missing_file_exits_before_uploading(tmp_path: Path, monkeypatch: Any) -> None:
+    calls = _capture(monkeypatch, IMPORTED)
+    with pytest.raises(typer.Exit):
+        import_file.import_activity(
+            path=tmp_path / "nope.gpx", timezone="America/New_York", json_output=False
+        )
+    assert calls == []
+
+
+def test_unsupported_extension_exits_before_uploading(tmp_path: Path, monkeypatch: Any) -> None:
+    calls = _capture(monkeypatch, IMPORTED)
+    fit = tmp_path / "run.fit"
+    fit.write_bytes(b"\x0e\x10")
+
+    with pytest.raises(typer.Exit):
+        import_file.import_activity(path=fit, timezone="America/New_York", json_output=False)
+    assert calls == []

--- a/supabase/migrations/20260814000000_add_import_source_type.sql
+++ b/supabase/migrations/20260814000000_add_import_source_type.sql
@@ -1,0 +1,17 @@
+-- SB-99: file import needs a source of its own.
+--
+-- Runs are keyed (user_id, source_id, source_activity_id), so an imported run
+-- has to hang off a user_sources row like any synced one. Typing that source
+-- as 'import' — rather than reusing 'other' with a naming convention — keeps
+-- provenance checkable in SQL: a run came from a file if and only if its
+-- source is of type 'import'. Bulk zip import (SB-419) reuses the same source.
+--
+-- ALTER TYPE ... ADD VALUE is safe inside a transaction on PG 12+, but the new
+-- value cannot be *used* until that transaction commits — which is why nothing
+-- below inserts an 'import' source. Those rows are created lazily by the API on
+-- a user's first upload.
+
+ALTER TYPE source_type ADD VALUE IF NOT EXISTS 'import';
+
+COMMENT ON TYPE source_type IS
+    'Where a run came from. smashrun/strava/garmin are live-API syncs; import is a user-uploaded activity file (GPX/TCX/JSON); other is a fallback.';

--- a/tests/test_import_parsers.py
+++ b/tests/test_import_parsers.py
@@ -1,0 +1,301 @@
+"""SB-99: GPX / TCX / SmashRun-JSON parsers for single-file activity import."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from src.shared.importers import (
+    ActivityParseError,
+    FileTooLargeError,
+    NoRunFoundError,
+    UnsupportedFileError,
+    parse_activity_file,
+    parse_gpx,
+    parse_smashrun_json,
+    parse_tcx,
+)
+from src.shared.importers.dispatch import MAX_UPLOAD_BYTES
+
+# Four fixes ~ 111 m apart in latitude, one minute between each.
+GPX = b"""<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="Test" xmlns="http://www.topografix.com/GPX/1/1"
+     xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1">
+  <metadata><name>export</name></metadata>
+  <trk>
+    <name>Evening Run</name>
+    <trkseg>
+      <trkpt lat="42.2400" lon="-71.6500">
+        <ele>10</ele><time>2026-08-10T23:30:00Z</time>
+        <extensions><gpxtpx:TrackPointExtension>
+          <gpxtpx:hr>140</gpxtpx:hr><gpxtpx:cad>85</gpxtpx:cad>
+        </gpxtpx:TrackPointExtension></extensions>
+      </trkpt>
+      <trkpt lat="42.2410" lon="-71.6500">
+        <ele>11</ele><time>2026-08-10T23:31:00Z</time>
+        <extensions><gpxtpx:TrackPointExtension>
+          <gpxtpx:hr>150</gpxtpx:hr><gpxtpx:cad>88</gpxtpx:cad>
+        </gpxtpx:TrackPointExtension></extensions>
+      </trkpt>
+      <trkpt lat="42.2420" lon="-71.6500">
+        <ele>12</ele><time>2026-08-10T23:32:00Z</time>
+        <extensions><gpxtpx:TrackPointExtension>
+          <gpxtpx:hr>160</gpxtpx:hr><gpxtpx:cad>90</gpxtpx:cad>
+        </gpxtpx:TrackPointExtension></extensions>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>
+"""
+
+TCX = b"""<?xml version="1.0" encoding="UTF-8"?>
+<TrainingCenterDatabase xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2">
+  <Activities>
+    <Activity Sport="Running">
+      <Id>2026-08-10T12:00:00Z</Id>
+      <Lap StartTime="2026-08-10T12:00:00Z">
+        <TotalTimeSeconds>1800</TotalTimeSeconds>
+        <DistanceMeters>5000</DistanceMeters>
+        <Track>
+          <Trackpoint>
+            <Time>2026-08-10T12:00:00Z</Time>
+            <Position>
+              <LatitudeDegrees>42.2400</LatitudeDegrees>
+              <LongitudeDegrees>-71.6500</LongitudeDegrees>
+            </Position>
+            <HeartRateBpm><Value>142</Value></HeartRateBpm>
+            <Cadence>86</Cadence>
+          </Trackpoint>
+          <Trackpoint>
+            <Time>2026-08-10T12:15:00Z</Time>
+            <Position>
+              <LatitudeDegrees>42.2500</LatitudeDegrees>
+              <LongitudeDegrees>-71.6500</LongitudeDegrees>
+            </Position>
+            <HeartRateBpm><Value>158</Value></HeartRateBpm>
+            <Cadence>90</Cadence>
+          </Trackpoint>
+        </Track>
+      </Lap>
+    </Activity>
+  </Activities>
+</TrainingCenterDatabase>
+"""
+
+SMASHRUN = {
+    "activityId": 987654,
+    "startDateTimeLocal": "2026-08-10T07:15:00-04:00",
+    "distance": 8.05,
+    "duration": 2700.0,
+    "heartRateAverage": 152,
+    "recordingKeys": ["latitude", "longitude"],
+    "recordingValues": [[42.24, 42.25, 42.26], [-71.65, -71.66, -71.67]],
+}
+
+
+# --- GPX -------------------------------------------------------------------
+
+
+def test_gpx_derives_distance_and_duration_from_track() -> None:
+    parsed = parse_gpx(GPX)
+    # Two hops of 0.001 deg latitude ~= 111 m each.
+    assert parsed.activity.distance == pytest.approx(0.222, abs=0.01)
+    assert parsed.activity.duration == 120.0
+    assert parsed.activity.start_date_time_local == datetime(2026, 8, 10, 23, 30, tzinfo=UTC)
+
+
+def test_gpx_keeps_the_gps_track_and_hr_cadence() -> None:
+    parsed = parse_gpx(GPX)
+    assert parsed.has_track is True
+    assert parsed.latitudes == [42.2400, 42.2410, 42.2420]
+    assert parsed.activity.start_latitude == 42.2400
+    assert parsed.activity.heart_rate_average == pytest.approx(150.0)
+    assert parsed.activity.heart_rate_max == 160
+    assert parsed.activity.cadence_average == pytest.approx(87.667, abs=0.01)
+    assert parsed.activity.has_details_gps is True
+
+
+def test_gpx_uses_track_name_as_notes() -> None:
+    # <metadata><name> is "export"; the run's title lives on <trk>.
+    assert parse_gpx(GPX).activity.notes == "Evening Run"
+
+
+def test_gpx_dedup_key_is_stable_for_identical_bytes() -> None:
+    assert parse_gpx(GPX).activity.activity_id == parse_gpx(GPX).activity.activity_id
+    assert parse_gpx(GPX).activity.activity_id.startswith("gpx-")
+
+
+def test_gpx_dedup_key_differs_for_different_files() -> None:
+    other = GPX.replace(b"42.2420", b"42.2430")
+    assert parse_gpx(GPX).activity.activity_id != parse_gpx(other).activity.activity_id
+
+
+def test_gpx_excludes_paused_gaps_from_duration() -> None:
+    # Push the last fix 20 minutes out: a stopped watch, not a slow kilometre.
+    paused = GPX.replace(b"2026-08-10T23:32:00Z", b"2026-08-10T23:52:00Z")
+    assert parse_gpx(paused).activity.duration == 60.0
+
+
+def test_gpx_without_timestamps_is_rejected() -> None:
+    timeless = GPX.replace(b"<time>2026-08-10T23:30:00Z</time>", b"").replace(
+        b"<time>2026-08-10T23:31:00Z</time>", b""
+    )
+    with pytest.raises(NoRunFoundError, match="no timestamps"):
+        parse_gpx(timeless)
+
+
+def test_gpx_route_only_file_is_rejected() -> None:
+    route_only = b"""<?xml version="1.0"?>
+    <gpx xmlns="http://www.topografix.com/GPX/1/1">
+      <rte><rtept lat="42.2" lon="-71.6"/></rte>
+    </gpx>"""
+    with pytest.raises(NoRunFoundError, match="No GPS trackpoints"):
+        parse_gpx(route_only)
+
+
+def test_malformed_xml_reports_a_usable_error() -> None:
+    with pytest.raises(ActivityParseError, match="not valid XML"):
+        parse_gpx(b"<gpx><trk>")
+
+
+def test_entity_bomb_is_refused_not_expanded() -> None:
+    # defusedxml refuses the DTD outright; xml.etree would try to expand it.
+    bomb = b"""<?xml version="1.0"?>
+    <!DOCTYPE gpx [
+      <!ENTITY a "aaaaaaaaaa">
+      <!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">
+    ]>
+    <gpx><trk><trkseg><trkpt lat="1" lon="1"><name>&b;</name></trkpt></trkseg></trk></gpx>"""
+    with pytest.raises(Exception) as err:  # noqa: B017 - defusedxml raises its own type
+        parse_gpx(bomb)
+    assert "Entit" in str(type(err.value).__name__) or "not valid XML" in str(err.value)
+
+
+# --- TCX -------------------------------------------------------------------
+
+
+def test_tcx_trusts_the_stated_lap_totals_over_the_track() -> None:
+    parsed = parse_tcx(TCX)
+    # Track spans ~1.1 km; the lap states 5 km, and the lap wins.
+    assert parsed.activity.distance == 5.0
+    assert parsed.activity.duration == 1800.0
+
+
+def test_tcx_uses_the_activity_id_as_dedup_key() -> None:
+    parsed = parse_tcx(TCX)
+    assert parsed.activity.activity_id == "tcx-2026-08-10T12:00:00Z"
+    # Re-exported with a different creator, same run -> same key.
+    reexported = TCX.replace(b'Sport="Running"', b'Sport="Running" Creator="Other"')
+    assert parse_tcx(reexported).activity.activity_id == parsed.activity.activity_id
+
+
+def test_tcx_reads_heart_rate_and_cadence() -> None:
+    parsed = parse_tcx(TCX)
+    assert parsed.activity.heart_rate_average == pytest.approx(150.0)
+    assert parsed.activity.heart_rate_min == 142
+    assert parsed.activity.cadence_average == pytest.approx(88.0)
+
+
+def test_tcx_falls_back_to_the_track_when_laps_state_no_distance() -> None:
+    no_distance = TCX.replace(b"<DistanceMeters>5000</DistanceMeters>", b"")
+    parsed = parse_tcx(no_distance)
+    assert parsed.activity.distance == pytest.approx(1.11, abs=0.02)
+
+
+def test_tcx_non_running_activity_is_rejected() -> None:
+    biking = TCX.replace(b'Sport="Running"', b'Sport="Biking"')
+    with pytest.raises(NoRunFoundError, match="only runs"):
+        parse_tcx(biking)
+
+
+def test_tcx_indoor_run_without_gps_is_marked_treadmill() -> None:
+    indoor = TCX
+    for tag in (b"LatitudeDegrees", b"LongitudeDegrees"):
+        indoor = indoor.replace(b"<" + tag + b">", b"<Ignored>").replace(
+            b"</" + tag + b">", b"</Ignored>"
+        )
+    parsed = parse_tcx(indoor)
+    assert parsed.activity.is_treadmill is True
+    assert parsed.activity.has_details_gps is False
+    assert parsed.has_track is False
+
+
+# --- SmashRun JSON ---------------------------------------------------------
+
+
+def test_smashrun_json_maps_straight_onto_activity() -> None:
+    parsed = parse_smashrun_json(json.dumps(SMASHRUN).encode())
+    assert parsed.activity.activity_id == "smashrun-987654"
+    assert parsed.activity.distance == 8.05
+    assert parsed.activity.heart_rate_average == 152
+    assert parsed.latitudes == [42.24, 42.25, 42.26]
+
+
+def test_smashrun_json_accepts_a_single_element_list() -> None:
+    parsed = parse_smashrun_json(json.dumps([SMASHRUN]).encode())
+    assert parsed.activity.activity_id == "smashrun-987654"
+
+
+def test_smashrun_json_rejects_a_multi_activity_export() -> None:
+    with pytest.raises(ActivityParseError, match="one run at a time"):
+        parse_smashrun_json(json.dumps([SMASHRUN, SMASHRUN]).encode())
+
+
+def test_smashrun_json_missing_fields_names_the_problem() -> None:
+    partial = {k: v for k, v in SMASHRUN.items() if k != "distance"}
+    with pytest.raises(ActivityParseError, match="missing required fields"):
+        parse_smashrun_json(json.dumps(partial).encode())
+
+
+def test_invalid_json_reports_a_usable_error() -> None:
+    with pytest.raises(ActivityParseError, match="not valid JSON"):
+        parse_smashrun_json(b"{not json")
+
+
+# --- dispatch: allowlist, size cap, timezone --------------------------------
+
+
+def test_dispatch_routes_on_extension() -> None:
+    assert parse_activity_file("run.gpx", GPX).activity.activity_id.startswith("gpx-")
+    assert parse_activity_file("run.TCX", TCX).activity.activity_id.startswith("tcx-")
+    parsed = parse_activity_file("run.json", json.dumps(SMASHRUN).encode())
+    assert parsed.activity.activity_id.startswith("smashrun-")
+
+
+def test_dispatch_rejects_unknown_extensions_before_parsing() -> None:
+    with pytest.raises(UnsupportedFileError, match="Supported formats"):
+        parse_activity_file("run.fit", b"whatever")
+
+
+def test_dispatch_enforces_the_size_cap() -> None:
+    with pytest.raises(FileTooLargeError, match="10 MB"):
+        parse_activity_file("run.gpx", b"x" * (MAX_UPLOAD_BYTES + 1))
+
+
+def test_dispatch_rejects_an_empty_file() -> None:
+    with pytest.raises(ActivityParseError, match="empty"):
+        parse_activity_file("run.gpx", b"   ")
+
+
+def test_utc_timestamps_move_into_the_runners_timezone() -> None:
+    # 23:30 UTC on the 10th is 19:30 on the 10th in New York — the date the
+    # streak has to count, and the one a naive UTC read would push to the 11th.
+    parsed = parse_activity_file("run.gpx", GPX, timezone="America/New_York")
+    local = parsed.activity.start_date_time_local
+    assert (local.hour, local.day) == (19, 10)
+    assert parsed.times_are_utc is False
+
+
+def test_smashrun_local_time_is_left_alone() -> None:
+    parsed = parse_activity_file(
+        "run.json", json.dumps(SMASHRUN).encode(), timezone="America/Los_Angeles"
+    )
+    # Already local with an offset; converting it would move the run 3 hours.
+    assert parsed.activity.start_date_time_local.hour == 7
+
+
+def test_unknown_timezone_is_reported() -> None:
+    with pytest.raises(ActivityParseError, match="Unknown timezone"):
+        parse_activity_file("run.gpx", GPX, timezone="Mars/Olympus_Mons")

--- a/uv.lock
+++ b/uv.lock
@@ -504,6 +504,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "deprecation"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1622,6 +1631,7 @@ dependencies = [
     { name = "authlib" },
     { name = "aws-lambda-powertools" },
     { name = "boto3" },
+    { name = "defusedxml" },
     { name = "google-cloud-storage" },
     { name = "httpx" },
     { name = "psycopg2-binary" },
@@ -1651,6 +1661,7 @@ dev = [
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "types-defusedxml" },
     { name = "types-python-dateutil" },
 ]
 
@@ -1660,6 +1671,7 @@ requires-dist = [
     { name = "aws-lambda-powertools", specifier = ">=3.2.0" },
     { name = "boto3", specifier = ">=1.35.0" },
     { name = "boto3-stubs", extras = ["essential"], marker = "extra == 'dev'", specifier = ">=1.35.0" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "google-cloud-storage", specifier = ">=2.18.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'chat'", specifier = ">=0.27.0" },
@@ -1683,6 +1695,7 @@ provides-extras = ["dev", "chat"]
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=4.6.0" },
+    { name = "types-defusedxml", specifier = ">=0.7" },
     { name = "types-python-dateutil", specifier = ">=2.9.0.20251115" },
 ]
 
@@ -3032,6 +3045,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/86/65/f92debc7c9ff9e6e51cf1495248f0edd2fa7123461acf5d07ec1688d8ac1/types_awscrt-0.28.2.tar.gz", hash = "sha256:4349b6fc7b1cd9c9eb782701fb213875db89ab1781219c0e947dd7c4d9dcd65e", size = 17438, upload-time = "2025-10-19T06:39:11.202Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/23/535c2b3492fb31286a6adad45af3367eba3c23edc2fa24824d9526626012/types_awscrt-0.28.2-py3-none-any.whl", hash = "sha256:d08916fa735cfc032e6a8cfdac92785f1c4e88623999b224ea4e6267d5de5fcb", size = 41929, upload-time = "2025-10-19T06:39:10.042Z" },
+]
+
+[[package]]
+name = "types-defusedxml"
+version = "0.7.0.20260504"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/d2/4553c8fa9cdebfe1e84b950cf790a4d2376a97fa016e43f7c65323fa6c7d/types_defusedxml-0.7.0.20260504.tar.gz", hash = "sha256:2ab2828a3f97111ba1c16cee273ad4124a831fc9198c41bf8368ff6ea48ad300", size = 10729, upload-time = "2026-05-04T05:22:50.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/2d/8a4b5ba1d732b8bc691f0efbb1c6f77cb5f6f473b2afe181d83d910773c5/types_defusedxml-0.7.0.20260504-py3-none-any.whl", hash = "sha256:a959e3a0a43b93e464bd625d91ec9193a2703ddc10443bdd627792485fae0b10", size = 13467, upload-time = "2026-05-04T05:22:49.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

`POST /import/activity` — upload one activity file, get a run. GPX, TCX and SmashRun export JSON, parsed into the canonical `Activity` model and upserted through the existing `activity_to_run_dict` → `upsert_run` path, so an imported run is stored, deduped and displayed exactly like a synced one.

Synchronous by design: a single file parses in milliseconds. Bulk zip import (SB-419) is the one that needs a background job.

## Parsers (`src/shared/importers/`)

| Format | Distance / duration | Dedup key |
|---|---|---|
| GPX | Derived — summed over trackpoints; duration excludes gaps >60s (a paused watch, not a slow kilometre) | `gpx-<sha256(file)[:24]>` — GPX states no id |
| TCX | Stated lap totals win over the track; the watch knows its own calibration and summing raw GPS fixes over-reads | `tcx-<Activity/Id>` — stable across re-exports |
| SmashRun JSON | Stated | `smashrun-<activityId>`, prefixed so an import can't collide with the same activity arriving later over OAuth sync |

## Decisions worth flagging

**`import` is its own `source_type`** (migration `20260814000000`), not `other` + a marker. Provenance becomes checkable in SQL: a run came from a file iff its source is `import`. The row is created lazily on a user's first upload.

**Timezone is part of the contract.** GPX and TCX record UTC. Their timestamps are read into the caller's zone (default `America/New_York`) *before* the run's date is taken — a 9pm run would otherwise land on tomorrow and break the streak. The zone is stored on the run. SmashRun's export already states local time with an offset and is deliberately left alone.

**GPS tracks are imported too**, simplified through the existing `simplify_and_encode` → `upsert_track`, so imported runs get a route map rather than reading as second-class.

## Upload safety

- Extension allowlist checked **before** any parsing → 415
- 10 MB cap applied **while streaming**, so an oversized file costs one 64 KB chunk rather than its full size → 413
- XML parsed through `defusedxml`: `xml.etree` is entity-bomb prone, and a size cap doesn't help when a few hundred bytes of nested entities can exhaust memory
- Every write scoped to the authenticated user

Re-uploading an already-imported file returns `status: "duplicate"` and writes nothing — a re-upload is a reasonable thing to do, not an error.

## Testing

- 28 parser tests (root suite) — per-format behaviour, malformed input, entity bomb, size cap, allowlist, the UTC→local date boundary
- 11 endpoint tests (backend suite), **100% coverage of `backend/routes/imports.py`**
- 4 CLI tests
- Suites green: root 225, backend 417 (93%), stk 131
- **Verified end-to-end against local Supabase**: run stored under `source_type='import'`, 23:30 UTC correctly landed as 19:00-hour on the *same* local date, track stored (3 points after simplification), re-upload deduped to the same `run_id`. Test data cleaned up afterwards.

## Not in this PR

- **Upload UI is SB-418** — until that lands the feature exists but nobody can reach it (the SB-395 pattern). `stk import <file>` is here so the endpoint is usable meanwhile.
- FIT parsing is SB-421 (Garmin bulk export).
- **Known gap, now documented:** a run imported from a file and later synced from SmashRun lands as two rows — different `source_id`, so the upsert key can't see the collision. Cross-source dedup isn't built.

Fixes SB-99

🤖 Generated with [Claude Code](https://claude.com/claude-code)
