### PR TITLE
fix(import): serve an imported run's map from our own stored track

### DIFF
--- a/backend/routes/imports.py
+++ b/backend/routes/imports.py
@@ -41,6 +41,14 @@ IMPORT_SOURCE_LABEL = "file-import"
 
 _READ_CHUNK = 64 * 1024
 
+# Finer than the 6 m default used when caching a synced run's shape (SB-309).
+# That default is tuned for the territory heatmap, and a synced run can always
+# re-fetch its full track from SmashRun. An imported run cannot: this polyline
+# is the only copy of its geometry, and it feeds the detail map too (SB-622).
+# On a 3.2 km run this is the difference between 12 points and 62 — 215 bytes
+# instead of 54, for a route that reads as a run rather than a polygon.
+IMPORT_TRACK_TOLERANCE_M = 1.0
+
 
 async def _read_capped(upload: UploadFile) -> bytes:
     """Read the upload, refusing anything over the cap.
@@ -128,7 +136,9 @@ async def import_activity(
 
     stored_track = False
     if parsed.has_track:
-        polyline, point_count = simplify_and_encode(parsed.latitudes, parsed.longitudes)
+        polyline, point_count = simplify_and_encode(
+            parsed.latitudes, parsed.longitudes, tolerance_m=IMPORT_TRACK_TOLERANCE_M
+        )
         if polyline:
             runs_repo.upsert_track(run_id, polyline, point_count)
             stored_track = True

--- a/backend/routes/runs.py
+++ b/backend/routes/runs.py
@@ -8,14 +8,15 @@ from uuid import UUID
 
 from backend.auth import authenticate_request
 from backend.cache import cached, invalidate_user
+from backend.routes.imports import IMPORT_SOURCE_TYPE
 from backend.routes.sync import _resolve_access_token
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
-from src.shared.geo import simplify_and_encode
+from src.shared.geo import decode_polyline, haversine_km, simplify_and_encode
 from src.shared.route_shape import SHAPE_GROUPING_ENABLED
 from src.shared.smashrun import SmashRunAPIClient
 from src.shared.supabase_client import get_supabase_client
-from src.shared.supabase_ops import RunsRepository, TokenRepository
+from src.shared.supabase_ops import RunsRepository, TokenRepository, UsersRepository
 from src.shared.supabase_ops.mappers import WeatherType
 
 router = APIRouter(prefix="/runs", tags=["runs"])
@@ -301,6 +302,52 @@ async def all_tracks(
     return await _tracks(user_id)
 
 
+def _is_imported(supabase: Any, run: dict[str, Any]) -> bool:
+    """Did this run come from an uploaded file rather than a live-API sync?
+
+    Anything we can't positively identify as an import keeps the old SmashRun
+    behaviour — the column is NOT NULL in practice, but a map is not worth a
+    500 over a missing source.
+    """
+    source_id = run.get("source_id")
+    if not source_id:
+        return False
+    source = UsersRepository(supabase).get_source_by_id(UUID(str(source_id)))
+    return (source or {}).get("source_type") == IMPORT_SOURCE_TYPE
+
+
+def _stored_track(supabase: Any, run: dict[str, Any]) -> dict[str, list[float]]:
+    """Track from our own `run_tracks` polyline (SB-622).
+
+    An imported run has no SmashRun activity to fetch a track from — its id is
+    ours (`gpx-<hash>`), and the owner may never have connected SmashRun at
+    all. The polyline import already stored is the only copy, so this decodes
+    it back into the lat/lon arrays the map expects.
+
+    Cumulative distance is re-derived so the map's hover readout still works.
+    The per-point pace/HR/elevation series are *not* recoverable: `run_tracks`
+    holds geometry only. The map falls back to an uncoloured line.
+    """
+    stored = RunsRepository(supabase).get_track_polyline(UUID(run["id"]))
+    polyline = (stored or {}).get("polyline")
+    if not polyline:
+        return {"lat": [], "lon": [], "dist_km": []}
+
+    points = decode_polyline(str(polyline))
+    if len(points) < 2:
+        return {"lat": [], "lon": [], "dist_km": []}
+
+    cumulative = [0.0]
+    for i in range(1, len(points)):
+        cumulative.append(round(cumulative[-1] + haversine_km(points[i - 1], points[i]), 4))
+
+    return {
+        "lat": [p[0] for p in points],
+        "lon": [p[1] for p in points],
+        "dist_km": cumulative,
+    }
+
+
 @cached(ttl=86400, key_prefix="runs:track")
 async def _track(user_id: UUID, activity_id: str) -> dict[str, Any]:
     supabase = get_supabase_client()
@@ -308,38 +355,47 @@ async def _track(user_id: UUID, activity_id: str) -> dict[str, Any]:
     if run is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Run not found")
 
-    # The GPS track lives only in SmashRun's per-activity detail (recordingValues),
-    # not our DB — fetch it on demand with the user's token.
-    token = _resolve_access_token(user_id, TokenRepository(supabase))
-    with SmashRunAPIClient(access_token=token) as api:
-        detail = api.get_activity_by_id(activity_id)
+    detail: dict[str, Any] = {}
+    elevation: list[float] = []
+    heart_rate: list[float] = []
+    pace: list[float] = []
 
-    keys = detail.get("recordingKeys") or []
-    values = detail.get("recordingValues") or []
+    if _is_imported(supabase, run):
+        stored = _stored_track(supabase, run)
+        lat, lon, dist_km = stored["lat"], stored["lon"], stored["dist_km"]
+    else:
+        # The GPS track lives only in SmashRun's per-activity detail
+        # (recordingValues), not our DB — fetch it on demand with the user's token.
+        token = _resolve_access_token(user_id, TokenRepository(supabase))
+        with SmashRunAPIClient(access_token=token) as api:
+            detail = api.get_activity_by_id(activity_id)
 
-    def series(name: str) -> list[float]:
-        return [float(v) for v in values[keys.index(name)]] if name in keys and values else []
+        keys = detail.get("recordingKeys") or []
+        values = detail.get("recordingValues") or []
 
-    lat = series("latitude")
-    lon = series("longitude")
-    elevation = series("elevation")
-    heart_rate = series("heartRate")
-    # Per-point pace (min/km) smoothed over a short window of the cumulative
-    # distance/clock series — SmashRun gives cumulative km + seconds, not pace.
-    dist_km = series("distance")
-    clock_s = series("clock")
-    pace = _per_point_pace(dist_km, clock_s)
+        def series(name: str) -> list[float]:
+            return [float(v) for v in values[keys.index(name)]] if name in keys and values else []
 
-    # Persist the simplified polyline for the heatmap + route-matching (SB-309).
-    # Best-effort store-on-read: never fail the request over it; the batched
-    # backfill covers runs whose map is never opened.
-    if lat and lon:
-        try:
-            polyline, n_pts = simplify_and_encode(lat, lon)
-            if polyline:
-                RunsRepository(supabase).upsert_track(UUID(run["id"]), polyline, n_pts)
-        except Exception:  # noqa: BLE001 — storage is a side effect, not the response
-            pass
+        lat = series("latitude")
+        lon = series("longitude")
+        elevation = series("elevation")
+        heart_rate = series("heartRate")
+        # Per-point pace (min/km) smoothed over a short window of the cumulative
+        # distance/clock series — SmashRun gives cumulative km + seconds, not pace.
+        dist_km = series("distance")
+        clock_s = series("clock")
+        pace = _per_point_pace(dist_km, clock_s)
+
+        # Persist the simplified polyline for the heatmap + route-matching (SB-309).
+        # Best-effort store-on-read: never fail the request over it; the batched
+        # backfill covers runs whose map is never opened.
+        if lat and lon:
+            try:
+                polyline, n_pts = simplify_and_encode(lat, lon)
+                if polyline:
+                    RunsRepository(supabase).upsert_track(UUID(run["id"]), polyline, n_pts)
+            except Exception:  # noqa: BLE001 — storage is a side effect, not the response
+                pass
 
     # How many times this route has been run (count + rank), so the card can say
     # "run N times, #k of M" (SB-297). Needs the run's own start coords.

--- a/backend/tests/test_imported_run_track.py
+++ b/backend/tests/test_imported_run_track.py
@@ -1,0 +1,145 @@
+"""SB-622: an imported run's map comes from our stored polyline, not SmashRun."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from backend.routes import runs as runs_module
+from fastapi import HTTPException
+from src.shared.geo import encode_polyline
+
+USER = uuid4()
+RUN_ID = uuid4()
+SOURCE_ID = uuid4()
+
+# A short L-shaped route, ~100 m a side.
+POINTS = [(42.2400, -71.6500), (42.2409, -71.6500), (42.2409, -71.6488)]
+
+_RUN = {
+    "id": str(RUN_ID),
+    "source_id": str(SOURCE_ID),
+    "start_date_time_local": "2026-08-08T10:50:35-04:00",
+    "distance_km": "3.24",
+    "duration_seconds": "1119",
+    "average_pace_min_per_km": "5.75",
+    "weather_type": None,
+    "temperature_celsius": None,
+}
+
+
+class _Repo:
+    def __init__(self, run: dict[str, Any] | None, polyline: str | None) -> None:
+        self._run = run
+        self._polyline = polyline
+        self.upserted_tracks: list[Any] = []
+
+    def __call__(self, _sb: Any) -> _Repo:
+        return self
+
+    def get_run_by_activity_id(self, _uid: Any, _aid: str) -> dict[str, Any] | None:
+        return self._run
+
+    def get_track_polyline(self, _run_id: Any) -> dict[str, Any] | None:
+        return {"polyline": self._polyline} if self._polyline else None
+
+    def get_route_for_run(self, *_a: Any, **_k: Any) -> dict[str, Any] | None:
+        return None
+
+    def upsert_track(self, *a: Any) -> None:
+        self.upserted_tracks.append(a)
+
+
+class _Users:
+    def __init__(self, source_type: str) -> None:
+        self._source_type = source_type
+
+    def __call__(self, _sb: Any) -> _Users:
+        return self
+
+    def get_source_by_id(self, _sid: Any) -> dict[str, Any]:
+        return {"source_type": self._source_type}
+
+
+def _boom(*_a: Any, **_k: Any) -> Any:
+    raise AssertionError("SmashRun must not be called for an imported run")
+
+
+def _track(
+    monkeypatch: Any,
+    *,
+    missing: bool = False,
+    polyline: str | None = None,
+    source_type: str = "import",
+) -> Any:
+    repo = _Repo(None if missing else _RUN, polyline)
+    monkeypatch.setattr(runs_module, "get_supabase_client", lambda: object())
+    monkeypatch.setattr(runs_module, "RunsRepository", repo)
+    monkeypatch.setattr(runs_module, "UsersRepository", _Users(source_type))
+    monkeypatch.setattr(runs_module, "_resolve_access_token", _boom)
+    monkeypatch.setattr(runs_module, "SmashRunAPIClient", _boom)
+    return asyncio.run(runs_module._track(USER, "gpx-abc123"))
+
+
+def test_imported_run_track_comes_from_the_stored_polyline(monkeypatch: Any) -> None:
+    out = _track(monkeypatch, polyline=encode_polyline(POINTS))
+
+    assert out["has_track"] is True
+    assert len(out["lat"]) == 3
+    assert out["lat"][0] == pytest.approx(42.2400, abs=1e-4)
+    assert out["lon"][2] == pytest.approx(-71.6488, abs=1e-4)
+
+
+def test_imported_run_never_calls_smashrun(monkeypatch: Any) -> None:
+    # _resolve_access_token and SmashRunAPIClient both raise if touched. The
+    # owner may have no SmashRun connection at all, which is what used to make
+    # this 500 before the track lookup even happened.
+    _track(monkeypatch, polyline=encode_polyline(POINTS))
+
+
+def test_distance_series_is_rederived_and_aligned(monkeypatch: Any) -> None:
+    out = _track(monkeypatch, polyline=encode_polyline(POINTS))
+
+    assert len(out["dist_km"]) == len(out["lat"])
+    assert out["dist_km"][0] == 0.0
+    assert out["dist_km"] == sorted(out["dist_km"])  # cumulative, never decreasing
+    assert out["dist_km"][-1] == pytest.approx(0.2, abs=0.05)  # ~100 m + ~100 m
+
+
+def test_per_point_series_are_empty_for_an_import(monkeypatch: Any) -> None:
+    # run_tracks holds geometry only; the map draws an uncoloured line.
+    out = _track(monkeypatch, polyline=encode_polyline(POINTS))
+
+    assert out["pace_min_per_km"] == []
+    assert out["heart_rate"] == []
+    assert out["elevation_m"] == []
+
+
+def test_imported_run_without_a_stored_track_reports_no_track(monkeypatch: Any) -> None:
+    out = _track(monkeypatch, polyline=None)
+
+    assert out["has_track"] is False
+    assert out["lat"] == []
+    # Still answers with the run's own stats rather than erroring.
+    assert out["distance_km"] == 3.24
+
+
+def test_degenerate_polyline_is_not_drawable(monkeypatch: Any) -> None:
+    out = _track(monkeypatch, polyline=encode_polyline([(42.24, -71.65)]))
+
+    assert out["has_track"] is False
+
+
+def test_missing_run_is_404(monkeypatch: Any) -> None:
+    with pytest.raises(HTTPException) as err:
+        _track(monkeypatch, missing=True)
+    assert err.value.status_code == 404
+
+
+def test_synced_run_still_uses_the_smashrun_path(monkeypatch: Any) -> None:
+    # The stub raises, proving the synced branch is the one taken — the fix
+    # must not divert runs that do have a SmashRun activity behind them.
+    with pytest.raises(AssertionError, match="must not be called"):
+        _track(monkeypatch, polyline=encode_polyline(POINTS), source_type="smashrun")

