### PR TITLE
ci: inherit the shared Renovate policy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>silverbeer/.github"]
+}


### PR DESCRIPTION
Adds a one-line `renovate.json` pointing at the shared preset in the new [silverbeer/.github](https://github.com/silverbeer/.github) repo.

```json
{ "extends": ["local>silverbeer/.github"] }
```

STK is the **pilot** for the Dependency & Version Hygiene epic. Chosen because its pre-commit ruff rev (`v0.14.2`) is the most current of any repo surveyed, so it has the least surprise formatter movement queued up — a bad first impression from the tooling is how the tooling gets ignored.

## What the policy does

Declared once in `silverbeer/.github/default.json`, with the reasoning in that repo's README:

- **Group by ecosystem, not dependency.** One "github actions" PR, not forty. Muted automation is worse than none.
- **Patch and minor auto-merge on green CI**; majors get a `major-update` label and a human.
- **Formatters never auto-merge.** Their output is the contract — SB-432 is the evidence.
- **pre-commit hook revs are managed** (Renovate disables that manager by default; the preset enables it). This is the mechanism that catches the SB-432 class of drift before it bites.
- **Weekly window, 3-day minimum release age.** Security advisories bypass both.

## What will land here once Renovate is installed

uv/pep621 dependencies, GitHub Actions, Docker tags, Helm chart values, and `.pre-commit-config.yaml` revs.

## Verification

`renovate-config-validator --strict` passes on this file and on the preset it extends.

Note this PR does not itself install the Renovate GitHub App — that is a browser OAuth flow, and doing it account-wide is SB-662.

Refs SB-661

🤖 Generated with [Claude Code](https://claude.com/claude-code)