### PR TITLE
feat(import): web UI for single activity file upload

### DIFF
--- a/docs/SOURCES_AND_IMPORT.md
+++ b/docs/SOURCES_AND_IMPORT.md
@@ -1,6 +1,6 @@
 # Data Sources, BYOK & Import — Design
 
-**Status:** Partly shipped — single-run file import live (SB-99, 2026-08-14);
+**Status:** Partly shipped — single-run file import live end to end (SB-99 backend + SB-418 web UI, 2026-08-14);
 provider abstraction and bulk zip import still proposed (2026-06-01)
 **Owner:** @silverbeer
 **Related:** `docs/GOALS_TRACKING.md`, `docs/SMASHRUN_OAUTH.md`
@@ -131,7 +131,15 @@ file parses in milliseconds, so it answers in the request.
 - **Distance/duration.** TCX's stated lap totals win over the track. GPX has
   neither, so distance is summed over the trackpoints and duration excludes
   gaps longer than 60s (a paused watch, not a slow kilometre).
-- **CLI:** `stk import <file> [--timezone ZONE]`, ahead of the upload UI (SB-418).
+- **CLI:** `stk import <file> [--timezone ZONE]`.
+- **Web UI (SB-418):** `ImportRunCard.vue` on the Settings page — drop zone plus
+  file picker, client-side type/size check before upload, and a result surface
+  that distinguishes imported from already-imported. It reads the allowlist and
+  cap from `GET /import/formats` rather than restating them, and sends the
+  browser's own IANA zone so the run lands on the right date without the
+  runner being asked. The `accept` attribute is deliberately wider than the
+  extension list: iOS greys out files whose extension it can't map to a UTI,
+  which would make a `.tcx` unpickable on the phone.
 
 Re-uploading an already-imported file returns `status: "duplicate"` and writes
 nothing — a re-upload is a reasonable thing to do, not an error.

