### PR TITLE
fix(import): read imported cadence as steps per minute, not strides

### DIFF
--- a/docs/SOURCES_AND_IMPORT.md
+++ b/docs/SOURCES_AND_IMPORT.md
@@ -131,6 +131,18 @@ file parses in milliseconds, so it answers in the request.
 - **Distance/duration.** TCX's stated lap totals win over the track. GPX has
   neither, so distance is summed over the trackpoints and duration excludes
   gaps longer than 60s (a paused watch, not a slow kilometre).
+- **Cadence units (SB-623).** Garmin writes cadence as *strides* per minute
+  (~93 for a normal running cadence); SmashRun, and therefore the
+  `cadence_average` column, stores *steps* per minute (~186). Imported cadence
+  is doubled when the average falls below 130 — running cadence sits at
+  150–200 steps/min and stride rates at 75–100, so the ranges don't overlap.
+  The decision is made once from the average and applied to min/max too, since
+  a doubled average beside an untouched maximum is worse than either unit
+  applied consistently.
+- **Zero samples are gaps, not readings (SB-623).** A watch writes 0 for heart
+  rate or cadence when it has nothing to report — stopped at a light, or a
+  strap that lost contact. Those are dropped before averaging, or "minimum
+  cadence" reads 0 on every run that ever paused.
 - **CLI:** `stk import <file> [--timezone ZONE]`.
 - **Web UI (SB-418):** `ImportRunCard.vue` on the Settings page — drop zone plus
   file picker, client-side type/size check before upload, and a result surface

--- a/src/shared/importers/cadence.py
+++ b/src/shared/importers/cadence.py
@@ -1,0 +1,53 @@
+"""Normalize imported cadence to steps per minute (SB-623).
+
+Sources disagree about what "cadence" counts:
+
+* **Garmin GPX** (`<gpxtpx:cad>`) and **Garmin TCX** (`<RunCadence>`, and
+  `<Cadence>` on a running activity) report **strides** per minute — one foot,
+  so a normal running cadence reads ~85–95.
+* **SmashRun**, and therefore the `cadence_average` column and everything that
+  reads it, stores **steps** per minute — both feet, ~170–190 for the same run.
+
+Left alone, an imported run sits next to a synced one showing half its
+cadence, with nothing on screen to explain the discontinuity.
+"""
+
+from __future__ import annotations
+
+# Above this, a value is already steps per minute. Running cadence lives at
+# 150–200 steps/min and stride rates at 75–100, so the gap is wide. The
+# threshold sits above brisk walking in *strides* (~65) and below the slowest
+# plausible running cadence in *steps*, which is where the two ranges could
+# otherwise be confused.
+STRIDE_RATE_CEILING = 130.0
+
+
+def to_steps_per_minute(
+    average: float | None,
+    minimum: float | None,
+    maximum: float | None,
+) -> tuple[float | None, float | None, float | None]:
+    """Convert a stride-rate cadence triple to steps per minute.
+
+    The decision is made once, from the average, and applied to all three
+    values — deciding per value would let a doubled average sit beside an
+    untouched maximum, which is worse than either unit consistently.
+
+    A file that already states steps per minute is returned unchanged.
+
+    Args:
+        average: Mean cadence over the run
+        minimum: Lowest recorded cadence
+        maximum: Highest recorded cadence
+
+    Returns:
+        The same triple, in steps per minute.
+    """
+    if average is None or average <= 0 or average >= STRIDE_RATE_CEILING:
+        return average, minimum, maximum
+
+    return (
+        average * 2,
+        minimum * 2 if minimum is not None else None,
+        maximum * 2 if maximum is not None else None,
+    )

--- a/src/shared/importers/gpx.py
+++ b/src/shared/importers/gpx.py
@@ -15,9 +15,10 @@ from xml.etree.ElementTree import Element
 from src.shared.geo import path_length_km
 from src.shared.models import Activity
 
+from .cadence import to_steps_per_minute
 from .errors import NoRunFoundError
 from .models import ParsedActivityFile