--- a/frontend/src/components/RouteMap.vue
+++ b/frontend/src/components/RouteMap.vue
@@ -89,12 +89,15 @@
       </div>
     </div>
 
-    <!-- legend for the active metric -->
-    <div class="flex items-center justify-between mt-3 text-xs text-gray-400">
+    <!-- legend for the active metric — nothing to scale when there are no series -->
+    <div v-if="hasSeries" class="flex items-center justify-between mt-3 text-xs text-gray-400">
       <span>{{ activeMode.legendLow }}</span>
       <div class="h-1.5 flex-1 mx-3 rounded-full" :style="{ background: legendGradient }" />
       <span>{{ activeMode.legendHigh }}</span>
     </div>
+    <p v-else class="mt-3 text-xs text-gray-400">
+      Route only — an imported run carries no per-point pace or heart rate.
+    </p>
   </div>
 </template>
 
@@ -209,9 +212,22 @@ function ramp(values: number[], stops: Stop[]) {
   return { color, lo, hi }
 }
 
+/**
+ * An imported run has geometry but no per-point series (SB-622): `run_tracks`
+ * stores the polyline only. Without this the ramp would index an empty array
+ * and throw, taking the whole map with it — so the route draws in one colour
+ * and the metric switcher and legend hide themselves.
+ */
+const hasSeries = computed(() => availableModes.value.length > 0)
+
+const PLAIN_LINE = 'rgb(241,147,15)'
+
 const segments = computed(() => {
   const s = activeDef.value.series()
-  const { color } = ramp(s, activeDef.value.stops)
+  const plain = !hasSeries.value
+  const { color } = plain
+    ? { color: () => PLAIN_LINE }
+    : ramp(s, activeDef.value.stops)
   const p = pts.value
   const out: { x1: number; y1: number; x2: number; y2: number; color: string }[] = []
   for (let i = 1; i < p.length; i++) {

--- a/frontend/src/components/__tests__/RouteMap.test.ts
+++ b/frontend/src/components/__tests__/RouteMap.test.ts
@@ -63,4 +63,37 @@ describe('RouteMap', () => {
     const elevColors = w.findAll('line').map((l) => l.attributes('stroke'))
     expect(elevColors).not.toEqual(paceColors)
   })
+
+  // SB-622: an imported run has geometry but no per-point series — run_tracks
+  // stores the polyline only. This used to index an empty array in the colour
+  // ramp and throw, taking the whole map down with it.
+  describe('with no per-point series (imported run)', () => {
+    const geometryOnly: RunTrack = {
+      ...track,
+      elevation_m: [],
+      heart_rate: [],
+      pace_min_per_km: [],
+      city: null,
+      state: null,
+    }
+
+    it('still draws the route', () => {
+      const w = mount(RouteMap, { props: { track: geometryOnly, unit: 'mi' } })
+      expect(w.findAll('line').length).toBe(3)
+    })
+
+    it('draws every segment in one colour', () => {
+      const w = mount(RouteMap, { props: { track: geometryOnly, unit: 'mi' } })
+      const colors = new Set(w.findAll('line').map((l) => l.attributes('stroke')))
+      expect(colors.size).toBe(1)
+      expect([...colors][0]).not.toContain('NaN')
+    })
+
+    it('offers no metric modes and no legend', () => {
+      const w = mount(RouteMap, { props: { track: geometryOnly, unit: 'mi' } })
+      const labels = w.findAll('button').map((b) => b.text())
+      expect(labels).toEqual(['↻ Replay'])
+      expect(w.text()).toContain('Route only')
+    })
+  })
 })


### PR DESCRIPTION
## The bug

An imported run stored its GPS track and then showed no map. Reported from a real upload.

`GET /runs/{activity_id}/track` — the only source `RunDetailView` reads — fetched the track from **SmashRun's** per-activity detail, not from our own database:

```python
token = _resolve_access_token(user_id, TokenRepository(supabase))
detail = api.get_activity_by_id(activity_id)
```

For an imported run that fails twice:

* the activity id is ours (`gpx-<hash>`, `tcx-<Id>`), so SmashRun 404s on it
* a user who never connected SmashRun has no token at all, so `_resolve_access_token` raises before the lookup is even attempted

SB-99 had been storing the polyline in `run_tracks` all along. Nothing read it for this view — it only fed the territory heatmap.

## The fix

Serve the stored polyline when the run's source is `import`, with cumulative distance re-derived from the geometry so the map's hover readout still works. Synced runs keep the SmashRun path untouched.

**The frontend half was not optional.** `run_tracks` holds geometry only, so an imported run has no per-point pace/HR/elevation. Passing empty series to `RouteMap` doesn't degrade — it *throws*: `ramp()` indexes a sorted empty array, `hi` becomes `NaN`, `stops[NaN]` is `undefined`, and reading `a[0]` takes the whole map down. The map now detects it has no usable series, draws the route in one colour, and hides the metric switcher and legend in favour of a line saying why.

## Tolerance change, and why

Imports now store their polyline at **1 m** simplification instead of the 6 m default.

That default is right for the heatmap, and harmless for a synced run — SmashRun can always be re-asked for the full track. An imported run has no such fallback: this polyline is the only copy of its geometry, and now it feeds the detail map too.

Measured on the real Garmin export from this report (239 raw points, 3.24 km):

| Tolerance | Points | Polyline |
|---|---|---|
| 6 m (old) | 12 | 54 B |
| 3 m | 20 | 81 B |
| **1 m (new)** | **62** | **215 B** |
| 0.5 m | 95 | 292 B |

161 bytes for a route that reads as a run rather than a polygon.

## Testing

- 8 new backend tests: stored-polyline path, **SmashRun stubbed to raise so any call fails the test**, distance series alignment, empty per-point series, no stored track, degenerate 1-point polyline, 404, and a synced run still taking the old path.
- 3 new `RouteMap` tests for the geometry-only case — draws, single colour, no `NaN` in the stroke, no modes/legend.
- Verified end to end against local Supabase with the reporter's actual Garmin GPX: imported, then read back as a 62-point drawable track with no SmashRun call in the path.
- Backend 425 passing (93%), frontend 471 passing, lint and type-check clean.

## Known limitation

An imported run's map draws the route but **no pace/HR/elevation colouring**. GPX and TCX carry all three and we parse them for the summary columns — we just don't persist the series. Storing them (probably in `recording_data`, which already exists and is UNIQUE on run_id) would close it, and deserves its own ticket rather than being smuggled in here.

## Note on already-imported runs

This fixes what gets stored going forward. A run imported before this merges keeps its 12-point track, since a re-upload dedups to the existing row. Deleting and re-importing (SB-621) or a backfill would refresh it.

Fixes SB-622

🤖 Generated with [Claude Code](https://claude.com/claude-code)