--- a/frontend/src/components/ImportRunCard.vue
+++ b/frontend/src/components/ImportRunCard.vue
@@ -1,0 +1,165 @@
+<template>
+  <div class="bg-white rounded-xl border border-gray-100 shadow-sm p-6">
+    <h2 class="text-lg font-semibold text-gray-900 mb-1">Import a run</h2>
+    <p class="text-sm text-gray-500 mb-4">
+      Upload an activity file from Strava, Garmin, Polar, Coros or SmashRun. Every platform
+      lets you export your own data, so this works without connecting an account.
+    </p>
+
+    <!--
+      The drop zone is a <label>: the click path is the file input's own, so the
+      picker opens on mobile (where drag-and-drop doesn't exist) and via the
+      keyboard, without re-implementing either.
+    -->
+    <label
+      class="block border-2 border-dashed rounded-xl px-4 py-8 text-center cursor-pointer transition"
+      :class="
+        dragging
+          ? 'border-brand-500 bg-brand-50'
+          : 'border-gray-200 hover:border-gray-300 bg-gray-50'
+      "
+      @dragover.prevent="dragging = true"
+      @dragenter.prevent="dragging = true"
+      @dragleave.prevent="dragging = false"
+      @drop.prevent="handleDrop"
+    >
+      <!--
+        `accept` is deliberately broader than the extension list. iOS maps
+        extensions to UTIs, and an unrecognised one greys the file out in the
+        Files app — a .tcx export would be unselectable on the phone, which is
+        where most of these imports will happen. The generic types keep the
+        picker open; validation still runs on our side, then the server's.
+      -->
+      <input
+        ref="input"
+        type="file"
+        class="sr-only"
+        :accept="acceptAttr"
+        :disabled="importing"
+        @change="handlePick"
+      />
+      <svg
+        class="w-8 h-8 mx-auto text-gray-400 mb-2"
+        :class="{ 'animate-pulse': importing }"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"
+        />
+      </svg>
+      <p class="text-sm font-semibold text-gray-700">
+        {{ importing ? 'Importing…' : 'Choose a file' }}
+      </p>
+      <p class="hidden sm:block text-xs text-gray-500 mt-1">or drop one here</p>
+      <p class="text-xs text-gray-400 mt-2">
+        {{ formats.extensions.join(', ') }} · up to {{ limitLabel }}
+      </p>
+    </label>
+
+    <!-- Rejected before upload, or refused by the server. Either way it says why. -->
+    <div
+      v-if="error"
+      class="mt-4 rounded-lg border border-red-100 bg-red-50 px-4 py-3"
+      role="alert"
+    >
+      <p class="text-sm text-red-700">{{ error }}</p>
+      <button type="button" class="text-xs text-red-600 underline mt-1" @click="clear">
+        Try another file
+      </button>
+    </div>
+
+    <div
+      v-else-if="result"
+      class="mt-4 rounded-lg border px-4 py-3"
+      :class="
+        result.status === 'duplicate'
+          ? 'border-amber-100 bg-amber-50'
+          : 'border-green-100 bg-green-50'
+      "
+    >
+      <!--
+        A re-upload is a reasonable thing to do, so it reads as a no-op rather
+        than a failure — the run it already matched is still linked.
+      -->
+      <p
+        class="text-sm font-semibold"
+        :class="result.status === 'duplicate' ? 'text-amber-800' : 'text-green-800'"
+      >
+        {{ result.status === 'duplicate' ? 'Already imported' : 'Run imported' }}
+      </p>
+      <p class="text-sm text-gray-600 mt-0.5">
+        {{ formatDate(result.start_date_time_local) }} ·
+        {{ formatDistanceWithUnit(result.distance_km, unit) }} ·
+        {{ formatDuration(result.duration_seconds) }}
+        <span v-if="!result.has_track" class="text-gray-400">· no GPS track</span>
+      </p>
+      <div class="flex items-center gap-3 mt-2">
+        <RouterLink
+          :to="{ name: 'run-detail', params: { activityId: result.activity_id } }"
+          class="text-xs font-semibold text-brand-600 hover:underline"
+        >
+          View run
+        </RouterLink>
+        <button type="button" class="text-xs text-gray-500 underline" @click="clear">
+          Import another
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { RouterLink } from 'vue-router'
+import { formatSize, useImport } from '@/composables/useImport'
+import { useUserPreferences } from '@/composables/useUserPreferences'
+import { formatDate, formatDistanceWithUnit, formatDuration } from '@/utils/format'
+
+const emit = defineEmits<{
+  imported: [activityId: string]
+}>()
+
+const { importFile, loadFormats, reset, importing, error, result, formats } = useImport()
+const { unit } = useUserPreferences()
+
+const input = ref<HTMLInputElement | null>(null)
+const dragging = ref(false)
+
+const limitLabel = computed(() => formatSize(formats.value.max_bytes))
+
+// See the note on the file input: the extensions alone are too narrow for iOS.
+const acceptAttr = computed(() =>
+  [...formats.value.extensions, 'application/xml', 'text/xml', 'application/json'].join(','),
+)
+
+const submit = async (file: File | undefined) => {
+  if (!file || importing.value) return
+  const imported = await importFile(file)
+  if (imported?.status === 'imported') emit('imported', imported.activity_id)
+}
+
+const handlePick = async (event: Event) => {
+  const target = event.target as HTMLInputElement
+  await submit(target.files?.[0])
+  // Clear the input so picking the same file again still fires change — the
+  // natural thing to do after a failure the runner has since fixed.
+  target.value = ''
+}
+
+const handleDrop = async (event: DragEvent) => {
+  dragging.value = false
+  await submit(event.dataTransfer?.files?.[0])
+}
+
+const clear = () => {
+  reset()
+  if (input.value) input.value.value = ''
+}
+
+onMounted(loadFormats)
+</script>

--- a/frontend/src/components/__tests__/ImportRunCard.test.ts
+++ b/frontend/src/components/__tests__/ImportRunCard.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { ref } from 'vue'
+import ImportRunCard from '../ImportRunCard.vue'
+import type { ImportResult } from '@/types/runs'
+
+const IMPORTED: ImportResult = {
+  status: 'imported',
+  activity_id: 'gpx-abc123',
+  run_id: '3f0d0f6e-0000-0000-0000-000000000000',
+  distance_km: 8.05,
+  duration_seconds: 2700,
+  start_date_time_local: '2026-08-10T07:15:00-04:00',
+  has_track: true,
+}
+
+// One shared harness the component's useImport() resolves to, so a test can
+// drive the outcome (imported / duplicate / rejected) without any HTTP.
+const importing = ref(false)
+const error = ref<string | null>(null)
+const result = ref<ImportResult | null>(null)
+const importFile = vi.fn()
+const loadFormats = vi.fn()
+
+vi.mock('@/composables/useImport', async () => {
+  const actual = await vi.importActual<typeof import('@/composables/useImport')>(
+    '@/composables/useImport'
+  )
+  return {
+    ...actual,
+    useImport: () => ({
+      importFile,
+      loadFormats,
+      validate: vi.fn(),
+      reset: () => {
+        error.value = null
+        result.value = null
+      },
+      importing,
+      error,
+      result,
+      formats: ref({
+        extensions: ['.gpx', '.json', '.tcx'],
+        max_bytes: 10 * 1024 * 1024,
+        default_timezone: 'America/New_York',
+      }),
+    }),
+  }
+})
+
+vi.mock('@/composables/useUserPreferences', () => ({
+  useUserPreferences: () => ({ unit: ref('mi') }),
+}))
+
+const RouterLinkStub = {
+  props: ['to'],
+  template: '<a><slot /></a>',
+}
+
+const mountCard = () =>
+  mount(ImportRunCard, { global: { stubs: { RouterLink: RouterLinkStub } } })
+
+const file = (name: string): File => new File(['x'], name)
+
+/** Fire the file input's change event with a chosen file, as the picker does. */
+const pick = async (w: ReturnType<typeof mountCard>, chosen: File) => {
+  const input = w.find('input[type="file"]')
+  Object.defineProperty(input.element, 'files', { value: [chosen], configurable: true })
+  await input.trigger('change')
+  await flushPromises()
+}
+
+describe('ImportRunCard', () => {
+  beforeEach(() => {
+    importing.value = false
+    error.value = null
+    result.value = null
+    importFile.mockReset()
+    loadFormats.mockReset()
+  })
+
+  it('states the accepted formats and the size cap', () => {
+    const w = mountCard()
+    expect(w.text()).toContain('.gpx, .json, .tcx')
+    expect(w.text()).toContain('10.0 MB')
+    // Broader than the extension list on purpose: iOS greys out files whose
+    // extension it can't map to a UTI, which would make .tcx unpickable.
+    const accept = w.find('input[type="file"]').attributes('accept') ?? ''
+    expect(accept).toContain('.gpx')
+    expect(accept).toContain('.tcx')
+    expect(accept).toContain('application/xml')
+  })
+
+  it('asks the server what it accepts on mount', () => {
+    mountCard()
+    expect(loadFormats).toHaveBeenCalled()
+  })
+
+  it('uploads the picked file and shows the imported run', async () => {
+    importFile.mockImplementation(async () => {
+      result.value = IMPORTED
+      return IMPORTED
+    })
+    const w = mountCard()
+
+    await pick(w, file('run.gpx'))
+
+    expect(importFile).toHaveBeenCalledWith(expect.any(File))
+    expect(w.text()).toContain('Run imported')
+    expect(w.text()).toContain('5.00 mi') // 8.05 km, shown in the user's unit
+    expect(w.emitted('imported')?.[0]).toEqual(['gpx-abc123'])
+    expect(w.findComponent(RouterLinkStub).props('to')).toEqual({
+      name: 'run-detail',
+      params: { activityId: 'gpx-abc123' },
+    })
+  })
+
+  it('reads a re-upload as already imported, not a failure', async () => {
+    const duplicate = { ...IMPORTED, status: 'duplicate' as const }
+    importFile.mockImplementation(async () => {
+      result.value = duplicate
+      return duplicate
+    })
+    const w = mountCard()
+
+    await pick(w, file('run.gpx'))
+
+    expect(w.text()).toContain('Already imported')
+    expect(w.text()).not.toContain('failed')
+    // Still links to the run it matched.
+    expect(w.findComponent(RouterLinkStub).exists()).toBe(true)
+    // A duplicate is not a new run, so nothing to tell the parent about.
+    expect(w.emitted('imported')).toBeUndefined()
+  })
+
+  it('shows a rejected file type as an error with a retry', async () => {
+    importFile.mockImplementation(async () => {
+      error.value = ".png can't be imported. Try .gpx, .json, .tcx."
+      return null
+    })
+    const w = mountCard()
+
+    await pick(w, file('photo.png'))
+
+    expect(w.find('[role="alert"]').text()).toContain("can't be imported")
+    expect(w.text()).toContain('Try another file')
+  })
+
+  it('shows the parse failure reason the server gave', async () => {
+    importFile.mockImplementation(async () => {
+      error.value = 'Trackpoints carry no timestamps, so the run has no duration.'
+      return null
+    })
+    const w = mountCard()
+
+    await pick(w, file('bad.gpx'))
+
+    expect(w.find('[role="alert"]').text()).toContain('no timestamps')
+  })
+
+  it('notes when an imported run has no GPS track', async () => {
+    const noTrack = { ...IMPORTED, has_track: false }
+    importFile.mockImplementation(async () => {
+      result.value = noTrack
+      return noTrack
+    })
+    const w = mountCard()
+
+    await pick(w, file('treadmill.tcx'))
+
+    expect(w.text()).toContain('no GPS track')
+  })
+
+  it('clears the outcome so another file can be imported', async () => {
+    importFile.mockImplementation(async () => {
+      result.value = IMPORTED
+      return IMPORTED
+    })
+    const w = mountCard()
+    await pick(w, file('run.gpx'))
+    expect(w.text()).toContain('Run imported')
+
+    await w.get('button').trigger('click')
+    await flushPromises()
+
+    expect(w.text()).not.toContain('Run imported')
+  })
+
+  it('accepts a dropped file', async () => {
+    importFile.mockImplementation(async () => {
+      result.value = IMPORTED
+      return IMPORTED
+    })
+    const w = mountCard()
+
+    await w.find('label').trigger('drop', { dataTransfer: { files: [file('run.gpx')] } })
+    await flushPromises()
+
+    expect(importFile).toHaveBeenCalledWith(expect.any(File))
+    expect(w.text()).toContain('Run imported')
+  })
+
+  it('ignores a second file while one is uploading', async () => {
+    importing.value = true
+    const w = mountCard()
+
+    await pick(w, file('run.gpx'))
+
+    expect(importFile).not.toHaveBeenCalled()
+    expect(w.text()).toContain('Importing…')
+  })
+})

--- a/frontend/src/composables/__tests__/useImport.test.ts
+++ b/frontend/src/composables/__tests__/useImport.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('@/config/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn().mockResolvedValue({ data: { session: { access_token: 'test-token' } } }),
+    },
+  },
+}))
+
+const fetchMock = vi.fn()
+
+const IMPORTED = {
+  status: 'imported',
+  activity_id: 'gpx-abc123',
+  run_id: '3f0d0f6e-0000-0000-0000-000000000000',
+  distance_km: 8.05,
+  duration_seconds: 2700,
+  start_date_time_local: '2026-08-10T07:15:00-04:00',
+  has_track: true,
+}
+
+const okJson = (body: unknown) => ({
+  ok: true,
+  status: 200,
+  headers: new Headers(),
+  json: async () => body,
+})
+
+const file = (name: string, size = 1024): File => {
+  const f = new File(['x'], name)
+  Object.defineProperty(f, 'size', { value: size })
+  return f
+}
+
+describe('useImport', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock)
+    fetchMock.mockReset()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uploads the file as multipart and returns the result', async () => {
+    fetchMock.mockResolvedValueOnce(okJson(IMPORTED))
+    const { useImport } = await import('../useImport')
+    const { importFile, result, error } = useImport()
+
+    const out = await importFile(file('run.gpx'))
+
+    expect(out).toEqual(IMPORTED)
+    expect(result.value).toEqual(IMPORTED)
+    expect(error.value).toBeNull()
+
+    const [path, init] = fetchMock.mock.calls[0]
+    expect(path).toContain('/import/activity')
+    expect(init.method).toBe('POST')
+    expect(init.body).toBeInstanceOf(FormData)
+    // The browser must set Content-Type itself so the multipart boundary is
+    // included; sending our own would break parsing server-side.
+    expect(init.headers['Content-Type']).toBeUndefined()
+    expect(init.headers['Authorization']).toBe('Bearer test-token')
+  })
+
+  it('sends the browser timezone so the run lands on the right date', async () => {
+    fetchMock.mockResolvedValueOnce(okJson(IMPORTED))
+    const { useImport } = await import('../useImport')
+
+    await useImport().importFile(file('run.gpx'))
+
+    const body = fetchMock.mock.calls[0][1].body as FormData
+    expect(body.get('timezone')).toBe(Intl.DateTimeFormat().resolvedOptions().timeZone)
+    expect((body.get('file') as File).name).toBe('run.gpx')
+  })
+
+  it('surfaces a duplicate as a result, not an error', async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ ...IMPORTED, status: 'duplicate' }))
+    const { useImport } = await import('../useImport')
+    const { importFile, error } = useImport()
+
+    const out = await importFile(file('run.gpx'))
+
+    expect(out?.status).toBe('duplicate')
+    expect(error.value).toBeNull()
+  })
+
+  it('rejects an unsupported extension without uploading', async () => {
+    const { useImport } = await import('../useImport')
+    const { importFile, error } = useImport()
+
+    const out = await importFile(file('photo.png'))
+
+    expect(out).toBeNull()
+    expect(error.value).toContain(".png can't be imported")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an oversized file without uploading', async () => {
+    const { useImport } = await import('../useImport')
+    const { importFile, error } = useImport()
+
+    const out = await importFile(file('huge.gpx', 11 * 1024 * 1024))
+
+    expect(out).toBeNull()
+    expect(error.value).toContain('the limit is 10 MB')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty file without uploading', async () => {
+    const { useImport } = await import('../useImport')
+    const { importFile, error } = useImport()
+
+    expect(await importFile(file('empty.gpx', 0))).toBeNull()
+    expect(error.value).toBe('That file is empty.')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("keeps the server's reason when a parse fails", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      headers: new Headers(),
+      json: async () => ({ detail: 'Trackpoints carry no timestamps, so the run has no duration.' }),
+    })
+    const { useImport } = await import('../useImport')
+    const { importFile, error, result } = useImport()
+
+    expect(await importFile(file('bad.gpx'))).toBeNull()
+    expect(error.value).toBe('Trackpoints carry no timestamps, so the run has no duration.')
+    expect(result.value).toBeNull()
+  })
+
+  it('validates against the server allowlist once formats load', async () => {
+    fetchMock.mockResolvedValueOnce(
+      okJson({ extensions: ['.gpx'], max_bytes: 1024, default_timezone: 'UTC' })
+    )
+    const { useImport } = await import('../useImport')
+    const { loadFormats, validate } = useImport()
+
+    await loadFormats()
+
+    expect(validate(file('run.gpx', 100))).toBeNull()
+    expect(validate(file('run.tcx', 100))).toContain("can't be imported")
+    expect(validate(file('run.gpx', 2048))).toContain('the limit is')
+  })
+
+  it('falls back to built-in formats when the formats call fails', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('offline'))
+    const { useImport } = await import('../useImport')
+    const { loadFormats, formats, validate } = useImport()
+
+    await loadFormats()
+
+    expect(formats.value.extensions).toContain('.tcx')
+    expect(validate(file('run.tcx', 100))).toBeNull()
+  })
+
+  it('clears the previous outcome on reset', async () => {
+    fetchMock.mockResolvedValueOnce(okJson(IMPORTED))
+    const { useImport } = await import('../useImport')
+    const { importFile, reset, result } = useImport()
+
+    await importFile(file('run.gpx'))
+    expect(result.value).not.toBeNull()
+
+    reset()
+    expect(result.value).toBeNull()
+  })
+})