-from .xml_common import child_text, find_all, mean, parse_timestamp, parse_xml
+from .xml_common import child_text, find_all, mean, parse_timestamp, parse_xml, recorded
 
 # GPS fixes 60s+ apart are a paused watch, not a slow kilometre. Elapsed time
 # includes such gaps; the run's duration should not, so they are subtracted —
@@ -98,6 +99,8 @@ def parse_gpx(content: bytes) -> ParsedActivityFile:
         raise NoRunFoundError("No GPS trackpoints found — is this an empty or route-only GPX?")
 
     lats, lons, times, heart_rates, cadences = _point_values(points)
+    # A 0 sample means the watch had nothing to report, not a real reading.
+    heart_rates, cadences = recorded(heart_rates), recorded(cadences)
     if len(lats) < 2:
         raise NoRunFoundError("Track has fewer than two GPS points, so it has no distance.")
     if len(times) < 2:
@@ -118,6 +121,14 @@ def parse_gpx(content: bytes) -> ParsedActivityFile:
     track = find_all(root, "trk")
     title = child_text(track[0], "name") if track else None
 
+    # <gpxtpx:cad> is strides per minute on Garmin and most watches; the runs
+    # table stores steps per minute (SB-623).
+    cadence_avg, cadence_min, cadence_max = to_steps_per_minute(
+        mean(cadences),
+        min(cadences) if cadences else None,
+        max(cadences) if cadences else None,
+    )
+
     activity = Activity(
         activityId=f"gpx-{digest}",
         startDateTimeLocal=min(times),
@@ -130,8 +141,8 @@ def parse_gpx(content: bytes) -> ParsedActivityFile:
         heartRateAverage=mean(heart_rates),
         heartRateMin=min(heart_rates) if heart_rates else None,
         heartRateMax=max(heart_rates) if heart_rates else None,
-        cadenceAverage=mean(cadences),
-        cadenceMin=min(cadences) if cadences else None,
-        cadenceMax=max(cadences) if cadences else None,
+        cadenceAverage=cadence_avg,
+        cadenceMin=cadence_min,
+        cadenceMax=cadence_max,
     )
     return ParsedActivityFile(activity=activity, latitudes=lats, longitudes=lons)

--- a/src/shared/importers/tcx.py
+++ b/src/shared/importers/tcx.py
@@ -14,9 +14,18 @@ from xml.etree.ElementTree import Element
 from src.shared.geo import path_length_km
 from src.shared.models import Activity
 
+from .cadence import to_steps_per_minute
 from .errors import NoRunFoundError
 from .models import ParsedActivityFile
-from .xml_common import child_float, child_text, find_all, mean, parse_timestamp, parse_xml
+from .xml_common import (
+    child_float,
+    child_text,
+    find_all,
+    mean,
+    parse_timestamp,
+    parse_xml,
+    recorded,
+)
 
 # TCX Sport attribute values we accept. Biking/Other files parse fine but are
 # not runs, and the runs table is running-only (ActivityType has one member).
@@ -85,6 +94,8 @@ def parse_tcx(content: bytes) -> ParsedActivityFile:
     duration_seconds = sum(child_float(lap, "TotalTimeSeconds") or 0.0 for lap in laps)
 
     lats, lons, heart_rates, cadences = _track_series(activity_el)
+    # A 0 sample means the watch had nothing to report, not a real reading.
+    heart_rates, cadences = recorded(heart_rates), recorded(cadences)
 
     # Some exporters write laps without distance; fall back to the track.
     if distance_km <= 0 and len(lats) >= 2:
@@ -105,6 +116,14 @@ def parse_tcx(content: bytes) -> ParsedActivityFile:
     raw_id = child_text(activity_el, "Id")
     identity = raw_id or hashlib.sha256(content).hexdigest()[:24]
 
