### PR TITLE
feat(runs): delete an imported run

### DIFF
--- a/backend/routes/runs.py
+++ b/backend/routes/runs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import date
 from typing import Any, Literal
 from uuid import UUID
@@ -13,11 +14,14 @@ from backend.routes.sync import _resolve_access_token
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 from src.shared.geo import decode_polyline, haversine_km, simplify_and_encode
+from src.shared.importers import DEFAULT_TIMEZONE
 from src.shared.route_shape import SHAPE_GROUPING_ENABLED
 from src.shared.smashrun import SmashRunAPIClient
 from src.shared.supabase_client import get_supabase_client
 from src.shared.supabase_ops import RunsRepository, TokenRepository, UsersRepository
 from src.shared.supabase_ops.mappers import WeatherType
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/runs", tags=["runs"])
 
@@ -520,6 +524,9 @@ async def get_run_detail(
         "distance_km": _f(run["distance_km"]),
         "duration_seconds": _f(run["duration_seconds"]),
         "avg_pace_min_per_km": _f(run.get("average_pace_min_per_km")),
+        # Only imported runs can be deleted (SB-621). The view needs to know
+        # before it offers the control — otherwise it shows a button that 409s.
+        "is_imported": _is_imported(get_supabase_client(), run),
         "weather": {
             "temperature_celsius": _f(run.get("temperature_celsius")),
             "weather_type": run.get("weather_type"),
@@ -565,6 +572,54 @@ async def set_run_audio(
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Run not found")
     await invalidate_user(user_id)
     return {"audio_type": updated.get("audio_type"), "audio_note": updated.get("audio_note")}
+
+
+@router.delete("/{activity_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_run(
+    activity_id: str,
+    user_id: UUID = Depends(authenticate_request),
+) -> None:
+    """Delete one of your **imported** runs (SB-621).
+
+    Import is the only ingestion path that can produce a run you did not do —
+    wrong file, misparse, a near-duplicate that dodged the dedup key — so it is
+    the one that needs an undo.
+
+    Synced runs are refused: deleting one only lasts until the next sync
+    recreates it from SmashRun, which reads as the delete having failed.
+
+    404 if the run isn't the caller's — never a 403, which would confirm that
+    someone else's activity id exists.
+    """
+    supabase = get_supabase_client()
+    repo = RunsRepository(supabase)
+
+    run = repo.get_run_by_activity_id(user_id, activity_id)
+    if run is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Run not found")
+
+    if not _is_imported(supabase, run):
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "Only imported runs can be deleted here. A synced run comes back on the "
+            "next sync — remove it in SmashRun instead.",
+        )
+
+    if not repo.delete_run(user_id, UUID(run["id"])):
+        # Lost a race with another delete of the same run; the end state is the
+        # one asked for either way.
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Run not found")
+
+    # Streak and totals read from the aggregation row, which would otherwise
+    # keep counting the run we just removed.
+    try:
+        repo.recalculate_user_stats(user_id, timezone=run.get("timezone") or DEFAULT_TIMEZONE)
+    except Exception as exc:  # noqa: BLE001 - the run is gone; stats catch up next write
+        logger.warning(f"recalculate_user_stats failed after delete for {user_id}: {exc}")
+
+    await invalidate_user(user_id)
+
+    await invalidate_user(user_id)
 
 
 def _f(value: Any) -> float | None:

--- a/backend/tests/test_delete_run.py
+++ b/backend/tests/test_delete_run.py
@@ -1,0 +1,158 @@
+"""SB-621: DELETE /runs/{activity_id} — remove an imported run."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from backend.routes import runs as runs_module
+from fastapi import HTTPException
+
+USER = uuid4()
+RUN_ID = uuid4()
+SOURCE_ID = uuid4()
+
+_RUN = {
+    "id": str(RUN_ID),
+    "source_id": str(SOURCE_ID),
+    "source_activity_id": "gpx-abc123",
+    "timezone": "America/Denver",
+    "start_date_time_local": "2026-08-08T10:50:35-04:00",
+}
+
+
+class _Repo:
+    def __init__(self, run: dict[str, Any] | None, deleted: bool = True) -> None:
+        self._run = run
+        self._deleted = deleted
+        self.delete_calls: list[tuple[Any, Any]] = []
+        self.stats_calls: list[str] = []
+
+    def __call__(self, _sb: Any) -> _Repo:
+        return self
+
+    def get_run_by_activity_id(self, _uid: Any, _aid: str) -> dict[str, Any] | None:
+        return self._run
+
+    def delete_run(self, user_id: Any, run_id: Any) -> bool:
+        self.delete_calls.append((user_id, run_id))
+        return self._deleted
+
+    def recalculate_user_stats(self, _uid: Any, timezone: str = "UTC") -> None:
+        self.stats_calls.append(timezone)
+
+
+class _Users:
+    def __init__(self, source_type: str) -> None:
+        self._source_type = source_type
+
+    def __call__(self, _sb: Any) -> _Users:
+        return self
+
+    def get_source_by_id(self, _sid: Any) -> dict[str, Any]:
+        return {"source_type": self._source_type}
+
+
+def _delete(
+    monkeypatch: Any,
+    *,
+    run: dict[str, Any] | None = None,
+    missing: bool = False,
+    source_type: str = "import",
+    deleted: bool = True,
+) -> _Repo:
+    repo = _Repo(None if missing else (run or _RUN), deleted=deleted)
+    monkeypatch.setattr(runs_module, "get_supabase_client", lambda: object())
+    monkeypatch.setattr(runs_module, "RunsRepository", repo)
+    monkeypatch.setattr(runs_module, "UsersRepository", _Users(source_type))
+
+    async def _no_cache(_uid: Any) -> int:
+        return 0
+
+    monkeypatch.setattr(runs_module, "invalidate_user", _no_cache)
+    asyncio.run(runs_module.delete_run("gpx-abc123", user_id=USER))
+    return repo
+
+
+def test_deletes_an_imported_run(monkeypatch: Any) -> None:
+    repo = _delete(monkeypatch)
+    assert repo.delete_calls == [(USER, RUN_ID)]
+
+
+def test_delete_is_scoped_to_the_caller(monkeypatch: Any) -> None:
+    # The owner is passed down to the repository rather than being checked only
+    # here — the backend holds the service-role key, so an unscoped delete by
+    # id would reach any user's run.
+    repo = _delete(monkeypatch)
+    user_arg, _ = repo.delete_calls[0]
+    assert user_arg == USER
+
+
+def test_stats_are_recalculated_in_the_runs_own_timezone(monkeypatch: Any) -> None:
+    repo = _delete(monkeypatch)
+    assert repo.stats_calls == ["America/Denver"]
+
+
+def test_stats_fall_back_when_the_run_has_no_timezone(monkeypatch: Any) -> None:
+    repo = _delete(monkeypatch, run={**_RUN, "timezone": None})
+    assert repo.stats_calls == [runs_module.DEFAULT_TIMEZONE]
+
+
+def test_someone_elses_run_is_404_not_403(monkeypatch: Any) -> None:
+    # get_run_by_activity_id is owner-scoped, so another user's id looks
+    # identical to one that doesn't exist. A 403 would confirm it exists.
+    with pytest.raises(HTTPException) as err:
+        _delete(monkeypatch, missing=True)
+    assert err.value.status_code == 404
+
+
+def test_synced_run_is_refused_with_a_reason(monkeypatch: Any) -> None:
+    with pytest.raises(HTTPException) as err:
+        _delete(monkeypatch, source_type="smashrun")
+    assert err.value.status_code == 409
+    assert "comes back on the next sync" in err.value.detail
+
+
+def test_synced_run_is_not_deleted(monkeypatch: Any) -> None:
+    repo = _Repo(_RUN)
+    monkeypatch.setattr(runs_module, "get_supabase_client", lambda: object())
+    monkeypatch.setattr(runs_module, "RunsRepository", repo)
+    monkeypatch.setattr(runs_module, "UsersRepository", _Users("smashrun"))
+
+    with pytest.raises(HTTPException):
+        asyncio.run(runs_module.delete_run("gpx-abc123", user_id=USER))
+
+    assert repo.delete_calls == []
+    assert repo.stats_calls == []
+
+
+def test_losing_a_delete_race_is_404(monkeypatch: Any) -> None:
+    # Two deletes of the same run: the second finds nothing to remove. The end
+    # state is what was asked for, but the response should still be honest.
+    with pytest.raises(HTTPException) as err:
+        _delete(monkeypatch, deleted=False)
+    assert err.value.status_code == 404
+
+
+def test_stats_failure_does_not_resurrect_the_run(monkeypatch: Any) -> None:
+    repo = _Repo(_RUN)
+    monkeypatch.setattr(runs_module, "get_supabase_client", lambda: object())
+    monkeypatch.setattr(runs_module, "RunsRepository", repo)
+    monkeypatch.setattr(runs_module, "UsersRepository", _Users("import"))
+
+    def _boom(*_a: Any, **_k: Any) -> None:
+        raise RuntimeError("rpc down")
+
+    monkeypatch.setattr(repo, "recalculate_user_stats", _boom)
+
+    async def _no_cache(_uid: Any) -> int:
+        return 0
+
+    monkeypatch.setattr(runs_module, "invalidate_user", _no_cache)
+
+    # The run is already gone; a stats refresh failure must not surface as an
+    # error that suggests otherwise.
+    asyncio.run(runs_module.delete_run("gpx-abc123", user_id=USER))
+    assert repo.delete_calls == [(USER, RUN_ID)]

--- a/frontend/src/composables/__tests__/useDeleteRun.test.ts
+++ b/frontend/src/composables/__tests__/useDeleteRun.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('@/config/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn().mockResolvedValue({ data: { session: { access_token: 'test-token' } } }),
+    },
+  },
+}))
+
+const fetchMock = vi.fn()
+
+describe('useDeleteRun', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock)
+    fetchMock.mockReset()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('DELETEs the run and reports success', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      headers: new Headers({ 'content-length': '0' }),
+      json: async () => null,
+    })
+    const { useDeleteRun } = await import('../useDeleteRun')
+    const { remove, error } = useDeleteRun()
+
+    expect(await remove('gpx-abc123')).toBe(true)
+    expect(error.value).toBeNull()
+
+    const [path, init] = fetchMock.mock.calls[0]
+    expect(path).toContain('/runs/gpx-abc123')
+    expect(init.method).toBe('DELETE')
+  })
+
+  it('encodes the activity id', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      headers: new Headers({ 'content-length': '0' }),
+      json: async () => null,
+    })
+    const { useDeleteRun } = await import('../useDeleteRun')
+
+    await useDeleteRun().remove('tcx-2026-08-10T12:00:00Z')
+
+    expect(fetchMock.mock.calls[0][0]).toContain('tcx-2026-08-10T12%3A00%3A00Z')
+  })
+
+  it("keeps the server's reason when a synced run is refused", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      headers: new Headers(),
+      json: async () => ({
+        detail:
+          'Only imported runs can be deleted here. A synced run comes back on the next sync — remove it in SmashRun instead.',
+      }),
+    })
+    const { useDeleteRun } = await import('../useDeleteRun')
+    const { remove, error } = useDeleteRun()
+
+    expect(await remove('act-42')).toBe(false)
+    expect(error.value).toContain('comes back on the next sync')
+  })
+
+  it('reports a run that is gone', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      headers: new Headers(),
+      json: async () => ({ detail: 'Run not found' }),
+    })
+    const { useDeleteRun } = await import('../useDeleteRun')
+    const { remove, error } = useDeleteRun()
+
+    expect(await remove('gpx-gone')).toBe(false)
+    expect(error.value).toBe('Run not found')
+  })
+})

--- a/frontend/src/composables/useDeleteRun.ts
+++ b/frontend/src/composables/useDeleteRun.ts
@@ -1,0 +1,31 @@
+import { ref } from 'vue'
+import { apiCall } from '@/config/api'
+
+/**
+ * Delete an imported run (SB-621).
+ *
+ * Only imported runs qualify — the API refuses a synced one with a 409, since
+ * deleting it would only last until the next sync recreated it. The view hides
+ * the control for those, so a 409 here means the run's source changed under us
+ * and the server's own wording is the honest thing to show.
+ */
+export function useDeleteRun() {
+  const deleting = ref(false)
+  const error = ref<string | null>(null)
+
+  const remove = async (activityId: string): Promise<boolean> => {
+    deleting.value = true
+    error.value = null
+    try {
+      await apiCall<null>(`/runs/${encodeURIComponent(activityId)}`, { method: 'DELETE' })
+      return true
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Could not delete this run'
+      return false
+    } finally {
+      deleting.value = false
+    }
+  }
+
+  return { remove, deleting, error }
+}

--- a/frontend/src/types/runs.ts
+++ b/frontend/src/types/runs.ts
@@ -157,6 +157,8 @@ export interface RunVitals {
 export interface RunDetail {
   activity_id: string
   date: string
+  /** Imported from a file rather than synced — the only kind that can be deleted (SB-621). */
+  is_imported?: boolean
   distance_km: number
   duration_seconds: number
   avg_pace_min_per_km: number | null

--- a/frontend/src/views/RunDetailView.vue
+++ b/frontend/src/views/RunDetailView.vue
@@ -105,13 +105,43 @@
       />
 
       <p v-if="run.notes" class="text-sm text-gray-500 mt-4">{{ run.notes }}</p>
+
+      <!--
+        Delete is offered only for imported runs (SB-621). A synced run would be
+        recreated by the next sync, so the API refuses it — showing the control
+        anyway would just hand the user a button that fails.
+      -->
+      <div v-if="run.is_imported" class="mt-6 flex items-center gap-3">
+        <button
+          type="button"
+          class="text-sm text-red-600 hover:text-red-700 hover:underline"
+          @click="confirmingDelete = true"
+        >
+          Delete this run
+        </button>
+        <span class="text-xs text-gray-400">Imported from a file</span>
+      </div>
+
+      <p v-if="deleteError" class="mt-2 text-sm text-red-600" role="alert">{{ deleteError }}</p>
+
+      <ConfirmModal
+        :show="confirmingDelete"
+        variant="danger"
+        title="Delete this run?"
+        :message="deleteMessage"
+        confirm-text="Delete run"
+        loading-text="Deleting…"
+        :loading="deleting"
+        @cancel="confirmingDelete = false"
+        @confirm="handleDelete"
+      />
     </template>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
-import { useRoute } from 'vue-router'
+import { computed, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { RouterLink } from 'vue-router'
 import ApexChart from 'vue3-apexcharts'
 import {
@@ -125,12 +155,34 @@ import { formatDate, formatDistance, formatDuration, formatPace, distanceLabel }
 import RouteMap from '@/components/RouteMap.vue'
 import RouteFrequency from '@/components/RouteFrequency.vue'
 import AudioLog from '@/components/AudioLog.vue'
+import ConfirmModal from '@/components/ConfirmModal.vue'
+import { useDeleteRun } from '@/composables/useDeleteRun'
 
 const KM_PER_MI = 1.609344
 
 const route = useRoute()
+const router = useRouter()
 const { unit } = useUserPreferences()
 const { run, loading, error, load } = useRunDetail(String(route.params.activityId))
+const { remove, deleting, error: deleteError } = useDeleteRun()
+
+const confirmingDelete = ref(false)
+
+// Name what is about to go, so the confirm isn't an abstract "are you sure".
+const deleteMessage = computed(() => {
+  if (!run.value) return ''
+  const distance = `${formatDistance(run.value.distance_km, unit.value)} ${distanceLabel(unit.value)}`
+  return `${formatDate(run.value.date)} · ${distance}. This also removes its GPS track and splits, and your streak and totals are recalculated. It can't be undone — you'd need to import the file again.`
+})
+
+const handleDelete = async () => {
+  const activityId = run.value?.activity_id
+  if (!activityId) return
+  const gone = await remove(activityId)
+  confirmingDelete.value = false
+  // The run no longer exists, so this page has nothing left to show.
+  if (gone) router.push('/runs')
+}
 const { track, load: loadTrack } = useRunTrack(String(route.params.activityId))
 const { penalty, load: loadPenalty } = useConditionsPenalty()
 

--- a/frontend/src/views/__tests__/RunDetailView.test.ts
+++ b/frontend/src/views/__tests__/RunDetailView.test.ts
@@ -9,8 +9,11 @@ vi.mock('@/composables/useUserPreferences', async () => {
   const { ref } = await import('vue')
   return { useUserPreferences: () => ({ unit: ref('mi') }) }
 })
+const routerPush = vi.fn()
 vi.mock('vue-router', () => ({
   useRoute: () => ({ params: { activityId: 'act-123' } }),
+  // Delete navigates away once the run is gone (SB-621).
+  useRouter: () => ({ push: routerPush }),
   RouterLink: { template: '<a><slot /></a>' },
 }))
 vi.mock('vue3-apexcharts', () => ({
@@ -71,5 +74,71 @@ describe('RunDetailView (SB-263)', () => {
     await flushPromises()
     expect(w.text()).not.toContain('splits')
     expect(w.text()).not.toContain('Elevation')
+  })
+
+  // SB-621: only imported runs can be deleted. A synced run would be recreated
+  // by the next sync, so the API refuses it — offering the control anyway would
+  // hand the user a button that fails.
+  describe('delete control', () => {
+    it('is absent on a synced run', async () => {
+      apiCallMock.mockResolvedValue(detail)
+      const w = mount(RunDetailView)
+      await flushPromises()
+      expect(w.text()).not.toContain('Delete this run')
+    })
+
+    it('is offered on an imported run', async () => {
+      apiCallMock.mockResolvedValue({ ...detail, is_imported: true })
+      const w = mount(RunDetailView)
+      await flushPromises()
+      expect(w.text()).toContain('Delete this run')
+      expect(w.text()).toContain('Imported from a file')
+    })
+
+    it('asks before deleting, naming what goes and that it cannot be undone', async () => {
+      apiCallMock.mockResolvedValue({ ...detail, is_imported: true })
+      const w = mount(RunDetailView)
+      await flushPromises()
+
+      // Nothing is requested just by opening the confirm.
+      const callsBefore = apiCallMock.mock.calls.length
+      await w.findAll('button').find((b) => b.text() === 'Delete this run')!.trigger('click')
+      await flushPromises()
+
+      expect(w.text()).toContain('Delete this run?')
+      expect(w.text()).toContain("can't be undone")
+      expect(w.text()).toContain('GPS track and splits')
+      expect(apiCallMock.mock.calls.length).toBe(callsBefore)
+    })
+
+    it('deletes and leaves the page once confirmed', async () => {
+      apiCallMock.mockResolvedValue({ ...detail, is_imported: true })
+      routerPush.mockClear()
+      const w = mount(RunDetailView)
+      await flushPromises()
+
+      await w.findAll('button').find((b) => b.text() === 'Delete this run')!.trigger('click')
+      apiCallMock.mockResolvedValueOnce(null)
+      await w.findAll('button').find((b) => b.text() === 'Delete run')!.trigger('click')
+      await flushPromises()
+
+      expect(apiCallMock).toHaveBeenCalledWith('/runs/act-123', { method: 'DELETE' })
+      expect(routerPush).toHaveBeenCalledWith('/runs')
+    })
+
+    it('stays put and shows why when the delete is refused', async () => {
+      apiCallMock.mockResolvedValue({ ...detail, is_imported: true })
+      routerPush.mockClear()
+      const w = mount(RunDetailView)
+      await flushPromises()
+
+      await w.findAll('button').find((b) => b.text() === 'Delete this run')!.trigger('click')
+      apiCallMock.mockRejectedValueOnce(new Error('A synced run comes back on the next sync'))
+      await w.findAll('button').find((b) => b.text() === 'Delete run')!.trigger('click')
+      await flushPromises()
+
+      expect(w.find('[role="alert"]').text()).toContain('comes back on the next sync')
+      expect(routerPush).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/shared/supabase_ops/runs_repository.py
+++ b/src/shared/supabase_ops/runs_repository.py
@@ -1021,15 +1021,37 @@ class RunsRepository:
         )
         return cast(int, result.count or 0)
 
-    def delete_run(self, run_id: UUID) -> None:
+    def delete_run(self, user_id: UUID, run_id: UUID) -> bool:
         """
-        Delete a run and all related data (cascades to splits, laps, etc.).
+        Delete one of a user's runs, with everything hanging off it.
+
+        The owner is part of the delete filter rather than something the caller
+        is trusted to have checked (SB-621). The backend holds the service-role
+        key, so RLS is not a second line of defence here — an unscoped delete by
+        id would remove any user's run given its uuid.
+
+        Cascades handle the rest: splits, laps, recording_data and run_tracks
+        are ON DELETE CASCADE, and project_run_to_metric_entry_trigger removes
+        the projected metric_entries row.
 
         Args:
+            user_id: Owner's UUID — the run is only deleted if it is theirs
             run_id: Run UUID
+
+        Returns:
+            True if a run was deleted, False if it did not exist or isn't theirs
         """
-        self.supabase.table("runs").delete().eq("id", str(run_id)).execute()
-        logger.info(f"Deleted run {run_id}")
+        result = (
+            self.supabase.table("runs")
+            .delete()
+            .eq("id", str(run_id))
+            .eq("user_id", str(user_id))
+            .execute()
+        )
+        deleted = bool(cast(list[dict[str, Any]], result.data))
+        if deleted:
+            logger.info(f"Deleted run {run_id} for user {user_id}")
+        return deleted
 
     def recalculate_user_stats(
         self, user_id: UUID, timezone: str = "America/New_York"

--- a/stk/src/cli/commands/delete_run.py
+++ b/stk/src/cli/commands/delete_run.py
@@ -1,0 +1,44 @@
+"""Delete an imported run (SB-621)."""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+
+from cli.api import delete_request, request
+from cli.display import display_error
+
+console = Console()
+
+
+def delete_run(
+    activity_id: str = typer.Argument(..., help="Activity id, e.g. gpx-7378842ad231bae2"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation prompt"),
+) -> None:
+    """Delete one of your imported runs.
+
+    Only imported runs can be deleted: a synced run would be recreated by the
+    next sync, so the API refuses those.
+    """
+    run = request(f"runs/{activity_id}")
+
+    distance = run.get("distance_km") or 0
+    console.print(f"[bold]{run.get('date', '')[:10]}[/bold] · {distance:.2f} km · {activity_id}")
+
+    if not run.get("is_imported"):
+        display_error("Only imported runs can be deleted.")
+        console.print(
+            "[dim]A synced run comes back on the next sync — remove it in SmashRun instead.[/dim]"
+        )
+        raise typer.Exit(1)
+
+    if not yes:
+        # Destructive and irreversible: the file would have to be imported
+        # again, and the GPS track and splits go with it.
+        typer.confirm(
+            "Delete this run, its GPS track and its splits?",
+            abort=True,
+        )
+
+    delete_request(f"runs/{activity_id}")
+    console.print("[green]Deleted.[/green] Streak and totals have been recalculated.")

--- a/stk/src/cli/main.py
+++ b/stk/src/cli/main.py
@@ -27,6 +27,7 @@ from cli.commands import (
     athlete,
     auth,
     cache,
+    delete_run,
     import_file,
     invite,
     plan,
@@ -154,6 +155,7 @@ app.command(name="audio", rich_help_panel=_PANEL_RUNS)(runs.audio)
 app.command(name="summary", rich_help_panel=_PANEL_RUNS)(runs.summary)
 app.command(name="sync", rich_help_panel=_PANEL_RUNS)(sync.sync_runs)
 app.command(name="import", rich_help_panel=_PANEL_RUNS)(import_file.import_activity)
+app.command(name="delete", rich_help_panel=_PANEL_RUNS)(delete_run.delete_run)
 app.command(name="verify", rich_help_panel=_PANEL_RUNS)(verify.verify)
 app.command(name="goals", rich_help_panel=_PANEL_PLANNING)(stats.goals)
 

--- a/stk/tests/test_delete_run_cmd.py
+++ b/stk/tests/test_delete_run_cmd.py
@@ -1,0 +1,71 @@
+"""Tests for `stk delete` — removing an imported run (SB-621)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import typer
+
+from cli.commands import delete_run as cmd
+
+IMPORTED = {
+    "activity_id": "gpx-abc123",
+    "date": "2026-08-08T10:50:35-04:00",
+    "distance_km": 3.24,
+    "is_imported": True,
+}
+
+
+def _wire(monkeypatch: Any, run: dict[str, Any]) -> list[str]:
+    """Stub the API; returns the list of endpoints DELETEd."""
+    deleted: list[str] = []
+    monkeypatch.setattr(cmd, "request", lambda _endpoint: run)
+    monkeypatch.setattr(cmd, "delete_request", lambda endpoint: deleted.append(endpoint))
+    return deleted
+
+
+def test_deletes_an_imported_run_when_confirmed(monkeypatch: Any) -> None:
+    deleted = _wire(monkeypatch, IMPORTED)
+    monkeypatch.setattr(typer, "confirm", lambda *_a, **_k: True)
+
+    cmd.delete_run(activity_id="gpx-abc123", yes=False)
+
+    assert deleted == ["runs/gpx-abc123"]
+
+
+def test_yes_flag_skips_the_prompt(monkeypatch: Any) -> None:
+    deleted = _wire(monkeypatch, IMPORTED)
+
+    def _no_prompt(*_a: Any, **_k: Any) -> bool:
+        raise AssertionError("should not prompt when --yes is passed")
+
+    monkeypatch.setattr(typer, "confirm", _no_prompt)
+
+    cmd.delete_run(activity_id="gpx-abc123", yes=True)
+
+    assert deleted == ["runs/gpx-abc123"]
+
+
+def test_declining_the_prompt_deletes_nothing(monkeypatch: Any) -> None:
+    deleted = _wire(monkeypatch, IMPORTED)
+
+    def _abort(*_a: Any, **_k: Any) -> bool:
+        raise typer.Abort()
+
+    monkeypatch.setattr(typer, "confirm", _abort)
+
+    with pytest.raises(typer.Abort):
+        cmd.delete_run(activity_id="gpx-abc123", yes=False)
+
+    assert deleted == []
+
+
+def test_synced_run_is_refused_before_any_delete(monkeypatch: Any) -> None:
+    deleted = _wire(monkeypatch, {**IMPORTED, "is_imported": False})
+    monkeypatch.setattr(typer, "confirm", lambda *_a, **_k: True)
+
+    with pytest.raises(typer.Exit):
+        cmd.delete_run(activity_id="act-42", yes=True)
+
+    assert deleted == []


### PR DESCRIPTION
## What

`DELETE /runs/{activity_id}` — remove a run you imported. Endpoint, UI control and `stk delete`.

There was no delete for runs anywhere before this. A run created from the wrong file, a misparse, or a near-duplicate that dodged the dedup key was permanent.

## Scope: imported runs only

A synced run is refused with **409** and a reason: deleting it lasts only until the next sync recreates it from SmashRun, which reads as the delete having silently failed. Fixing it in SmashRun is the honest answer.

A run that isn't yours is **404**, never 403 — a 403 would confirm that someone else's activity id exists.

## Security fix included

`RunsRepository.delete_run` already existed, **unused**, deleting by run id with **no owner check**:

```python
def delete_run(self, run_id: UUID) -> None:
    self.supabase.table("runs").delete().eq("id", str(run_id)).execute()
```

The backend holds the service-role key, so RLS is not a second line of defence here. Building the endpoint on that as written would have let any authenticated user delete any user's run given its uuid. It's now `delete_run(user_id, run_id)` with the owner **in the delete filter** rather than checked at the route first — which also closes the check-then-act race.

No live exposure existed, since nothing called it.

## The database already handled the rest

| Table | On run delete |
|---|---|
| `splits`, `laps`, `recording_data` | `ON DELETE CASCADE` |
| `run_tracks` | `ON DELETE CASCADE` |
| `metric_entries` | `project_run_to_metric_entry_trigger` removes the projected entry |

Stats are recalculated afterwards **in the run's own stored timezone**, or the streak keeps counting a run that no longer exists.

## UI

The detail payload now states `is_imported`, because the view has to know before offering the control — otherwise it renders a button that 409s. Reuses the existing `ConfirmModal` (`danger` variant) rather than adding another.

The confirm names what is going and does not soften it:

> 8 Aug 2026 · 2.02 mi. This also removes its GPS track and splits, and your streak and totals are recalculated. It can't be undone — you'd need to import the file again.

On success it navigates to `/runs`, since the page no longer has anything to show. On refusal it stays put and shows the server's wording.

## Testing

- **9 backend tests**: owner passed to the repository, 404 vs 403, the 409 path, a synced run not being deleted *at all*, losing a delete race, timezone fallback, and a stats failure not resurfacing as an error after the run is already gone.
- **5 view tests**: control hidden on a synced run, shown on an import, confirm required (and requesting nothing until confirmed), delete + navigate, and refusal leaving you on the page.
- **4 composable + 4 CLI tests**, including `--yes` skipping the prompt and declining deleting nothing.
- **Verified end to end against local Supabase** with a real Garmin GPX: imported, deleted, `run_tracks` row and the `metric_entries` projection both gone with it, second delete correctly 404s.
- Suites: backend 434 (93%), frontend 480, stk 135, root 225. Lint and type-check clean.

## Note

This branch was rebased onto SB-622, so it reuses that PR's `_is_imported` helper rather than duplicating the source lookup.

Fixes SB-621

🤖 Generated with [Claude Code](https://claude.com/claude-code)