--- a/frontend/src/composables/useImport.ts
+++ b/frontend/src/composables/useImport.ts
@@ -1,0 +1,103 @@
+import { ref } from 'vue'
+import { apiCall, apiUpload } from '@/config/api'
+import type { ImportFormats, ImportResult } from '@/types/runs'
+
+/**
+ * Single activity file import (SB-418) — the UI half of SB-99.
+ *
+ * The accepted extensions and size cap come from `GET /import/formats` rather
+ * than being restated here: the server enforces them either way, and a second
+ * hard-coded copy is one that drifts. FALLBACK_FORMATS only covers the window
+ * before that call lands (or if it fails), so the picker is never inert.
+ */
+const FALLBACK_FORMATS: ImportFormats = {
+  extensions: ['.gpx', '.json', '.tcx'],
+  max_bytes: 10 * 1024 * 1024,
+  default_timezone: 'America/New_York',
+}
+
+export function useImport() {
+  const importing = ref(false)
+  const error = ref<string | null>(null)
+  const result = ref<ImportResult | null>(null)
+  const formats = ref<ImportFormats>(FALLBACK_FORMATS)
+
+  const loadFormats = async (): Promise<void> => {
+    try {
+      formats.value = await apiCall<ImportFormats>('/import/formats')
+    } catch {
+      // Non-fatal: the fallback is accurate today, and the server still
+      // rejects anything outside its own allowlist.
+    }
+  }
+
+  /** Client-side check, so a wrong or huge file fails instantly. Null when OK. */
+  const validate = (file: File): string | null => {
+    const { extensions, max_bytes: maxBytes } = formats.value
+    const dot = file.name.lastIndexOf('.')
+    const extension = dot === -1 ? '' : file.name.slice(dot).toLowerCase()
+
+    if (!extensions.includes(extension)) {
+      return `${extension || 'That file'} can't be imported. Try ${extensions.join(', ')}.`
+    }
+    if (file.size > maxBytes) {
+      const limitMb = Math.round(maxBytes / (1024 * 1024))
+      return `That file is ${formatSize(file.size)} — the limit is ${limitMb} MB.`
+    }
+    if (file.size === 0) {
+      return 'That file is empty.'
+    }
+    return null
+  }
+
+  const importFile = async (file: File): Promise<ImportResult | null> => {
+    error.value = null
+    result.value = null
+
+    const invalid = validate(file)
+    if (invalid) {
+      error.value = invalid
+      return null
+    }
+
+    importing.value = true
+    try {
+      const body = new FormData()
+      body.append('file', file, file.name)
+      // GPX and TCX record UTC, so the run's date depends on which zone it is
+      // read into. The browser knows the runner's; sending it beats the
+      // server's America/New_York default for anyone outside that zone.
+      body.append('timezone', browserTimezone() ?? formats.value.default_timezone)
+
+      const res = await apiUpload<ImportResult>('/import/activity', body)
+      result.value = res
+      return res
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Import failed'
+      return null
+    } finally {
+      importing.value = false
+    }
+  }
+
+  const reset = (): void => {
+    error.value = null
+    result.value = null
+  }
+
+  return { importFile, loadFormats, validate, reset, importing, error, result, formats }
+}
+
+export function browserTimezone(): string | null {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || null
+  } catch {
+    return null
+  }
+}
+
+export function formatSize(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  if (bytes >= 1024) return `${Math.round(bytes / 1024)} KB`
+  return `${bytes} bytes`
+}

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -35,6 +35,37 @@ const readableError = (body: unknown): string | null => {
   return typeof top === 'string' && top ? top : null
 }
 