+    # Garmin writes running cadence as strides per minute in both <Cadence> and
+    # <RunCadence>; the runs table stores steps per minute (SB-623).
+    cadence_avg, cadence_min, cadence_max = to_steps_per_minute(
+        mean(cadences),
+        min(cadences) if cadences else None,
+        max(cadences) if cadences else None,
+    )
+
     activity = Activity(
         activityId=f"tcx-{identity}",
         startDateTimeLocal=started,
@@ -117,8 +136,8 @@ def parse_tcx(content: bytes) -> ParsedActivityFile:
         heartRateAverage=mean(heart_rates),
         heartRateMin=min(heart_rates) if heart_rates else None,
         heartRateMax=max(heart_rates) if heart_rates else None,
-        cadenceAverage=mean(cadences),
-        cadenceMin=min(cadences) if cadences else None,
-        cadenceMax=max(cadences) if cadences else None,
+        cadenceAverage=cadence_avg,
+        cadenceMin=cadence_min,
+        cadenceMax=cadence_max,
     )
     return ParsedActivityFile(activity=activity, latitudes=lats, longitudes=lons)

--- a/src/shared/importers/xml_common.py
+++ b/src/shared/importers/xml_common.py
@@ -85,6 +85,17 @@ def mean(values: list[float]) -> float | None:
     return sum(values) / len(values) if values else None
 
 
+def recorded(values: list[float]) -> list[float]:
+    """Drop zero samples from a sensor series (SB-623).
+
+    A watch writes 0 for heart rate or cadence when it has nothing to report —
+    stopped at a light, or a strap that lost contact. Those are gaps, not
+    measurements: kept in, they make "minimum cadence" read 0 on every run that
+    ever paused, and drag the average below what the runner actually held.
+    """
+    return [v for v in values if v > 0]
+
+
 def as_float(value: Any) -> float | None:
     try:
         return float(value)

--- a/tests/test_import_cadence.py
+++ b/tests/test_import_cadence.py
@@ -1,0 +1,159 @@
+"""SB-623: imported cadence is normalized from strides to steps per minute."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.shared.importers import parse_gpx, parse_tcx
+from src.shared.importers.cadence import STRIDE_RATE_CEILING, to_steps_per_minute
+
+
+def _gpx(cadences: list[int]) -> bytes:
+    points = "\n".join(
+        f"""      <trkpt lat="42.24{i:02d}" lon="-71.6500">
+        <time>2026-08-10T11:{i:02d}:00Z</time>
+        <extensions><gpxtpx:TrackPointExtension>
+          <gpxtpx:cad>{c}</gpxtpx:cad>
+        </gpxtpx:TrackPointExtension></extensions>
+      </trkpt>"""
+        for i, c in enumerate(cadences)
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="Test" xmlns="http://www.topografix.com/GPX/1/1"
+     xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1">
+  <trk><name>Test</name><trkseg>
+{points}
+  </trkseg></trk>
+</gpx>
+""".encode()
+
+
+def _tcx(cadences: list[int]) -> bytes:
+    points = "\n".join(
+        f"""          <Trackpoint>
+            <Time>2026-08-10T12:{i:02d}:00Z</Time>
+            <Position>
+              <LatitudeDegrees>42.24{i:02d}</LatitudeDegrees>
+              <LongitudeDegrees>-71.6500</LongitudeDegrees>
+            </Position>
+            <Cadence>{c}</Cadence>
+          </Trackpoint>"""
+        for i, c in enumerate(cadences)
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<TrainingCenterDatabase xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2">
+  <Activities><Activity Sport="Running">
+      <Id>2026-08-10T12:00:00Z</Id>
+      <Lap StartTime="2026-08-10T12:00:00Z">
+        <TotalTimeSeconds>1800</TotalTimeSeconds>
+        <DistanceMeters>5000</DistanceMeters>
+        <Track>
+{points}
+        </Track>
+      </Lap>
+  </Activity></Activities>
+</TrainingCenterDatabase>
+""".encode()
+
+
+# --- the helper ------------------------------------------------------------
+
+
+def test_stride_rate_is_doubled() -> None:
+    assert to_steps_per_minute(93.0, 80.0, 99.0) == (186.0, 160.0, 198.0)
+
+
+def test_step_rate_is_left_alone() -> None:
+    assert to_steps_per_minute(178.0, 160.0, 190.0) == (178.0, 160.0, 190.0)
+
+
+def test_the_whole_triple_moves_together() -> None:
+    # Deciding per value would leave a doubled average beside an untouched
+    # maximum — worse than either unit applied consistently.
+    average, minimum, maximum = to_steps_per_minute(95.0, 60.0, 129.0)
+    assert (average, minimum, maximum) == (190.0, 120.0, 258.0)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (STRIDE_RATE_CEILING - 0.1, (STRIDE_RATE_CEILING - 0.1) * 2),
+        (STRIDE_RATE_CEILING, STRIDE_RATE_CEILING),
+        (STRIDE_RATE_CEILING + 0.1, STRIDE_RATE_CEILING + 0.1),
+    ],
+)
+def test_the_boundary_is_exclusive(value: float, expected: float) -> None:
+    assert to_steps_per_minute(value, None, None)[0] == pytest.approx(expected)
+
+
+def test_absent_cadence_stays_absent() -> None:
+    assert to_steps_per_minute(None, None, None) == (None, None, None)
+
+
+def test_zero_is_not_doubled() -> None:
+    # A watch that reported nothing shouldn't become a run with 0 cadence
+    # "corrected" to 0 — and shouldn't crash on the way through either.
+    assert to_steps_per_minute(0.0, 0.0, 0.0) == (0.0, 0.0, 0.0)
+
+
+def test_missing_bounds_survive_the_correction() -> None:
+    assert to_steps_per_minute(90.0, None, None) == (180.0, None, None)
+
+
+# --- through the parsers ---------------------------------------------------
+
+
+def test_gpx_stride_cadence_becomes_steps() -> None:
+    # A real Garmin export reads ~93 for a normal running cadence.
+    activity = parse_gpx(_gpx([90, 93, 96])).activity
+    assert activity.cadence_average == pytest.approx(186.0)
+    assert activity.cadence_min == 180
+    assert activity.cadence_max == 192
+
+
+def test_gpx_step_cadence_is_untouched() -> None:
+    activity = parse_gpx(_gpx([176, 180, 184])).activity
+    assert activity.cadence_average == pytest.approx(180.0)
+    assert activity.cadence_max == 184
+
+
+def test_tcx_stride_cadence_becomes_steps() -> None:
+    activity = parse_tcx(_tcx([86, 90, 94])).activity
+    assert activity.cadence_average == pytest.approx(180.0)
+    assert activity.cadence_min == 172
+
+
+def test_tcx_step_cadence_is_untouched() -> None:
+    activity = parse_tcx(_tcx([170, 178, 186])).activity
+    assert activity.cadence_average == pytest.approx(178.0)
+
+
+def test_zero_samples_do_not_become_the_minimum() -> None:
+    # A watch writes 0 while stopped. Kept in, "minimum cadence" reads 0 on
+    # every run that ever paused, and the average sits below what was held.
+    activity = parse_gpx(_gpx([0, 90, 96, 0])).activity
+    assert activity.cadence_min == 180
+    assert activity.cadence_average == pytest.approx(186.0)
+
+
+def test_zero_samples_are_dropped_from_tcx_too() -> None:
+    activity = parse_tcx(_tcx([0, 86, 94])).activity
+    assert activity.cadence_min == 172
+    assert activity.cadence_average == pytest.approx(180.0)
+
+
+def test_an_all_zero_series_reads_as_no_cadence() -> None:
+    activity = parse_gpx(_gpx([0, 0, 0])).activity
+    assert activity.cadence_average is None
+    assert activity.cadence_min is None
+
+
+def test_a_file_without_cadence_is_unaffected() -> None:
+    no_cadence = (
+        _gpx([90, 93])
+        .replace(b"<gpxtpx:cad>90</gpxtpx:cad>", b"")
+        .replace(b"<gpxtpx:cad>93</gpxtpx:cad>", b"")
+    )
+    activity = parse_gpx(no_cadence).activity
+    assert activity.cadence_average is None
+    assert activity.cadence_min is None

--- a/tests/test_import_parsers.py
+++ b/tests/test_import_parsers.py
@@ -113,7 +113,8 @@ def test_gpx_keeps_the_gps_track_and_hr_cadence() -> None:
     assert parsed.activity.start_latitude == 42.2400
     assert parsed.activity.heart_rate_average == pytest.approx(150.0)
     assert parsed.activity.heart_rate_max == 160
-    assert parsed.activity.cadence_average == pytest.approx(87.667, abs=0.01)
+    # Strides in the file (85/88/90) -> steps per minute on the model (SB-623).
+    assert parsed.activity.cadence_average == pytest.approx(175.333, abs=0.01)
     assert parsed.activity.has_details_gps is True
 
 
@@ -195,7 +196,8 @@ def test_tcx_reads_heart_rate_and_cadence() -> None:
     parsed = parse_tcx(TCX)
     assert parsed.activity.heart_rate_average == pytest.approx(150.0)
     assert parsed.activity.heart_rate_min == 142
-    assert parsed.activity.cadence_average == pytest.approx(88.0)
+    # 86/90 strides -> steps per minute (SB-623).
+    assert parsed.activity.cadence_average == pytest.approx(176.0)
 
 
 def test_tcx_falls_back_to_the_track_when_laps_state_no_distance() -> None:


### PR DESCRIPTION
## The bug

An imported run showed roughly **half** the cadence of a synced one, silently. Found on a real Garmin Connect export: **93**, where a SmashRun-synced run of the same effort reads ~186.

The two sources count different things:

| Source | Field | Counts | Typical running value |
|---|---|---|---|
| Garmin GPX | `<gpxtpx:cad>` | **strides**/min (one foot) | ~93 |
| Garmin TCX | `<Cadence>`, `<RunCadence>` | **strides**/min | ~93 |
| SmashRun → `cadence_average` | — | **steps**/min (both feet) | ~186 |

The parsers passed the value straight through, so two runs sitting next to each other in the same list disagreed about their units. A Garmin backfill alongside ongoing SmashRun syncs would put a 2× step in the middle of any cadence trend, with nothing on screen to explain it.

## Fix

Double when the average falls below **130**. Running cadence sits at 150–200 steps/min and stride rates at 75–100, so the ranges don't overlap and the threshold has room either side.

The decision is made **once, from the average**, and applied to min and max too. Deciding per value would leave a doubled average beside an untouched maximum — worse than either unit applied consistently.

## Second fix, slightly beyond the ticket

Zero samples are now dropped before averaging.

A watch writes `0` for cadence or heart rate when it has nothing to report — stopped at a light, or a strap that lost contact. Those are gaps, not measurements. Kept in, **"minimum cadence" reads 0 on every run that ever paused.**

On the reporter's export, 3 zero samples out of 239 were enough to make the minimum `0` and pull the average from 188 down to 186.

This is beyond the strict letter of the ticket. It's the same field, on the same path, surfaced by the same test — and shipping a run whose stated minimum cadence is 0 would have been knowingly wrong. Flagging it rather than burying it.

## Result on the reported file

| | Before | After |
|---|---|---|
| Average | 93 | **188** steps/min |
| Minimum | 0 | **108** |
| Maximum | 100 | **200** |

## Testing

17 new tests: the helper (doubling, leaving step-rates alone, the whole triple moving together, an **exclusive** boundary via parametrize, absent/zero/missing-bound inputs), both parsers end to end for stride and step files, zero-sample handling in each, and an all-zero series correctly reading as no cadence at all.

Two SB-99 tests asserted the old unnormalized values and now assert the corrected ones.

Suites: root 242, backend 434 (93%), stk 135. Lint, format and types clean.

## Note on existing imports

This corrects what gets stored going forward. A run imported before this keeps its halved cadence, since re-uploading dedups to the existing row. With SB-621 now merged, delete-and-re-import is the way to refresh one; a bulk backfill over `source_type = 'import'` would be the way to fix them all, and isn't in this PR.

Fixes SB-623

🤖 Generated with [Claude Code](https://claude.com/claude-code)