+/**
+ * Multipart upload (SB-418: activity file import).
+ *
+ * Separate from `apiCall` because that one always sets
+ * `Content-Type: application/json`. A multipart body must NOT carry a
+ * hand-written Content-Type — the browser has to set it itself so it can
+ * include the boundary, and overriding it makes the server fail to parse.
+ */
+export const apiUpload = async <T>(path: string, body: FormData): Promise<T> => {
+  const { data: { session } } = await supabase.auth.getSession()
+  const token = session?.access_token
+
+  const headers: Record<string, string> = {}
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`
+  }
+
+  const response = await fetch(`${API_BASE}${path}`, { method: 'POST', headers, body })
+
+  if (!response.ok) {
+    const errorBody = await response.json().catch(() => ({ message: 'Upload failed' }))
+    const message = readableError(errorBody) ?? `HTTP ${response.status}`
+    const err = new Error(message) as Error & { status?: number; body?: unknown }
+    err.status = response.status
+    err.body = errorBody
+    throw err
+  }
+
+  return response.json()
+}
+
 export const apiCall = async <T>(
   path: string,
   options: RequestInit = {}

--- a/frontend/src/types/runs.ts
+++ b/frontend/src/types/runs.ts
@@ -215,3 +215,21 @@ export interface ConditionsPenalty {
   steamy_run_count?: number
   baseline_run_count?: number
 }
+
+/** One activity file imported, or found to be already imported (SB-99/SB-418). */
+export interface ImportResult {
+  status: 'imported' | 'duplicate'
+  activity_id: string
+  run_id: string
+  distance_km: number
+  duration_seconds: number
+  start_date_time_local: string
+  has_track: boolean
+}
+
+/** What the importer accepts. Served by the API so the UI keeps no second copy. */
+export interface ImportFormats {
+  extensions: string[]
+  max_bytes: number
+  default_timezone: string
+}

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -53,11 +53,16 @@
 
       <p v-if="viewSaved" class="text-xs text-green-600 mt-3">Saved</p>
     </div>
+
+    <!-- No navigation on success: the card's own result surface is what the
+         runner needs to see (imported / already imported, and a link out). -->
+    <ImportRunCard class="mt-6" />
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import ImportRunCard from '@/components/ImportRunCard.vue'
 import { useUserPreferences, type DefaultView } from '@/composables/useUserPreferences'
 import { useRoles } from '@/composables/useCoach'
 import { resetLanding } from '@/composables/useLanding'


### PR DESCRIPTION
## What

The UI half of SB-99, which shipped endpoint-only this morning. `ImportRunCard` on the Settings page — drag a GPX from a Strava or Garmin export onto it, or tap to pick one, and the run appears.

Without this the feature exists but nobody outside a terminal can reach it (the SB-395 pattern: the API returned route data for weeks while the frontend never read it).

## Decisions worth flagging

**One control, both platforms.** The drop zone *is* the file picker — it's a `<label>` wrapping the input, so the click path is the input's own. Drag-and-drop works on desktop, tap-to-pick works on the phone, keyboard works everywhere, and none of it is re-implemented.

**`accept` is deliberately wider than the extension list.** iOS maps extensions to UTIs and greys out the ones it can't place — a `.tcx` export would be unselectable in the Files app, on the device where most of these imports will happen. Generic XML/JSON types keep the picker open; validation still runs locally, then again server-side.

**No second copy of the rules.** The allowlist and size cap come from `GET /import/formats` (built in SB-99 for exactly this). A hard-coded copy is one that drifts. There's a fallback for the window before that call lands, so the picker is never inert.

**The browser sends its own timezone.** GPX and TCX record UTC, so the zone decides the run's *date*. The browser knows it — better than the server's `America/New_York` default for anyone outside that zone, and it asks the runner nothing.

**No navigation on success.** The result surface is what the runner needs to see: imported vs already-imported, distance and duration in their unit, a note when there's no GPS track, and a link to the run. Redirecting would skip all of it.

**A re-upload reads as "Already imported"**, with the matched run still linked — not an error. The server already treats it as a no-op; the UI should agree.

`apiUpload` is separate from `apiCall` because that one always sets `Content-Type: application/json`. A multipart body must *not* carry a hand-written Content-Type — the browser has to set it so the boundary is included.

## Testing

20 new tests:
- **Composable (10):** multipart shape, no hand-set Content-Type, timezone sent, duplicate-as-result, rejected type / oversized / empty all short-circuit before any upload, server's parse reason preserved, allowlist honoured once formats load, fallback when that call fails.
- **Component (10):** success, duplicate, rejected type, parse failure, no-GPS note, clear-and-retry, drop path, in-flight guard, stated limits, formats fetched on mount.

Frontend suite **468 passing**, lint and type-check clean.

## Acceptance

| Criterion | Status |
|---|---|
| Drag a GPX from a Strava/Garmin export → run appears | ✅ |
| Wrong type or oversized rejected client-side with a clear message | ✅ before upload |
| Re-upload reports "already imported", not a failure | ✅ |
| Works on mobile (picker path) | ✅ built for it — **wants a real-device check, see below** |
| Component tests: success, duplicate, parse failure, rejected type | ✅ all four |

## Not in this PR

- **Onboarding source-choice placement is SB-420** — the ticket names both homes; that screen doesn't exist yet, so this lands on Settings only.
- **Mobile verification is desk-checked, not device-checked.** The iOS `accept` behaviour above is the exact kind of thing that only shows up on the phone. Worth a minute on your iPhone before this counts as done for mobile.

Fixes SB-418

🤖 Generated with [Claude Code](https://claude.com/claude-code)
